### PR TITLE
[dagster-pipes-test] make job name flag consistent with other flags

### DIFF
--- a/libraries/pipes/implementations/java/dagster-pipes-java/src/test/java/pipes/MainTest.java
+++ b/libraries/pipes/implementations/java/dagster-pipes-java/src/test/java/pipes/MainTest.java
@@ -48,7 +48,7 @@ public class MainTest implements Runnable {
     private boolean env = false;
 
     @CommandLine.Option(
-        names = {"--jobName"},
+        names = {"--job-name"},
         description = "Provide value of 'jobName' for testing"
     )
     private String jobName;

--- a/libraries/pipes/implementations/rust/src/bin/pipes_tests.rs
+++ b/libraries/pipes/implementations/rust/src/bin/pipes_tests.rs
@@ -20,7 +20,7 @@ struct Cli {
         require_equals = false,
     )]
     env: bool,
-    #[arg(long = "jobName")]
+    #[arg(long = "job-name")]
     job_name: Option<String>,
     #[arg(long)]
     extras: Option<String>,

--- a/libraries/pipes/tests/dagster-pipes-tests/src/dagster_pipes_tests/suite.py
+++ b/libraries/pipes/tests/dagster-pipes-tests/src/dagster_pipes_tests/suite.py
@@ -132,7 +132,7 @@ class PipesTestSuite:
             args = self.BASE_ARGS + [
                 "--env",
                 f"--extras={str(extras_path)}",
-                f"--jobName={job_name}",
+                f"--job-name={job_name}",
             ]
 
             return pipes_subprocess_client.run(
@@ -227,7 +227,7 @@ class PipesTestSuite:
                 "--full",
                 "--env",
                 f"--extras={metadata_path}",
-                f"--jobName={job_name}",
+                f"--job-name={job_name}",
             ]
 
             invocation_result = pipes_subprocess_client.run(
@@ -419,7 +419,7 @@ class PipesTestSuite:
             args = self.BASE_ARGS + [
                 "--full",
                 "--env",
-                f"--jobName={job_name}",
+                f"--job-name={job_name}",
                 "--custom-payload-path",
                 str(custom_payload_path),
             ]
@@ -495,7 +495,7 @@ class PipesTestSuite:
             args = self.BASE_ARGS + [
                 "--full",
                 "--env",
-                f"--jobName={job_name}",
+                f"--job-name={job_name}",
                 "--report-asset-materialization",
                 str(asset_materialization_path),
             ]
@@ -592,7 +592,7 @@ class PipesTestSuite:
             args = self.BASE_ARGS + [
                 "--full",
                 "--env",
-                f"--jobName={job_name}",
+                f"--job-name={job_name}",
                 "--report-asset-check",
                 str(report_asset_check_path),
             ]


### PR DESCRIPTION
## Summary & Motivation

Currently, the job name flag use camel case while other flags use kebab case. This changeset convert the `jobName` into `job-name` to make it consistent with other flags and change the Java implementation to use that flag instead.

## How I Tested These Changes

Make java implementation tests passed by running `uv run pytest` in java directory.

## Changelog
