### PR TITLE
fix: add cloud run job timeout to instance config

### DIFF
--- a/libraries/dagster-contrib-gcp/README.md
+++ b/libraries/dagster-contrib-gcp/README.md
@@ -11,3 +11,38 @@ make test
 ```sh
 make build
 ```
+
+## Overview
+
+This package provides integrations with Google Cloud Platform (GCP) services. It currently includes the following 
+integrations:
+
+### Cloud Run
+
+#### Cloud Run run launcher
+
+Adds support for launching Dagster runs on Google Cloud Run. Usage is as follows:
+
+1. Create a Cloud Run Job from your Dagster code location image to act as the run worker. If you require multiple 
+   environments/code locations, you can create multiple Cloud Run Jobs.
+2. Add `dagster-contrib-gcp` to your Dagster webserver/daemon environment.
+3. Add the following configuration to your Dagster instance YAML:
+
+```yaml
+run_launcher:
+  module: dagster_contrib_gcp.cloud_run.run_launcher
+  class: CloudRunRunLauncher
+  config:
+    project:
+      env: GOOGLE_CLOUD_PROJECT
+    region:
+      env: GOOGLE_CLOUD_REGION
+    job_name_by_code_location:
+      my-code-location-1: my-cloud-run-job-1
+      my-code-location-2: my-cloud-run-job-2
+```
+
+Additional steps may be required for configuring IAM permissions, etc. In particular:
+- Ensure that the webserver/daemon environment has the necessary permissions to execute the Cloud Run jobs
+- Ensure that the Cloud Run run worker jobs have the necessary permissions to execute your Dagster runs
+See the [Cloud Run documentation](https://cloud.google.com/run/docs) for more information.

--- a/libraries/dagster-contrib-gcp/dagster_contrib_gcp_tests/cloud_run_tests/conftest.py
+++ b/libraries/dagster-contrib-gcp/dagster_contrib_gcp_tests/cloud_run_tests/conftest.py
@@ -44,6 +44,7 @@ def instance(
             "region": "test_region",
             "job_name_by_code_location": {IN_PROCESS_NAME: "test_job_name"},
             "run_job_retry": {"wait": 1, "timeout": 60},
+            "run_timeout": 7200,
         }
     ) as dagster_instance:
         yield dagster_instance

--- a/libraries/dagster-contrib-gcp/dagster_contrib_gcp_tests/cloud_run_tests/test_run_launcher.py
+++ b/libraries/dagster-contrib-gcp/dagster_contrib_gcp_tests/cloud_run_tests/test_run_launcher.py
@@ -11,6 +11,7 @@ from google.cloud.run_v2 import (
     GetExecutionRequest,
     RunJobRequest,
 )
+import datetime as dt
 
 
 def test_launch_run(
@@ -33,6 +34,7 @@ def test_launch_run(
     assert (
         args[0].name == "projects/test_project/locations/test_region/jobs/test_job_name"
     )
+    assert args[0].overrides.timeout == dt.timedelta(seconds=7200)
 
 
 def test_terminate(

--- a/libraries/dagster-contrib-gcp/uv.lock
+++ b/libraries/dagster-contrib-gcp/uv.lock
@@ -222,8 +222,8 @@ wheels = [
 
 [[package]]
 name = "dagster-contrib-gcp"
-version = "0.0.1"
-source = { virtual = "." }
+version = "0.0.2"
+source = { editable = "." }
 dependencies = [
     { name = "dagster" },
     { name = "google-cloud-run" },


### PR DESCRIPTION
Adds job timeout as dagster.yaml instance config. Also adds some basic docs for the Cloud Run run launcher.

## Summary & Motivation

Ensure that Cloud Run run worker timeout is configurable at the instance level.

## How I Tested These Changes

Unit tests have been updated.
