### PR TITLE
[dagster-pipes-test] use context.run to get job_name

### DIFF
--- a/libraries/pipes/tests/dagster-pipes-tests/src/dagster_pipes_tests/suite.py
+++ b/libraries/pipes/tests/dagster-pipes-tests/src/dagster_pipes_tests/suite.py
@@ -127,7 +127,7 @@ class PipesTestSuite:
             context: AssetExecutionContext,
             pipes_subprocess_client: PipesSubprocessClient,
         ) -> MaterializeResult:
-            job_name = context.dagster_run.job_name
+            job_name = context.run.job_name
 
             args = self.BASE_ARGS + [
                 "--env",
@@ -221,7 +221,7 @@ class PipesTestSuite:
             context: AssetExecutionContext,
             pipes_subprocess_client: PipesSubprocessClient,
         ) -> MaterializeResult:
-            job_name = context.dagster_run.job_name
+            job_name = context.run.job_name
 
             args = self.BASE_ARGS + [
                 "--full",
@@ -414,7 +414,7 @@ class PipesTestSuite:
             context: AssetExecutionContext,
             pipes_subprocess_client: PipesSubprocessClient,
         ) -> MaterializeResult:
-            job_name = context.dagster_run.job_name
+            job_name = context.run.job_name
 
             args = self.BASE_ARGS + [
                 "--full",
@@ -490,7 +490,7 @@ class PipesTestSuite:
             context: AssetExecutionContext,
             pipes_subprocess_client: PipesSubprocessClient,
         ) -> MaterializeResult:
-            job_name = context.dagster_run.job_name
+            job_name = context.run.job_name
 
             args = self.BASE_ARGS + [
                 "--full",
@@ -587,7 +587,7 @@ class PipesTestSuite:
             context: AssetExecutionContext,
             pipes_subprocess_client: PipesSubprocessClient,
         ):
-            job_name = context.dagster_run.job_name
+            job_name = context.run.job_name
 
             args = self.BASE_ARGS + [
                 "--full",


### PR DESCRIPTION
## Summary & Motivation

I found during run pytest that `context.dagster_run` is deprecated and will be remove in the future. This PR migrate those calls to use `context.run` instead.

## How I Tested These Changes

-

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
