### PR TITLE
[pipes-rust] - use ::new to create the metadata value

### DIFF
--- a/libraries/pipes/implementations/rust/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
+++ b/libraries/pipes/implementations/rust/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
@@ -14,10 +14,7 @@ fn main() -> Result<(), DagsterPipesError> {
 
     let check_metadata = HashMap::from([(
         "quality".to_string(),
-        PipesMetadataValue {
-            raw_value: Some(RawValue::Integer(100)),
-            pipes_metadata_value_type: Some(Type::Int),
-        },
+        PipesMetadataValue::new(RawValue::Integer(100), Type::Int),
     )]);
     context.report_asset_check(
         "example_rust_subprocess_check",


### PR DESCRIPTION
## Summary & Motivation

Makes the creation of the metadata a little bit less verbose and consistent with the other invocation

## How I Tested These Changes

Tests