### PR TITLE
[dagster-pipes-rust] set codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *   @cmpadden
 
-# Pipes codeowners
 /libraries/pipes/   @danielgafni
 /libraries/pipes/implementations/java   @GingerYouth
+/libraries/pipes/implementations/rust  @christeefy @marijncv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 /libraries/pipes/   @danielgafni
 /libraries/pipes/implementations/java   @GingerYouth
-/libraries/pipes/implementations/rust  @christeefy @marijncv
+/libraries/pipes/implementations/rust  @cmpadden @christeefy @marijncv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *   @cmpadden
 
 /libraries/pipes/   @danielgafni
-/libraries/pipes/implementations/java   @GingerYouth
+/libraries/pipes/implementations/java   @GingerYouth @danielgafni
 /libraries/pipes/implementations/rust  @cmpadden @christeefy @marijncv

--- a/.github/workflows/libraries-pipes-rust.yml
+++ b/.github/workflows/libraries-pipes-rust.yml
@@ -49,6 +49,9 @@ jobs:
   integration:
     name: "integration"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./libraries/pipes/implementations/rust/example-dagster-pipes-rust-project
     steps:
       - uses: actions/checkout@v4
 
@@ -56,17 +59,13 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: "Install Python"
-        working-directory: example-dagster-pipes-rust-project
         run: uv python install
 
       - name: "Install the project"
-        working-directory: example-dagster-pipes-rust-project
         run: uv sync --all-extras --dev
 
       - name: "Lint"
-        working-directory: example-dagster-pipes-rust-project
         run: uv run make ruff 
 
       - name: "Tests"
-        working-directory: example-dagster-pipes-rust-project
         run: uv run pytest example_dagster_pipes_rust_project_tests

--- a/.github/workflows/libraries-pipes-rust.yml
+++ b/.github/workflows/libraries-pipes-rust.yml
@@ -2,9 +2,10 @@ name: dagster-pipes-rust
 
 on:
   pull_request:
-  paths:
-    - "./libraries/pipes/implementations/rust/**"
-    - ".github/workflows/libraries-pipes-rust.yml"
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "./libraries/pipes/implementations/rust/**"
+      - ".github/workflows/libraries-pipes-rust.yml"
 
 defaults:
   run:

--- a/libraries/pipes/implementations/rust/README.md
+++ b/libraries/pipes/implementations/rust/README.md
@@ -1,6 +1,3 @@
-> [!WARNING]
-> This project is under active development and is subject to change!
-
 # dagster-pipes-rust
 
 Get full observability into your Rust workloads when orchestrating through Dagster. With this light weight interface, you can retrieve data directly from the Dagster context, report asset materializations, report asset checks, provide structured logging, end more.


### PR DESCRIPTION
## Summary & Motivation

- Moves the GitHub actions original in the `dagster-pipes-rust` repo
- Sets codeowners for `libraries/pipes/implementations/rust`

## How I Tested These Changes

- Observe CI

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
