### PR TITLE
[dagster-pipes-rust] 📝 Sort exports and update docs for public-facing traits

### DIFF
--- a/libraries/pipes/implementations/rust/src/context_loader.rs
+++ b/libraries/pipes/implementations/rust/src/context_loader.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 use crate::PipesContextData;
 
+/// Load context data injected by the orchestration process.
 pub trait LoadContext {
     fn load_context(
         &self,

--- a/libraries/pipes/implementations/rust/src/lib.rs
+++ b/libraries/pipes/implementations/rust/src/lib.rs
@@ -12,18 +12,19 @@ use serde_json::Map;
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::context_loader::DefaultLoader as PipesDefaultContextLoader;
-pub use crate::context_loader::LoadContext;
-use crate::context_loader::PayloadErrorKind;
-use crate::params_loader::EnvVarLoader as PipesEnvVarParamsLoader;
-pub use crate::params_loader::LoadParams;
-use crate::params_loader::ParamsError;
-pub use crate::types::PipesMetadataValue;
+use crate::context_loader::{DefaultLoader as PipesDefaultContextLoader, PayloadErrorKind};
+use crate::params_loader::{EnvVarLoader as PipesEnvVarParamsLoader, ParamsError};
 use crate::types::{Method, PipesContextData, PipesMessage};
-use crate::writer::message_writer::get_opened_payload;
-use crate::writer::message_writer::DefaultWriter as PipesDefaultMessageWriter;
+use crate::writer::message_writer::{
+    get_opened_payload, DefaultWriter as PipesDefaultMessageWriter,
+};
+use crate::writer::message_writer_channel::MessageWriteError;
+
+pub use crate::context_loader::LoadContext;
+pub use crate::params_loader::LoadParams;
+pub use crate::types::PipesMetadataValue;
 pub use crate::writer::message_writer::{DefaultWriter, MessageWriter};
-use crate::writer::message_writer_channel::{MessageWriteError, MessageWriterChannel};
+pub use crate::writer::message_writer_channel::MessageWriterChannel;
 
 #[derive(Serialize)]
 #[serde(rename_all = "UPPERCASE")]

--- a/libraries/pipes/implementations/rust/src/params_loader.rs
+++ b/libraries/pipes/implementations/rust/src/params_loader.rs
@@ -10,8 +10,8 @@ const DAGSTER_PIPES_CONTEXT_ENV_VAR: &str = "DAGSTER_PIPES_CONTEXT";
 const DAGSTER_PIPES_MESSAGES_ENV_VAR: &str = "DAGSTER_PIPES_MESSAGES";
 
 /// Load params passed from the orchestration process by the context injector and
-/// message reader. These params are used to respectively bootstrap
-/// [`LoadContext`](crate::LoadContext) and [`PipesMessageWriter`].
+/// message reader. These params are used to respectively bootstrap implementations of
+/// [`LoadContext`](crate::LoadContext) and [`PipesMessageWriter`](crate::MessageWriter).
 pub trait LoadParams {
     /// Whether or not this process has been provided with provided with information
     /// to create a `PipesContext` or should instead return a mock.

--- a/libraries/pipes/implementations/rust/src/writer/message_writer.rs
+++ b/libraries/pipes/implementations/rust/src/writer/message_writer.rs
@@ -11,7 +11,7 @@ mod private {
     pub struct Token; // To seal certain trait methods
 }
 
-/// Write messages back to Dagster, via its associated [`Self::Channel`].
+/// Write messages back to Dagster, via its associated [`MessageWriterChannel`](crate::MessageWriterChannel).
 pub trait MessageWriter {
     type Channel: MessageWriterChannel;
 


### PR DESCRIPTION
## Summary & Motivation
It's not clear what's types are publiclly exposed. Exposing too much may lead to unnecessary breaking changes in the future. 

As such, public re-exports (`pub use ...`) are grouped separately in `lib.rs`. 
I also took this chance to improve the docs for public facing types and traits. 

With changes here and from #61, here's the exposed surface area:
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/ab138b92-816e-4a1b-b529-2069ff388f6f" />


## How I Tested These Changes
- cargo tests and manually running `dagster dev`.

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
