### PR TITLE
[dagster-pipes-tests] - assert that all levels are logged at least once

### DIFF
--- a/libraries/pipes/tests/dagster-pipes-tests/src/dagster_pipes_tests/suite.py
+++ b/libraries/pipes/tests/dagster-pipes-tests/src/dagster_pipes_tests/suite.py
@@ -372,14 +372,19 @@ class PipesTestSuite:
 
         err = captured.err
 
-        for level in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        expected_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        logged_levels = set()
+
+        for level in expected_levels:
             # example log line we are looking for:
             # 2024-11-13 16:54:55 +0100 - dagster - WARNING - __ephemeral_asset_job__ - 2716d101-cf11-4baa-b22d-d2530cb8b121 - my_asset - Warning message
 
             for line in err.split("\n"):
                 if f"{level.lower().capitalize()} message" in line:
                     assert level in line
-
+                    logged_levels.add(level)
+                    
+        assert logged_levels == expected_levels
         assert (
             "[pipes] did not receive any messages from external process"
             not in captured.err


### PR DESCRIPTION
## Summary & Motivation

This asserts that all log levels are logged at least once by the external pipes process. Without this, an implementation would have the test succeeding if no log levels are actually logged.

## How I Tested These Changes

Ran the log tests in the runs implementation after this change and observed the test failing

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
