### PR TITLE
[dagster-pipes-rust] - Adds pipes logger

### DIFF
--- a/libraries/pipes/implementations/rust/src/lib.rs
+++ b/libraries/pipes/implementations/rust/src/lib.rs
@@ -1,4 +1,5 @@
 mod context_loader;
+mod logger;
 mod params_loader;
 mod types;
 mod types_ext;
@@ -13,6 +14,7 @@ use thiserror::Error;
 use types::PipesException;
 
 use crate::context_loader::{DefaultLoader as PipesDefaultContextLoader, PayloadErrorKind};
+use crate::logger::PipesLogger;
 use crate::params_loader::{EnvVarLoader as PipesEnvVarParamsLoader, ParamsError};
 use crate::types::{Method, PipesContextData, PipesMessage};
 use crate::writer::message_writer::{
@@ -39,6 +41,7 @@ where
 {
     pub data: PipesContextData,
     message_channel: W::Channel,
+    pub logger: PipesLogger<W>,
 }
 
 impl<W> PipesContext<W>
@@ -51,13 +54,15 @@ where
         message_writer: &W,
     ) -> Result<Self, MessageWriteError> {
         let mut message_channel = message_writer.open(message_params);
+        let logger = PipesLogger::new(message_channel.clone());
+
         let opened_payload = get_opened_payload(message_writer);
         let opened_message = PipesMessage::new(Method::Opened, Some(opened_payload));
         message_channel.write_message(opened_message)?;
-
         Ok(Self {
             data: context_data,
             message_channel,
+            logger,
         })
     }
 
@@ -209,13 +214,15 @@ mod tests {
         ]);
 
         let file = NamedTempFile::new().unwrap();
+        let channel = DefaultChannel::File(FileChannel::new(file.path().into()));
         let mut context: PipesContext<DefaultWriter> = PipesContext {
-            message_channel: DefaultChannel::File(FileChannel::new(file.path().into())),
+            message_channel: channel.clone(),
             data: PipesContextData {
                 asset_keys: Some(vec!["asset1".to_string()]),
                 run_id: "012345".to_string(),
                 ..Default::default()
             },
+            logger: PipesLogger::new(channel),
         };
         context
             .report_asset_materialization("asset1", asset_metadata, Some("v1"))
