### PR TITLE
[pipes-rust] - enable asset materialization test

### DIFF
--- a/libraries/pipes/implementations/rust/CHANGELOG.md
+++ b/libraries/pipes/implementations/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
--
+- (pull/117) Made the `asset_key` parameter of `report_asset_materialization` & `report_asset_check` optional. Added check to resolve the optionally passed asset key.
 
 ## 0.1.8
 

--- a/libraries/pipes/implementations/rust/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
+++ b/libraries/pipes/implementations/rust/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
@@ -8,7 +8,11 @@ fn main() -> Result<(), DagsterPipesError> {
     let mut context = open_dagster_pipes()?;
 
     let asset_metadata = HashMap::from([("row_count", PipesMetadataValue::from(100))]);
-    context.report_asset_materialization(Some("example_rust_subprocess_asset"), asset_metadata, None)?;
+    context.report_asset_materialization(
+        Some("example_rust_subprocess_asset"),
+        asset_metadata,
+        None,
+    )?;
 
     let check_metadata = HashMap::from([("quality", PipesMetadataValue::from(100))]);
     context.report_asset_check(

--- a/libraries/pipes/implementations/rust/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
+++ b/libraries/pipes/implementations/rust/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
@@ -8,13 +8,13 @@ fn main() -> Result<(), DagsterPipesError> {
     let mut context = open_dagster_pipes()?;
 
     let asset_metadata = HashMap::from([("row_count", PipesMetadataValue::from(100))]);
-    context.report_asset_materialization("example_rust_subprocess_asset", asset_metadata, None)?;
+    context.report_asset_materialization(Some("example_rust_subprocess_asset"), asset_metadata, None)?;
 
     let check_metadata = HashMap::from([("quality", PipesMetadataValue::from(100))]);
     context.report_asset_check(
         "example_rust_subprocess_check",
         true,
-        "example_rust_subprocess_asset",
+        Some("example_rust_subprocess_asset"),
         &AssetCheckSeverity::Warn,
         check_metadata,
     )?;

--- a/libraries/pipes/implementations/rust/pipes.toml
+++ b/libraries/pipes/implementations/rust/pipes.toml
@@ -4,7 +4,7 @@ error_reporting = false
 [messages]
 log = true
 report_custom_message = true
-report_asset_materialization = false
+report_asset_materialization = true
 report_asset_check = false
 log_external_stream = false
 

--- a/libraries/pipes/implementations/rust/src/bin/pipes_tests.rs
+++ b/libraries/pipes/implementations/rust/src/bin/pipes_tests.rs
@@ -111,8 +111,12 @@ where
         .expect("report_asset_materialization could not be opened");
     let json: serde_json::Value =
         serde_json::from_reader(file).expect("report_asset_materialization could not be parsed");
-    let data_version = json.get("dataVersion").map(|v| v.as_str().expect("dataVersion must be a string"));
-    let asset_key = json.get("assetKey").map(|v| v.as_str().expect("assetKey must be a string"));
+    let data_version = json
+        .get("dataVersion")
+        .map(|v| v.as_str().expect("dataVersion must be a string"));
+    let asset_key = json
+        .get("assetKey")
+        .map(|v| v.as_str().expect("assetKey must be a string"));
 
     context.report_asset_materialization(asset_key, build_asset_metadata(), data_version)?;
     Ok(())

--- a/libraries/pipes/implementations/rust/src/bin/pipes_tests.rs
+++ b/libraries/pipes/implementations/rust/src/bin/pipes_tests.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
-use dagster_pipes_rust::{open_dagster_pipes, DagsterPipesError, MessageWriter, PipesContext};
+use dagster_pipes_rust::{
+    open_dagster_pipes, DagsterPipesError, MessageWriter, PipesContext, PipesMetadataValue,
+};
 use dagster_pipes_rust::{DAGSTER_PIPES_CONTEXT_ENV_VAR, DAGSTER_PIPES_MESSAGES_ENV_VAR};
+use serde_json::json;
 use std::collections::HashMap;
 use std::fs::File;
 
@@ -55,6 +58,9 @@ pub fn main() -> Result<(), DagsterPipesError> {
         "test_message_report_custom_message" => {
             test_message_report_custom_message(context, args.custom_payload)
         }
+        "test_message_report_asset_materialization" => {
+            test_message_report_asset_materialization(context, args.report_asset_materialization)
+        }
         _ => Ok(()),
     }?;
     Ok(())
@@ -90,4 +96,71 @@ where
         .clone();
     context.report_custom_message(payload)?;
     Ok(())
+}
+
+fn test_message_report_asset_materialization<W>(
+    mut context: PipesContext<W>,
+    report_asset_materialization: Option<String>,
+) -> Result<(), DagsterPipesError>
+where
+    W: MessageWriter,
+{
+    let report_asset_materialization =
+        report_asset_materialization.expect("report_asset_materialization is required");
+    let file = File::open(report_asset_materialization)
+        .expect("report_asset_materialization could not be opened");
+    let json: serde_json::Value =
+        serde_json::from_reader(file).expect("report_asset_materialization could not be parsed");
+    let data_version = json.get("dataVersion").map(|v| v.as_str().expect("dataVersion must be a string"));
+    let asset_key = json.get("assetKey").map(|v| v.as_str().expect("assetKey must be a string"));
+
+    context.report_asset_materialization(asset_key, build_asset_metadata(), data_version)?;
+    Ok(())
+}
+
+fn build_asset_metadata() -> HashMap<&'static str, PipesMetadataValue> {
+    HashMap::from([
+        ("float", PipesMetadataValue::from(0.1)),
+        ("int", PipesMetadataValue::from(1)),
+        ("text", PipesMetadataValue::from("hello".to_string())),
+        (
+            "notebook",
+            PipesMetadataValue::from_notebook("notebook.ipynb".to_string()),
+        ),
+        (
+            "md",
+            PipesMetadataValue::from_md("**markdown**".to_string()),
+        ),
+        ("bool_true", PipesMetadataValue::from(true)),
+        ("bool_false", PipesMetadataValue::from(false)),
+        (
+            "asset",
+            PipesMetadataValue::from_asset("foo/bar".to_string()),
+        ),
+        (
+            "dagster_run",
+            PipesMetadataValue::from_dagster_run(
+                "db892d7f-0031-4747-973d-22e8b9095d9d".to_string(),
+            ),
+        ),
+        ("null", PipesMetadataValue::null()),
+        (
+            "url",
+            PipesMetadataValue::from_url("https://dagster.io".to_string()),
+        ),
+        (
+            "path",
+            PipesMetadataValue::from_path("/dev/null".to_string()),
+        ),
+        (
+            "json",
+            PipesMetadataValue::from(HashMap::from([
+                ("quux".to_string(), Some(json!({"a": 1, "b": 2}))),
+                ("baz".to_string(), Some(json!(1))),
+                ("foo".to_string(), Some(json!("bar"))),
+                ("corge".to_string(), None),
+                ("qux".to_string(), Some(json!([1, 2, 3]))),
+            ])),
+        ),
+    ])
 }


### PR DESCRIPTION
## Summary & Motivation

Contributes to https://github.com/dagster-io/community-integrations/issues/58

This enables the asset materialization test from the test suite. In order to get there, this also:
- Makes the `asset_key` parameter of `report_asset_materialization` & `report_asset_check` optional. This relates to https://github.com/dagster-io/community-integrations/issues/63. I'm also in favor of going with approach 2 suggested by @christeefy, but would like to tackle it separately from enabling the test now.
- Adds a function to resolve the optionally passed asset key, and corresponding error struct 

## How I Tested These Changes

unit test & enabled test from suite

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
