### PR TITLE
Hex Assets

### DIFF
--- a/libraries/dagster-hex/dagster_hex/assets.py
+++ b/libraries/dagster-hex/dagster_hex/assets.py
@@ -1,0 +1,77 @@
+from dagster import (
+    AssetsDefinition,
+    asset,
+    AssetExecutionContext,
+    AssetMaterialization,
+    MetadataValue,
+    Output,
+)
+from dagster._annotations import experimental
+from typing import Optional
+from .resources import HexResource
+
+
+@experimental
+def build_hex_asset(
+    project_id: str,
+    resource: HexResource,
+    inputs: Optional[dict] = None,
+    update_cache: bool = False,
+    notifications: Optional[list] = None,
+    deps: Optional[list] = None,
+    tags: Optional[dict] = None,
+) -> AssetsDefinition:
+    """
+    Returns the AssetDefinition for a Hex Project
+
+    Args:
+        project_id: The Hex project id
+        resource: The HexResource
+        inputs: The inputs for the asset
+        update_cache: Whether to update the cache
+        notifications: The notifications for the asset
+        deps: The dependencies for the asset
+        tags: The tags for the asset
+    Returns:
+        AssetsDefinition: The AssetDefinition for the Hex Project
+    """
+
+    project_name = resource.get_project(project_id)["title"]
+    metadata = resource.get_project_details(project_id)
+
+    @asset(
+        name=f"{project_name}__{project_id.replace('-', '_')}",
+        required_resource_keys={"hex"},
+        deps=deps,
+        metadata=metadata,
+        tags=tags,
+        kinds={"hex"},
+    )
+    def hex_asset(context: AssetExecutionContext):
+        output = context.resources.hex.run_and_poll(
+            project_id=project_id,
+            inputs=inputs,
+            update_cache=update_cache,
+            notifications=notifications,
+        )
+        asset_key = ["hex", project_name, project_id]
+        context.log_event(
+            AssetMaterialization(
+                asset_key,
+                description="Hex Project Details",
+                metadata={
+                    "run_url": MetadataValue.url(output.run_response["runUrl"]),
+                    "run_status_url": MetadataValue.url(
+                        output.run_response["runStatusUrl"]
+                    ),
+                    "trace_id": MetadataValue.text(output.run_response["traceId"]),
+                    "run_id": MetadataValue.text(output.run_response["runId"]),
+                    "elapsed_time": MetadataValue.int(
+                        output.status_response["elapsedTime"]
+                    ),
+                },
+            )
+        )
+        yield Output(output)
+
+    return hex_asset

--- a/libraries/dagster-hex/dagster_hex/types.py
+++ b/libraries/dagster-hex/dagster_hex/types.py
@@ -10,6 +10,20 @@ RunResponse = TypedDict(
         "traceId": str,
     },
 )
+
+ProjectResponse = TypedDict(
+    "ProjectResponse",
+    {
+        "projectId": str,
+        "title": str,
+        "description": str,
+        "creator": dict,
+        "lastEditedAt": str,
+        "lastPublishedAt": str,
+        "categories": List[dict],
+    },
+)
+
 NotificationResponse = TypedDict(
     "NotificationResponse",
     {

--- a/libraries/dagster-hex/dagster_hex_tests/test_hex.py
+++ b/libraries/dagster-hex/dagster_hex_tests/test_hex.py
@@ -1,5 +1,3 @@
-import dagster as dg
-
 from dagster_hex.resources import HexResource
 
 
@@ -26,7 +24,7 @@ def test_run_project(requests_mock):
     assert response == {"data": "mocked response"}
     assert requests_mock.last_request.json() == {
         "inputParams": {"param": "var"},
-        "updateCache": False,
+        "useCachedSqlResults": True,
     }
 
 
@@ -41,32 +39,5 @@ def test_run_project_no_input(requests_mock):
     response = hex.run_project("abc-123")
     assert response == {"data": "mocked response"}
     assert requests_mock.last_request.json() == {
-        "updateCache": False,
-    }
-
-
-def test_run_project_from_asset(requests_mock):
-    project_id = "hex-project-id"
-    requests_mock.post(
-        f"https://testurl/api/v1/project/{project_id}/run",
-        headers={"Content-Type": "application/json"},
-        json={"data": "mocked response"},
-    )
-
-    @dg.asset()
-    def example_hex_project_asset(hex: HexResource) -> dg.MaterializeResult:
-        response = hex.run_project(project_id, inputs={"param": "var"})
-        return dg.MaterializeResult(metadata={"data": response.get("data")})
-
-    res = dg.materialize(
-        [example_hex_project_asset],
-        resources={
-            "hex": HexResource(api_key="HEX_API_KEY", base_url="https://testurl/")
-        },
-    )
-    assert res.success
-
-    assert requests_mock.last_request.json() == {
-        "inputParams": {"param": "var"},
-        "updateCache": False,
+        "useCachedSqlResults": True,
     }


### PR DESCRIPTION
## Summary & Motivation

- This PR adds asset definitions to Dagster-hex integration to enable creating assets from hex projects using the project_id. 
- Updates to the hex resource to sync with [latest changes to the hex api](https://learn.hex.tech/docs/explore-data/notebook-view/hex-api/api-reference)

## How I Tested These Changes

- Used the new changes to define assets from production hex notebooks.

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
