### PR TITLE
fix: builds for dagster-hex and dagster-modal

### DIFF
--- a/libraries/dagster-hex/pyproject.toml
+++ b/libraries/dagster-hex/pyproject.toml
@@ -22,3 +22,6 @@ dev-dependencies = [
     "pytest-mock",
     "requests-mock",
 ]
+
+[tool.setuptools]
+packages = ["dagster_hex"]

--- a/libraries/dagster-modal/pyproject.toml
+++ b/libraries/dagster-modal/pyproject.toml
@@ -15,3 +15,6 @@ dev-dependencies = [
     "ruff>=0.6.8",
     "pytest",
 ]
+
+[tool.setuptools]
+packages = ["dagster_modal"]


### PR DESCRIPTION
Resolves error:

```
$ uv build
Building source distribution...
error: Multiple top-level packages discovered in a flat-layout: ['dagster_modal', 'dagster_modal_tests'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple packages
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
error: Build backend failed to determine extra requires with `build_sdist()` with exit status: 1
```