### PR TITLE
[dagster-pipes-rust] - Add the test suite path to the workflow triggers

### DIFF
--- a/.github/workflows/libraries-pipes-rust.yml
+++ b/.github/workflows/libraries-pipes-rust.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, closed]
     paths:
       - "libraries/pipes/implementations/rust/**"
+      - "libraries/pipes/tests/**"
       - ".github/workflows/libraries-pipes-rust.yml"
 
 defaults:


### PR DESCRIPTION
## Summary & Motivation

This triggers the rust workflow when the test suite changes to make sure we catch breaking changes

## How I Tested These Changes

n/a

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