@@ -333,13 +340,15 @@ mod tests {
         #[case] expected_message: serde_json::Value,
     ) {
         let file = NamedTempFile::new().unwrap();
+        let channel = DefaultChannel::File(FileChannel::new(file.path().into()));
         let mut context: PipesContext<DefaultWriter> = PipesContext {
-            message_channel: DefaultChannel::File(FileChannel::new(file.path().into())),
+            message_channel: channel.clone(),
             data: PipesContextData {
                 asset_keys: Some(vec!["asset1".to_string()]),
                 run_id: "012345".to_string(),
                 ..Default::default()
             },
+            logger: PipesLogger::new(channel),
         };
         context.close(exc).expect("Failed to close context");
         assert_eq!(
@@ -353,13 +362,15 @@ mod tests {
     fn test_close_pipes_context_when_out_of_scope() {
         let file = NamedTempFile::new().unwrap();
         {
+            let channel = DefaultChannel::File(FileChannel::new(file.path().into()));
             let _: PipesContext<DefaultWriter> = PipesContext {
-                message_channel: DefaultChannel::File(FileChannel::new(file.path().into())),
+                message_channel: channel.clone(),
                 data: PipesContextData {
                     asset_keys: Some(vec!["asset1".to_string()]),
                     run_id: "012345".to_string(),
                     ..Default::default()
                 },
+                logger: PipesLogger::new(channel),
             };
         }
         assert_eq!(

--- a/libraries/pipes/implementations/rust/src/logger.rs
+++ b/libraries/pipes/implementations/rust/src/logger.rs
@@ -1,0 +1,105 @@
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use crate::{
+    types::{Method, PipesLogLevel, PipesMessage},
+    writer::{message_writer::MessageWriter, message_writer_channel::MessageWriteError},
+    MessageWriterChannel,
+};
+
+#[derive(Debug)]
+pub struct PipesLogger<W>
+where
+    W: MessageWriter,
+{
+    message_channel: W::Channel,
+}
+
+impl<W> PipesLogger<W>
+where
+    W: MessageWriter,
+{
+    pub fn new(message_channel: W::Channel) -> Self {
+        Self { message_channel }
+    }
+
+    fn _log_message(
+        &mut self,
+        message: &str,
+        level: PipesLogLevel,
+    ) -> Result<(), MessageWriteError> {
+        let params = HashMap::from([
+            ("message", Some(json!(message))),
+            ("level", Some(json!(level))),
+        ]);
+        let closed_message = PipesMessage::new(Method::Log, Some(params));
+        self.message_channel.write_message(closed_message)
+    }
+
+    pub fn critical(&mut self, message: &str) -> Result<(), MessageWriteError> {
+        self._log_message(message, PipesLogLevel::Critical)
+    }
+
+    pub fn debug(&mut self, message: &str) -> Result<(), MessageWriteError> {
+        self._log_message(message, PipesLogLevel::Debug)
+    }
+
+    pub fn error(&mut self, message: &str) -> Result<(), MessageWriteError> {
+        self._log_message(message, PipesLogLevel::Error)
+    }
+
+    pub fn info(&mut self, message: &str) -> Result<(), MessageWriteError> {
+        self._log_message(message, PipesLogLevel::Info)
+    }
+
+    pub fn warning(&mut self, message: &str) -> Result<(), MessageWriteError> {
+        self._log_message(message, PipesLogLevel::Warning)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use std::fs;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::writer::{
+        message_writer::DefaultWriter,
+        message_writer_channel::{DefaultChannel, FileChannel},
+    };
+
+    #[rstest]
+    #[case(PipesLogLevel::Critical)]
+    #[case(PipesLogLevel::Debug)]
+    #[case(PipesLogLevel::Error)]
+    #[case(PipesLogLevel::Info)]
+    #[case(PipesLogLevel::Warning)]
+    fn test_logger(#[case] level: PipesLogLevel) {
+        let file = NamedTempFile::new().unwrap();
+        let channel = DefaultChannel::File(FileChannel::new(file.path().into()));
+        let mut logger = PipesLogger::<DefaultWriter>::new(channel);
+
+        match level {
+            PipesLogLevel::Critical => logger.critical("message").unwrap(),
+            PipesLogLevel::Debug => logger.debug("message").unwrap(),
+            PipesLogLevel::Error => logger.error("message").unwrap(),
+            PipesLogLevel::Info => logger.info("message").unwrap(),
+            PipesLogLevel::Warning => logger.warning("message").unwrap(),
+        }
+
+        let json =
+            serde_json::from_str::<serde_json::Value>(&fs::read_to_string(file.path()).unwrap())
+                .unwrap();
+
+        assert!(json.get("method").is_some_and(|m| m == "log"));
+        assert!(json
+            .get("params")
+            .is_some_and(|p| p.get("message").is_some_and(|m| m == "message")));
+        assert!(json.get("params").is_some_and(|p| p
+            .get("level")
+            .is_some_and(|l| *l == serde_json::to_value(level).unwrap())));
+    }
+}

--- a/libraries/pipes/implementations/rust/src/writer/message_writer_channel.rs
+++ b/libraries/pipes/implementations/rust/src/writer/message_writer_channel.rs
@@ -8,7 +8,7 @@ use super::StdStream;
 
 /// Write messages back to the Dagster orchestration process.
 /// To be used in conjunction with [`MessageWriter`](crate::MessageWriter).
-pub trait MessageWriterChannel {
+pub trait MessageWriterChannel: Clone {
     /// Write a message to the orchestration process
     fn write_message(&mut self, message: PipesMessage) -> Result<(), MessageWriteError>;
 }
@@ -27,7 +27,7 @@ pub enum MessageWriteError {
     Invalid(#[from] serde_json::Error),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FileChannel {
     path: OsString,
 }
@@ -56,7 +56,7 @@ impl MessageWriterChannel for FileChannel {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StreamChannel {
     stream: StdStream,
 }
@@ -91,7 +91,7 @@ impl MessageWriterChannel for StreamChannel {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct BufferedStreamChannel {
     buffer: Vec<PipesMessage>,
     stream: StdStream,
@@ -153,7 +153,7 @@ impl MessageWriterChannel for BufferedStreamChannel {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[non_exhaustive]
 pub enum DefaultChannel {
     File(FileChannel),


### PR DESCRIPTION
## Summary & Motivation

This adds a `logger` field to the `PipesContext` that can be used to log messages to Dagster. I ended up deriving the `Clone` trait for the message channels to get around having to deal with lifetimes in sharing the channel between the top level `PipesContext` struct and the `PipesLogger` struct. Open to suggestions for an alternative approach!

## How I Tested These Changes

Added test. The `dagster-pipes-tests` suite tests can also be enabled after https://github.com/dagster-io/community-integrations/pull/76 is merged

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
