### PR TITLE
[dagster-contrib-modal] support AssetExecutionContext in pipes run

### DIFF
--- a/libraries/dagster-contrib-modal/CHANGELOG.md
+++ b/libraries/dagster-contrib-modal/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.2
+
+### Updated
+
+- Updated type of `modal.run` `context` parameter to `Union[AssetExecutionContext, OpExecutionContext]`

--- a/libraries/dagster-contrib-modal/dagster_contrib_modal/resources.py
+++ b/libraries/dagster-contrib-modal/dagster_contrib_modal/resources.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Mapping, Optional, Union
 
-from dagster import OpExecutionContext, PipesSubprocessClient
+from dagster import AssetExecutionContext, OpExecutionContext, PipesSubprocessClient
 from dagster._annotations import public
 from dagster._core.pipes.client import PipesClientCompletedInvocation
 from dagster_pipes import PipesExtras
@@ -46,7 +46,7 @@ class ModalClient(PipesSubprocessClient):
         self,
         *,
         func_ref: str,
-        context: OpExecutionContext,
+        context: Union[AssetExecutionContext, OpExecutionContext],
         extras: Optional[PipesExtras] = None,
         env: Optional[Mapping[str, str]] = None,
     ) -> PipesClientCompletedInvocation:

--- a/libraries/dagster-contrib-modal/pyproject.toml
+++ b/libraries/dagster-contrib-modal/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-contrib-modal"
-version = "0.0.1"
+version = "0.0.2"
 description = "Dagster integration with Modal"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/libraries/dagster-contrib-modal/uv.lock
+++ b/libraries/dagster-contrib-modal/uv.lock
@@ -413,7 +413,7 @@ wheels = [
 [[package]]
 name = "dagster-contrib-modal"
 version = "0.0.1"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "dagster" },
     { name = "dagster-pipes" },


### PR DESCRIPTION
`context` parameter should be a union of op execution and asset execution context.