### PR TITLE
[jsonschema] improve jsonschema optional fields

### DIFF
--- a/libraries/pipes/jsonschema/PipesContextData.schema.json
+++ b/libraries/pipes/jsonschema/PipesContextData.schema.json
@@ -4,13 +4,13 @@
   "description": "The serializable data passed from the orchestration process to the external process. This gets wrapped in a PipesContext.",
   "properties": {
     "asset_keys": {
-      "type": ["null", "array"],
+      "type": "array",
       "items": {
         "type": "string"
       }
     },
     "code_version_by_asset_key": {
-      "type": ["null", "object"],
+      "type": "object",
       "additionalProperties": {
         "type": ["null", "string"]
       }
@@ -36,10 +36,10 @@
       }
     },
     "partition_key": {
-      "type": ["null", "string"]
+      "type": "string"
     },
     "partition_key_range": {
-      "type": ["null", "object"],
+      "type": "object",
       "properties": {
         "start": {
           "type": "string"
@@ -50,7 +50,7 @@
       }
     },
     "partition_time_window": {
-      "type": ["null", "object"],
+      "type": "object",
       "properties": {
         "start": {
           "type": "string"
@@ -64,7 +64,7 @@
       "type": "string"
     },
     "job_name": {
-      "type": ["null", "string"]
+      "type": "string"
     },
     "retry_number": {
       "type": "integer"

--- a/libraries/pipes/jsonschema/PipesException.schema.json
+++ b/libraries/pipes/jsonschema/PipesException.schema.json
@@ -12,7 +12,7 @@
       }
     },
     "name": {
-      "type": ["null", "string"],
+      "type": "string",
       "description": "class name of Exception object"
     },
     "cause": {


### PR DESCRIPTION
## Summary & Motivation

Remove `null` type from any optional field in the object that wasn't specific in the `required` attribute. ~And fix `quicktype.sh` shebang from `#!bash` to `#!/bin/bash` to fix script broken on macOS.~

## How I Tested These Changes

~- Run `quicktype.sh` and expected no changes in `types.rs`.~

## Changelog

