### PR TITLE
[dagster-contrib-gcp] bump 0.0.3; add changelog entry

### DIFF
--- a/libraries/dagster-contrib-gcp/CHANGELOG.md
+++ b/libraries/dagster-contrib-gcp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.3
+
+### Updated
+
+- (pull/88) Added job timeout as dagster.yaml instance config

--- a/libraries/dagster-contrib-gcp/pyproject.toml
+++ b/libraries/dagster-contrib-gcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster_contrib_gcp"
-version = "0.0.2"
+version = "0.0.3"
 description = "Community contributed Google Cloud Platform integration"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary & Motivation

- Creates release 0.0.3 to include https://github.com/dagster-io/community-integrations/pull/88
