### PR TITLE
Add Ruff formatter check to quality check template

### DIFF
--- a/.github/workflows/template-quality-check.yml
+++ b/.github/workflows/template-quality-check.yml
@@ -26,14 +26,18 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         run: uv sync
 
-      - name: Ruff
+      - name: Lint
         working-directory: ${{ inputs.working_directory }}
         run: uv run ruff check
 
-      - name: Pyright
+      - name: Format
+        working-directory: ${{ inputs.working_directory }}
+        run: uv run ruff format --check
+
+      - name: Type check
         working-directory: ${{ inputs.working_directory }}
         run: uv run pyright
 
-      - name: Pytest
+      - name: Test
         working-directory: ${{ inputs.working_directory }}
         run: uv run pytest

--- a/libraries/dagster-chroma/dagster_chroma/resource.py
+++ b/libraries/dagster-chroma/dagster_chroma/resource.py
@@ -37,7 +37,7 @@ class ChromaResource(ConfigurableResource):
             resources={
                 "chroma": ChromaResource(
                     connection_config=
-                        LocalConfig(persistence_path="./chroma") if os.getenv("DEV") else 
+                        LocalConfig(persistence_path="./chroma") if os.getenv("DEV") else
                             HttpConfig(host="192.168.0.10", port=8000)
                 ),
             }

--- a/libraries/dagster-notdiamond/examples/example_book_reviews_summary_proxying.py
+++ b/libraries/dagster-notdiamond/examples/example_book_reviews_summary_proxying.py
@@ -1,5 +1,3 @@
-import time
-
 import dagster as dg
 import dagster_openai as oai
 
@@ -59,16 +57,19 @@ def book_reviews_summary(
     prompt = f"""
     Given the book reviews for {book_review_data["title"]}, provide a detailed summary:
 
-    {'|'.join([r['content'] for r in book_review_data["reviews"]])}
+    {"|".join([r["content"] for r in book_review_data["reviews"]])}
     """
 
     with openai.get_client(context) as client:
         chat_completion = client.chat.completions.create(
             model="notdiamond",
             extra_body={
-              "models": ["gpt-4o", "claude-3-5-sonnet-20240620"], # pass in the LLM options you want to route between
-              "tradeoff": "cost",
-              "preference_id": "YOUR_PREFERENCE_ID"
+                "models": [
+                    "gpt-4o",
+                    "claude-3-5-sonnet-20240620",
+                ],  # pass in the LLM options you want to route between
+                "tradeoff": "cost",
+                "preference_id": "YOUR_PREFERENCE_ID",
             },
             messages=[{"role": "user", "content": prompt}],
         )

--- a/libraries/dagster-sdf/dagster_sdf/__init__.py
+++ b/libraries/dagster-sdf/dagster_sdf/__init__.py
@@ -7,7 +7,9 @@ from dagster_sdf.asset_utils import (
     default_asset_key_fn as default_asset_key_fn,
 )
 from dagster_sdf.resource import SdfCliResource as SdfCliResource
-from dagster_sdf.sdf_information_schema import SdfInformationSchema as SdfInformationSchema
+from dagster_sdf.sdf_information_schema import (
+    SdfInformationSchema as SdfInformationSchema,
+)
 from dagster_sdf.sdf_workspace import SdfWorkspace as SdfWorkspace
 from dagster_sdf.version import __version__ as __version__
 

--- a/libraries/dagster-sdf/dagster_sdf/asset_decorator.py
+++ b/libraries/dagster-sdf/dagster_sdf/asset_decorator.py
@@ -26,7 +26,9 @@ def sdf_assets(
     required_resource_keys: Optional[set[str]] = None,
     retry_policy: Optional[RetryPolicy] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
-    dagster_sdf_translator = validate_translator(dagster_sdf_translator or DagsterSdfTranslator())
+    dagster_sdf_translator = validate_translator(
+        dagster_sdf_translator or DagsterSdfTranslator()
+    )
     information_schema = SdfInformationSchema(
         workspace_dir=workspace.workspace_dir,
         target_dir=workspace.target_dir,

--- a/libraries/dagster-sdf/dagster_sdf/asset_utils.py
+++ b/libraries/dagster-sdf/dagster_sdf/asset_utils.py
@@ -97,7 +97,9 @@ def build_schedule_from_sdf_selection(
     )
 
 
-def get_asset_key_for_table_id(sdf_assets: Sequence[AssetsDefinition], table_id: str) -> AssetKey:
+def get_asset_key_for_table_id(
+    sdf_assets: Sequence[AssetsDefinition], table_id: str
+) -> AssetKey:
     """Returns the corresponding Dagster asset key for an sdf table.
 
     Args:
@@ -156,7 +158,9 @@ def get_materialized_sql_dir(target_dir: Path, environment: str) -> Path:
     return get_output_dir(target_dir, environment).joinpath("materialized")
 
 
-def get_table_path_from_parts(catalog_name: str, schema_name: str, table_name: str) -> Path:
+def get_table_path_from_parts(
+    catalog_name: str, schema_name: str, table_name: str
+) -> Path:
     return Path(catalog_name.lower(), schema_name.lower(), table_name.lower())
 
 
@@ -173,26 +177,35 @@ def default_description_fn(
     enable_materialized_sql_description: bool = True,
 ) -> str:
     description_sections = [
-        table_row["description"] or f"sdf {table_row['materialization']} {table_row['table_id']}",
+        table_row["description"]
+        or f"sdf {table_row['materialization']} {table_row['table_id']}",
     ]
     if enable_raw_sql_description:
         if workspace_dir is None:
-            raise ValueError("workspace_dir must be provided to enable raw SQL description.")
+            raise ValueError(
+                "workspace_dir must be provided to enable raw SQL description."
+            )
         path_to_file = None
         for source_location in table_row["source_locations"]:
             if source_location.endswith(".sql"):
                 path_to_file = workspace_dir.joinpath(source_location)
                 break
         if path_to_file is not None and path_to_file.exists():
-            description_sections.append(f"#### Raw SQL:\n```\n{_read_sql_file(path_to_file)}\n```")
+            description_sections.append(
+                f"#### Raw SQL:\n```\n{_read_sql_file(path_to_file)}\n```"
+            )
     if enable_materialized_sql_description:
         if output_dir is None:
-            raise ValueError("output_dir must be provided to enable materialized SQL description.")
+            raise ValueError(
+                "output_dir must be provided to enable materialized SQL description."
+            )
         path_to_file = (
             output_dir.joinpath("materialized")
             .joinpath(
                 get_table_path_from_parts(
-                    table_row["catalog_name"], table_row["schema_name"], table_row["table_name"]
+                    table_row["catalog_name"],
+                    table_row["schema_name"],
+                    table_row["table_name"],
                 )
             )
             .with_suffix(".sql")
@@ -227,7 +240,9 @@ def exists_in_selected(
         if purpose == "test":
             test_name_prefix = get_test_prefix(dialect)
             asset_output_name = (
-                dagster_name_fn(catalog_name, schema_name, table_name[len(test_name_prefix) :])
+                dagster_name_fn(
+                    catalog_name, schema_name, table_name[len(test_name_prefix) :]
+                )
                 if table_name.startswith(test_name_prefix)
                 else asset_output_name
             )

--- a/libraries/dagster-sdf/dagster_sdf/cli/app.py
+++ b/libraries/dagster-sdf/dagster_sdf/cli/app.py
@@ -96,7 +96,9 @@ def copy_scaffold(
     for path in dagster_project_dir.glob("**/*"):
         if path.suffix == ".jinja":
             relative_path = path.relative_to(Path.cwd())
-            destination_path = os.fspath(relative_path.parent.joinpath(relative_path.stem))
+            destination_path = os.fspath(
+                relative_path.parent.joinpath(relative_path.stem)
+            )
             template_path = path.relative_to(dagster_project_dir).as_posix()
 
             env.get_template(template_path).stream(
@@ -109,7 +111,9 @@ def copy_scaffold(
 
             path.unlink()
 
-    dagster_project_dir.joinpath("scaffold").rename(dagster_project_dir.joinpath(workspace_name))
+    dagster_project_dir.joinpath("scaffold").rename(
+        dagster_project_dir.joinpath(workspace_name)
+    )
 
 
 def _check_and_error_on_package_conflicts(workspace_name: str) -> None:

--- a/libraries/dagster-sdf/dagster_sdf/dagster_sdf_translator.py
+++ b/libraries/dagster-sdf/dagster_sdf/dagster_sdf_translator.py
@@ -66,12 +66,17 @@ class DagsterSdfTranslator:
         return default_asset_key_fn(catalog, schema, table)
 
     @public
-    def get_check_key_for_test(self, catalog: str, schema: str, table: str) -> AssetCheckKey:
+    def get_check_key_for_test(
+        self, catalog: str, schema: str, table: str
+    ) -> AssetCheckKey:
         return default_asset_check_key_fn(catalog, schema, table)
 
     @public
     def get_description(
-        self, table_row: dict[str, Any], workspace_dir: Optional[Path], output_dir: Optional[Path]
+        self,
+        table_row: dict[str, Any],
+        workspace_dir: Optional[Path],
+        output_dir: Optional[Path],
     ) -> str:
         """A function that takes a dictionary representing columns of an sdf table row in sdf's
         information schema and returns the Dagster description for that table.
@@ -106,7 +111,9 @@ class DagsterSdfTranslator:
         )
 
 
-def validate_translator(dagster_sdf_translator: DagsterSdfTranslator) -> DagsterSdfTranslator:
+def validate_translator(
+    dagster_sdf_translator: DagsterSdfTranslator,
+) -> DagsterSdfTranslator:
     return check.inst_param(
         dagster_sdf_translator,
         "dagster_sdf_translator",

--- a/libraries/dagster-sdf/dagster_sdf/resource.py
+++ b/libraries/dagster-sdf/dagster_sdf/resource.py
@@ -32,7 +32,10 @@ from dagster_sdf.constants import (
     SDF_EXECUTABLE,
     SDF_WORKSPACE_YML,
 )
-from dagster_sdf.dagster_sdf_translator import DagsterSdfTranslator, validate_opt_translator
+from dagster_sdf.dagster_sdf_translator import (
+    DagsterSdfTranslator,
+    validate_opt_translator,
+)
 from dagster_sdf.sdf_cli_invocation import SdfCliInvocation
 from dagster_sdf.sdf_version import SDF_VERSION_LOWER_BOUND, SDF_VERSION_UPPER_BOUND
 from dagster_sdf.sdf_workspace import SdfWorkspace
@@ -93,7 +96,9 @@ class SdfCliResource(ConfigurableResource):
             try:
                 resolved_path = absolute_path.resolve(strict=True)
             except FileNotFoundError:
-                raise ValueError(f"The absolute path of '{v}' ('{absolute_path}') does not exist")
+                raise ValueError(
+                    f"The absolute path of '{v}' ('{absolute_path}') does not exist"
+                )
             return os.fspath(resolved_path)
 
         return v
@@ -156,7 +161,9 @@ class SdfCliResource(ConfigurableResource):
             assets_def = context.assets_def if context else None
 
         context = (
-            context.op_execution_context if isinstance(context, AssetExecutionContext) else context
+            context.op_execution_context
+            if isinstance(context, AssetExecutionContext)
+            else context
         )
 
         dagster_sdf_translator = dagster_sdf_translator or DagsterSdfTranslator()
@@ -175,10 +182,16 @@ class SdfCliResource(ConfigurableResource):
                 # Check if this output is expected, if so, add the table_id and optionally the expected test name to the run_args
                 if selected_output_names and asset_output_name in selected_output_names:
                     table_id: Optional[str] = asset_metadata.get(DAGSTER_SDF_TABLE_ID)
-                    catalog: Optional[str] = asset_metadata.get(DAGSTER_SDF_CATALOG_NAME)
+                    catalog: Optional[str] = asset_metadata.get(
+                        DAGSTER_SDF_CATALOG_NAME
+                    )
                     schema: Optional[str] = asset_metadata.get(DAGSTER_SDF_SCHEMA_NAME)
-                    table_name: Optional[str] = asset_metadata.get(DAGSTER_SDF_TABLE_NAME)
-                    table_dialect: Optional[str] = asset_metadata.get(DAGSTER_SDF_DIALECT)
+                    table_name: Optional[str] = asset_metadata.get(
+                        DAGSTER_SDF_TABLE_NAME
+                    )
+                    table_dialect: Optional[str] = asset_metadata.get(
+                        DAGSTER_SDF_DIALECT
+                    )
                     # If any of the metadata is missing, raise an error
                     if (
                         table_id is None
@@ -197,7 +210,9 @@ class SdfCliResource(ConfigurableResource):
                     test_name_prefix = get_test_prefix(table_dialect)
                     # If the command is test, then we need to add the test name to the run_args (temporary: until sdf-cli applies --targets-only for test)
                     if args[0] == "test":
-                        run_args.append(f"{catalog}.{schema}.{test_name_prefix}{table_name}")
+                        run_args.append(
+                            f"{catalog}.{schema}.{test_name_prefix}{table_name}"
+                        )
 
         # Pass the current environment variables to the sdf CLI invocation.
         env = os.environ.copy()
@@ -237,12 +252,16 @@ class SdfCliResource(ConfigurableResource):
         try:
             resolved_path = absolute_path.resolve(strict=True)
         except FileNotFoundError:
-            raise ValueError(f"The absolute path of '{path}' ('{absolute_path}') does not exist")
+            raise ValueError(
+                f"The absolute path of '{path}' ('{absolute_path}') does not exist"
+            )
 
         return resolved_path
 
     @classmethod
-    def _validate_path_contains_file(cls, path: Path, file_name: str, error_message: str):
+    def _validate_path_contains_file(
+        cls, path: Path, file_name: str, error_message: str
+    ):
         if not path.joinpath(file_name).exists():
             raise ValueError(error_message)
 
@@ -274,7 +293,10 @@ class SdfCliResource(ConfigurableResource):
             match = re.search(r"sdf (\d+\.\d+\.\d+)", output)
             if match:
                 version = match.group(1)
-                if version < SDF_VERSION_LOWER_BOUND or version >= SDF_VERSION_UPPER_BOUND:
+                if (
+                    version < SDF_VERSION_LOWER_BOUND
+                    or version >= SDF_VERSION_UPPER_BOUND
+                ):
                     logging.warning(
                         f"The sdf version '{version}' is not within the supported range of"
                         f" '{SDF_VERSION_LOWER_BOUND}' to '{SDF_VERSION_UPPER_BOUND}'. Check your"

--- a/libraries/dagster-sdf/dagster_sdf/sdf_cli_event.py
+++ b/libraries/dagster-sdf/dagster_sdf/sdf_cli_event.py
@@ -108,7 +108,9 @@ class SdfCliEventMessage:
             DAGSTER_SDF_PURPOSE: purpose,
             DAGSTER_SDF_DIALECT: dialect,
             "Execution Duration": self.raw_event["st_dur_ms"] / 1000,
-            "Materialized From Cache": True if self.raw_event["st_done"] == "cached" else False,
+            "Materialized From Cache": True
+            if self.raw_event["st_done"] == "cached"
+            else False,
         }
         asset_key = dagster_sdf_translator.get_asset_key(catalog, schema, table)
         if purpose == "model":
@@ -133,7 +135,9 @@ class SdfCliEventMessage:
             yield event
         elif purpose == "test" and dagster_sdf_translator.settings.enable_asset_checks:
             passed = self.raw_event["st_verdict"] == "passed"
-            asset_check_key = dagster_sdf_translator.get_check_key_for_test(catalog, schema, table)
+            asset_check_key = dagster_sdf_translator.get_check_key_for_test(
+                catalog, schema, table
+            )
             # if the asset key is the same as the asset check key, then the test is not a table / column test
             if asset_key == asset_check_key.asset_key:
                 return

--- a/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
+++ b/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
@@ -221,7 +221,9 @@ class SdfCliInvocation:
                 # Retrieve the makefile-run.json artifact.
                 run_results = sdf_cli_invocation.get_artifact("makefile-run.json")
         """
-        artifact_path = self.target_dir.joinpath(SDF_TARGET_DIR, self.environment, artifact)
+        artifact_path = self.target_dir.joinpath(
+            SDF_TARGET_DIR, self.environment, artifact
+        )
 
         return orjson.loads(artifact_path.read_bytes())
 
@@ -242,12 +244,16 @@ class SdfCliInvocation:
 
                     yield log
         except DagsterExecutionInterruptedError:
-            logger.info(f"Forwarding interrupt signal to sdf command: `{self.sdf_command}`.")
+            logger.info(
+                f"Forwarding interrupt signal to sdf command: `{self.sdf_command}`."
+            )
 
             self.process.send_signal(signal.SIGINT)
             self.process.wait(timeout=self.termination_timeout_seconds)
 
-            logger.info(f"sdf process terminated with exit code `{self.process.returncode}`.")
+            logger.info(
+                f"sdf process terminated with exit code `{self.process.returncode}`."
+            )
 
             raise
 

--- a/libraries/dagster-sdf/dagster_sdf/sdf_event_iterator.py
+++ b/libraries/dagster-sdf/dagster_sdf/sdf_event_iterator.py
@@ -8,7 +8,9 @@ from typing_extensions import TypeVar
 if TYPE_CHECKING:
     from dagster_sdf.sdf_cli_invocation import SdfCliInvocation
 
-SdfDagsterEventType = Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]
+SdfDagsterEventType = Union[
+    Output, AssetMaterialization, AssetObservation, AssetCheckResult
+]
 
 # We define SdfEventIterator as a generic type for the sake of type hinting.
 # This is so that users who inspect the type of the return value of `SdfCliInvocation.stream()`

--- a/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
+++ b/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
@@ -25,7 +25,11 @@ from dagster._core.definitions.metadata import (
 )
 from dagster._record import IHaveNew, record_custom
 
-from dagster_sdf.asset_utils import exists_in_selected, get_info_schema_dir, get_output_dir
+from dagster_sdf.asset_utils import (
+    exists_in_selected,
+    get_info_schema_dir,
+    get_output_dir,
+)
 from dagster_sdf.constants import (
     DAGSTER_SDF_CATALOG_NAME,
     DAGSTER_SDF_DIALECT,
@@ -99,7 +103,9 @@ class SdfInformationSchema(IHaveNew):
 
     def read_table(
         self,
-        table_name: Literal["tables", "columns", "table_lineage", "column_lineage", "table_deps"],
+        table_name: Literal[
+            "tables", "columns", "table_lineage", "column_lineage", "table_deps"
+        ],
     ) -> pl.DataFrame:
         check.invariant(
             table_name
@@ -110,7 +116,8 @@ class SdfInformationSchema(IHaveNew):
         )
 
         return self.information_schema.setdefault(
-            table_name, pl.read_parquet(self.information_schema_dir.joinpath(table_name))
+            table_name,
+            pl.read_parquet(self.information_schema_dir.joinpath(table_name)),
         )
 
     def build_sdf_multi_asset_args(
@@ -149,9 +156,9 @@ class SdfInformationSchema(IHaveNew):
                     elif meta_map["keys"] == "dagster-depends-on-asset-key":
                         dep_asset_key = meta_map["values"]
                         # Currently, we only support one upstream asset
-                        table_id_to_upstream.setdefault(table_row["table_id"], set()).add(
-                            AssetKey(dep_asset_key)
-                        )
+                        table_id_to_upstream.setdefault(
+                            table_row["table_id"], set()
+                        ).add(AssetKey(dep_asset_key))
                     elif table_row["origin"] == "remote":
                         origin_remote_tables.add(table_row["table_id"])
             elif table_row["origin"] == "remote":
@@ -160,7 +167,9 @@ class SdfInformationSchema(IHaveNew):
         # Step 3: Build Dagster Asset Outs and Internal Asset Deps
         for table_row in table_deps.rows(named=True):
             asset_key = dagster_sdf_translator.get_asset_key(
-                table_row["catalog_name"], table_row["schema_name"], table_row["table_name"]
+                table_row["catalog_name"],
+                table_row["schema_name"],
+                table_row["table_name"],
             )
             code_references = None
             if dagster_sdf_translator.settings.enable_code_references:
@@ -225,7 +234,14 @@ class SdfInformationSchema(IHaveNew):
 
     def get_columns(self) -> dict[str, list[TableColumn]]:
         columns = self.read_table("columns")[
-            ["table_id", "column_id", "classifiers", "column_name", "datatype", "description"]
+            [
+                "table_id",
+                "column_id",
+                "classifiers",
+                "column_name",
+                "datatype",
+                "description",
+            ]
         ]
         table_columns: dict[str, list[TableColumn]] = {}
         for row in columns.rows(named=True):
@@ -270,7 +286,9 @@ class SdfInformationSchema(IHaveNew):
         code_references = CodeReferencesMetadataSet(
             code_references=CodeReferencesMetadataValue(
                 code_references=[
-                    LocalFileCodeReference(file_path=os.fspath(self.workspace_dir.joinpath(loc)))
+                    LocalFileCodeReference(
+                        file_path=os.fspath(self.workspace_dir.joinpath(loc))
+                    )
                 ]
             )
         )
@@ -303,7 +321,9 @@ class SdfInformationSchema(IHaveNew):
                     continue
 
             asset_key = dagster_sdf_translator.get_asset_key(
-                table_row["catalog_name"], table_row["schema_name"], table_row["table_name"]
+                table_row["catalog_name"],
+                table_row["schema_name"],
+                table_row["table_name"],
             )
             code_references = None
             if dagster_sdf_translator.settings.enable_code_references:
@@ -326,7 +346,9 @@ class SdfInformationSchema(IHaveNew):
             yield AssetObservation(
                 asset_key=asset_key,
                 description=dagster_sdf_translator.get_description(
-                    table_row, self.workspace_dir, get_output_dir(self.target_dir, self.environment)
+                    table_row,
+                    self.workspace_dir,
+                    get_output_dir(self.target_dir, self.environment),
                 ),
                 metadata=metadata,
             )

--- a/libraries/dagster-sdf/dagster_sdf/sdf_workspace.py
+++ b/libraries/dagster-sdf/dagster_sdf/sdf_workspace.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 from dagster._model import DagsterModel
 from dagster._utils import run_with_concurrent_update_guard
 
-from dagster_sdf.constants import DEFAULT_SDF_WORKSPACE_ENVIRONMENT, SDF_EXECUTABLE, SDF_TARGET_DIR
+from dagster_sdf.constants import (
+    DEFAULT_SDF_WORKSPACE_ENVIRONMENT,
+    SDF_EXECUTABLE,
+    SDF_TARGET_DIR,
+)
 from dagster_sdf.errors import (
     DagsterSdfInformationSchemaNotFoundError,
     DagsterSdfWorkspaceNotFoundError,
@@ -72,7 +76,9 @@ class DagsterSdfWorkspacePreparer(SdfWorkspacePreparer):
                 )
 
     def prepare(self, workspace: "SdfWorkspace") -> None:
-        output_dir = workspace.target_dir.joinpath(SDF_TARGET_DIR, workspace.environment)
+        output_dir = workspace.target_dir.joinpath(
+            SDF_TARGET_DIR, workspace.environment
+        )
         run_with_concurrent_update_guard(
             output_dir,
             self._prepare_workspace,
@@ -131,7 +137,9 @@ class SdfWorkspace(DagsterModel):
     ):
         workspace_dir = Path(workspace_dir)
         if not workspace_dir.exists():
-            raise DagsterSdfWorkspaceNotFoundError(f"workspace_dir {workspace_dir} does not exist.")
+            raise DagsterSdfWorkspaceNotFoundError(
+                f"workspace_dir {workspace_dir} does not exist."
+            )
 
         target_dir = workspace_dir.joinpath(target_dir)
 

--- a/libraries/dagster-sdf/dagster_sdf_tests/cli/test_scaffold.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/cli/test_scaffold.py
@@ -50,11 +50,15 @@ def _assert_scaffold_defs(project_name: str, dagster_project_dir: Path) -> None:
     schedules_py_path = dagster_project_dir.joinpath(project_name, "schedules.py")
     schedules_py_path.write_text(schedules_py_path.read_text().replace("# ", ""))
 
-    scaffold_defs_module = importlib.import_module(f"{project_name}.{project_name}.definitions")
+    scaffold_defs_module = importlib.import_module(
+        f"{project_name}.{project_name}.definitions"
+    )
     defs: Definitions = getattr(scaffold_defs_module, "defs")
 
     materialize_sdf_models_job = defs.get_job_def("materialize_sdf_models")
-    materialize_sdf_models_schedule = defs.get_schedule_def("materialize_sdf_models_schedule")
+    materialize_sdf_models_schedule = defs.get_schedule_def(
+        "materialize_sdf_models_schedule"
+    )
 
     result = materialize_sdf_models_job.execute_in_process()
 
@@ -79,7 +83,14 @@ def test_project_scaffold_command(
     )
 
     subprocess.run(
-        ["sdf", "compile", "--save", "table-deps", "--target-dir", SDF_DAGSTER_OUTPUT_DIR],
+        [
+            "sdf",
+            "compile",
+            "--save",
+            "table-deps",
+            "--target-dir",
+            SDF_DAGSTER_OUTPUT_DIR,
+        ],
         cwd=sdf_workspace_dir,
         check=True,
     )
@@ -91,7 +102,9 @@ def test_project_scaffold_command(
     monkeypatch.chdir(tmp_path)
     sys.path.append(os.fspath(tmp_path))
 
-    _assert_scaffold_defs(project_name=project_name, dagster_project_dir=dagster_project_dir)
+    _assert_scaffold_defs(
+        project_name=project_name, dagster_project_dir=dagster_project_dir
+    )
 
 
 @pytest.mark.parametrize(
@@ -118,7 +131,9 @@ def test_project_scaffold_command_with_compile_env_var(
     monkeypatch.chdir(tmp_path)
     sys.path.append(os.fspath(tmp_path))
 
-    _assert_scaffold_defs(project_name=project_name, dagster_project_dir=dagster_project_dir)
+    _assert_scaffold_defs(
+        project_name=project_name, dagster_project_dir=dagster_project_dir
+    )
 
 
 def test_project_scaffold_command_on_invalid_dagster_project_name(
@@ -171,7 +186,10 @@ def test_project_scaffold_command_on_invalid_sdf_project_dir(
 
 @pytest.mark.parametrize("project_name", ["dagster", "dagster_sdf"])
 def test_project_scaffold_command_on_package_conflict(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, sdf_workspace_dir: Path, project_name: str
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sdf_workspace_dir: Path,
+    project_name: str,
 ) -> None:
     monkeypatch.chdir(tmp_path)
 

--- a/libraries/dagster-sdf/dagster_sdf_tests/conftest.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/conftest.py
@@ -21,12 +21,16 @@ def _create_sdf_invocation(
     sdf = SdfCliResource(workspace_dir=os.fspath(workspace_dir))
 
     sdf_invocation = sdf.cli(
-        ["compile", "--save", "table-deps"], environment=environment, raise_on_error=False
+        ["compile", "--save", "table-deps"],
+        environment=environment,
+        raise_on_error=False,
     ).wait()
 
     if run_workspace:
         sdf.cli(
-            ["run", "--save", "info-schema"], environment=environment, raise_on_error=True
+            ["run", "--save", "info-schema"],
+            environment=environment,
+            raise_on_error=True,
         ).wait()
 
     return sdf_invocation

--- a/libraries/dagster-sdf/dagster_sdf_tests/test_asset_checks.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/test_asset_checks.py
@@ -2,7 +2,10 @@ import os
 
 from dagster import AssetExecutionContext, AssetKey, materialize
 from dagster_sdf.asset_decorator import sdf_assets
-from dagster_sdf.dagster_sdf_translator import DagsterSdfTranslator, DagsterSdfTranslatorSettings
+from dagster_sdf.dagster_sdf_translator import (
+    DagsterSdfTranslator,
+    DagsterSdfTranslatorSettings,
+)
 from dagster_sdf.resource import SdfCliResource
 from dagster_sdf.sdf_workspace import SdfWorkspace
 
@@ -14,7 +17,9 @@ def test_asset_checks_passing() -> None:
         workspace_dir=os.fspath(lineage_asset_checks_path),
     )
     environment = "passing_tests"
-    sdf_cli_invocation = sdf.cli(["compile", "--save", "table-deps"], environment=environment)
+    sdf_cli_invocation = sdf.cli(
+        ["compile", "--save", "table-deps"], environment=environment
+    )
     assert sdf_cli_invocation.is_successful()
     target_dir = sdf_cli_invocation.target_dir
     dagster_sdf_translator = DagsterSdfTranslator(
@@ -23,7 +28,9 @@ def test_asset_checks_passing() -> None:
 
     @sdf_assets(
         workspace=SdfWorkspace(
-            workspace_dir=lineage_asset_checks_path, target_dir=target_dir, environment=environment
+            workspace_dir=lineage_asset_checks_path,
+            target_dir=target_dir,
+            environment=environment,
         ),
         dagster_sdf_translator=dagster_sdf_translator,
     )
@@ -72,13 +79,17 @@ def test_asset_checks_failing() -> None:
         settings=DagsterSdfTranslatorSettings(enable_asset_checks=True)
     )
     environment = "failing_tests"
-    sdf_cli_invocation = sdf.cli(["compile", "--save", "table-deps"], environment=environment)
+    sdf_cli_invocation = sdf.cli(
+        ["compile", "--save", "table-deps"], environment=environment
+    )
     assert sdf_cli_invocation.is_successful()
     target_dir = sdf_cli_invocation.target_dir
 
     @sdf_assets(
         workspace=SdfWorkspace(
-            workspace_dir=lineage_asset_checks_path, target_dir=target_dir, environment=environment
+            workspace_dir=lineage_asset_checks_path,
+            target_dir=target_dir,
+            environment=environment,
         ),
         dagster_sdf_translator=dagster_sdf_translator,
     )

--- a/libraries/dagster-sdf/dagster_sdf_tests/test_asset_decorator.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/test_asset_decorator.py
@@ -3,11 +3,17 @@ from pathlib import Path
 from dagster import AssetExecutionContext, AssetKey, materialize
 from dagster_sdf.asset_decorator import sdf_assets
 from dagster_sdf.asset_utils import get_asset_key_for_table_id
-from dagster_sdf.dagster_sdf_translator import DagsterSdfTranslator, DagsterSdfTranslatorSettings
+from dagster_sdf.dagster_sdf_translator import (
+    DagsterSdfTranslator,
+    DagsterSdfTranslatorSettings,
+)
 from dagster_sdf.resource import SdfCliResource
 from dagster_sdf.sdf_workspace import SdfWorkspace
 
-from dagster_sdf_tests.sdf_workspaces import lineage_upstream_path, moms_flower_shop_path
+from dagster_sdf_tests.sdf_workspaces import (
+    lineage_upstream_path,
+    moms_flower_shop_path,
+)
 
 
 def test_asset_deps(moms_flower_shop_target_dir: Path) -> None:
@@ -102,7 +108,9 @@ def test_sdf_with_materialize(moms_flower_shop_target_dir: Path) -> None:
     )
 
     assert first_result.success
-    first_num_asset_materialization_events = len(first_result.get_asset_materialization_events())
+    first_num_asset_materialization_events = len(
+        first_result.get_asset_materialization_events()
+    )
     assert first_num_asset_materialization_events > 0
 
     cached_result = materialize(
@@ -118,14 +126,21 @@ def test_sdf_with_materialize(moms_flower_shop_target_dir: Path) -> None:
             for event in materialization_events
         ]
     )
-    cached_num_asset_materialization_events = len(cached_result.get_asset_materialization_events())
-    assert first_num_asset_materialization_events == cached_num_asset_materialization_events
+    cached_num_asset_materialization_events = len(
+        cached_result.get_asset_materialization_events()
+    )
+    assert (
+        first_num_asset_materialization_events
+        == cached_num_asset_materialization_events
+    )
 
 
 def test_with_custom_translater_asset_key_fn(moms_flower_shop_target_dir: Path) -> None:
     class CustomDagsterSdfTranslator(DagsterSdfTranslator):
         def get_asset_key(self, catalog: str, schema: str, table_name: str) -> AssetKey:  # type: ignore
-            return AssetKey([f"pre-{catalog}-suff", f"pre-{schema}-suff", f"pre-{table_name}-suff"])
+            return AssetKey(
+                [f"pre-{catalog}-suff", f"pre-{schema}-suff", f"pre-{table_name}-suff"]
+            )
 
     @sdf_assets(
         workspace=SdfWorkspace(
@@ -136,14 +151,32 @@ def test_with_custom_translater_asset_key_fn(moms_flower_shop_target_dir: Path) 
     def my_flower_shop_assets(): ...
 
     assert my_flower_shop_assets.asset_deps == {
-        AssetKey(["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_addresses-suff"]): set(),
-        AssetKey(["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_customers-suff"]): set(),
-        AssetKey(["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_inapp_events-suff"]): set(),
         AssetKey(
-            ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_marketing_campaign_events-suff"]
+            ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_addresses-suff"]
         ): set(),
-        AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-app_installs-suff"]): {
-            AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-inapp_events-suff"]),
+        AssetKey(
+            ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_customers-suff"]
+        ): set(),
+        AssetKey(
+            ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_inapp_events-suff"]
+        ): set(),
+        AssetKey(
+            [
+                "pre-moms_flower_shop-suff",
+                "pre-raw-suff",
+                "pre-raw_marketing_campaign_events-suff",
+            ]
+        ): set(),
+        AssetKey(
+            ["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-app_installs-suff"]
+        ): {
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-staging-suff",
+                    "pre-inapp_events-suff",
+                ]
+            ),
             AssetKey(
                 [
                     "pre-moms_flower_shop-suff",
@@ -151,27 +184,63 @@ def test_with_custom_translater_asset_key_fn(moms_flower_shop_target_dir: Path) 
                     "pre-raw_marketing_campaign_events-suff",
                 ]
             ),
-        },
-        AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-app_installs_v2-suff"]): {
-            AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-inapp_events-suff"]),
-            AssetKey(
-                [
-                    "pre-moms_flower_shop-suff",
-                    "pre-raw-suff",
-                    "pre-raw_marketing_campaign_events-suff",
-                ]
-            ),
-        },
-        AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-customers-suff"]): {
-            AssetKey(["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_addresses-suff"]),
-            AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-app_installs_v2-suff"]),
-            AssetKey(["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_customers-suff"]),
-        },
-        AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-inapp_events-suff"]): {
-            AssetKey(["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_inapp_events-suff"])
         },
         AssetKey(
-            ["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-marketing_campaigns-suff"]
+            [
+                "pre-moms_flower_shop-suff",
+                "pre-staging-suff",
+                "pre-app_installs_v2-suff",
+            ]
+        ): {
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-staging-suff",
+                    "pre-inapp_events-suff",
+                ]
+            ),
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-raw-suff",
+                    "pre-raw_marketing_campaign_events-suff",
+                ]
+            ),
+        },
+        AssetKey(
+            ["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-customers-suff"]
+        ): {
+            AssetKey(
+                ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_addresses-suff"]
+            ),
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-staging-suff",
+                    "pre-app_installs_v2-suff",
+                ]
+            ),
+            AssetKey(
+                ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_customers-suff"]
+            ),
+        },
+        AssetKey(
+            ["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-inapp_events-suff"]
+        ): {
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-raw-suff",
+                    "pre-raw_inapp_events-suff",
+                ]
+            )
+        },
+        AssetKey(
+            [
+                "pre-moms_flower_shop-suff",
+                "pre-staging-suff",
+                "pre-marketing_campaigns-suff",
+            ]
         ): {
             AssetKey(
                 [
@@ -182,9 +251,19 @@ def test_with_custom_translater_asset_key_fn(moms_flower_shop_target_dir: Path) 
             )
         },
         AssetKey(
-            ["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-stg_installs_per_campaign-suff"]
+            [
+                "pre-moms_flower_shop-suff",
+                "pre-staging-suff",
+                "pre-stg_installs_per_campaign-suff",
+            ]
         ): {
-            AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-app_installs_v2-suff"])
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-staging-suff",
+                    "pre-app_installs_v2-suff",
+                ]
+            )
         },
         AssetKey(
             [
@@ -193,13 +272,27 @@ def test_with_custom_translater_asset_key_fn(moms_flower_shop_target_dir: Path) 
                 "pre-agg_installs_and_campaigns-suff",
             ]
         ): {
-            AssetKey(["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-app_installs_v2-suff"])
+            AssetKey(
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-staging-suff",
+                    "pre-app_installs_v2-suff",
+                ]
+            )
         },
         AssetKey(
-            ["pre-moms_flower_shop-suff", "pre-analytics-suff", "pre-dim_marketing_campaigns-suff"]
+            [
+                "pre-moms_flower_shop-suff",
+                "pre-analytics-suff",
+                "pre-dim_marketing_campaigns-suff",
+            ]
         ): {
             AssetKey(
-                ["pre-moms_flower_shop-suff", "pre-staging-suff", "pre-marketing_campaigns-suff"]
+                [
+                    "pre-moms_flower_shop-suff",
+                    "pre-staging-suff",
+                    "pre-marketing_campaigns-suff",
+                ]
             ),
             AssetKey(
                 [
@@ -212,7 +305,8 @@ def test_with_custom_translater_asset_key_fn(moms_flower_shop_target_dir: Path) 
     }
 
     asset_key = get_asset_key_for_table_id(
-        [my_flower_shop_assets], "pre-moms_flower_shop-suff.pre-raw-suff.pre-raw_addresses-suff"
+        [my_flower_shop_assets],
+        "pre-moms_flower_shop-suff.pre-raw-suff.pre-raw_addresses-suff",
     )
     assert asset_key == AssetKey(
         ["pre-moms_flower_shop-suff", "pre-raw-suff", "pre-raw_addresses-suff"]

--- a/libraries/dagster-sdf/dagster_sdf_tests/test_code_references.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/test_code_references.py
@@ -7,7 +7,10 @@ from dagster._core.definitions.metadata.source_code import (
     with_source_code_references,
 )
 from dagster_sdf.asset_decorator import sdf_assets
-from dagster_sdf.dagster_sdf_translator import DagsterSdfTranslator, DagsterSdfTranslatorSettings
+from dagster_sdf.dagster_sdf_translator import (
+    DagsterSdfTranslator,
+    DagsterSdfTranslatorSettings,
+)
 from dagster_sdf.sdf_workspace import SdfWorkspace
 
 from dagster_sdf_tests.sdf_workspaces import moms_flower_shop_path
@@ -39,7 +42,9 @@ def test_basic_attach_code_references(moms_flower_shop_target_dir: Path) -> None
         assert os.path.exists(reference.file_path), reference.file_path
 
 
-def test_basic_attach_code_references_disabled(moms_flower_shop_target_dir: Path) -> None:
+def test_basic_attach_code_references_disabled(
+    moms_flower_shop_target_dir: Path,
+) -> None:
     @sdf_assets(
         workspace=SdfWorkspace(
             workspace_dir=moms_flower_shop_path,

--- a/libraries/dagster-sdf/dagster_sdf_tests/test_resource.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/test_resource.py
@@ -65,7 +65,9 @@ def test_sdf_cli_executable() -> None:
 
     # sdf executable must exist
     with pytest.raises(ValidationError, match="does not exist"):
-        SdfCliResource(workspace_dir=os.fspath(moms_flower_shop_path), sdf_executable="nonexistent")
+        SdfCliResource(
+            workspace_dir=os.fspath(moms_flower_shop_path), sdf_executable="nonexistent"
+        )
 
 
 def test_sdf_cli_workspace_dir_path() -> None:
@@ -79,7 +81,9 @@ def test_sdf_cli_workspace_dir_path() -> None:
         SdfCliResource(workspace_dir="nonexistent")
 
     # workspace directory must be a valid sdf workspace
-    with pytest.raises(ValidationError, match="specify a valid path to an sdf workspace."):
+    with pytest.raises(
+        ValidationError, match="specify a valid path to an sdf workspace."
+    ):
         SdfCliResource(workspace_dir=f"{os.fspath(moms_flower_shop_path)}/models")
 
 
@@ -136,7 +140,9 @@ def test_sdf_cli_target_dir(tmp_path: Path, sdf: SdfCliResource) -> None:
         .st_mtime
     )
 
-    sdf_cli_invocation_2 = sdf.cli(["compile"], target_dir=sdf_cli_invocation_1.target_dir).wait()
+    sdf_cli_invocation_2 = sdf.cli(
+        ["compile"], target_dir=sdf_cli_invocation_1.target_dir
+    ).wait()
     manifest_st_mtime_2 = (
         sdf_cli_invocation_2.target_dir.joinpath(
             SDF_TARGET_DIR, sdf_cli_invocation_2.environment, "makefile-compile.json"
@@ -176,7 +182,9 @@ def test_sdf_cli_op_execution(sdf: SdfCliResource) -> None:
         yield from sdf.cli(["run", "--save", "info-schema"], context=context).stream()
 
     @op(out=Out(Nothing))
-    def my_sdf_op_yield_events_with_downstream(context: OpExecutionContext, sdf: SdfCliResource):
+    def my_sdf_op_yield_events_with_downstream(
+        context: OpExecutionContext, sdf: SdfCliResource
+    ):
         yield from sdf.cli(["run", "--save", "info-schema"], context=context).stream()
 
     @op(ins={"depends_on": In(dagster_type=Nothing)})

--- a/libraries/dagster-sdf/dagster_sdf_tests/test_sdf_workspace.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/test_sdf_workspace.py
@@ -11,12 +11,16 @@ from dagster_sdf_tests.sdf_workspaces import moms_flower_shop_path
 
 def test_local_dev(tmp_path: Path) -> None:
     with pytest.raises(CheckError):
-        workspace = SdfWorkspace(workspace_dir=moms_flower_shop_path, target_dir=tmp_path)
+        workspace = SdfWorkspace(
+            workspace_dir=moms_flower_shop_path, target_dir=tmp_path
+        )
         info_schema = SdfInformationSchema(
             workspace_dir=workspace.workspace_dir, target_dir=workspace.target_dir
         )
     with environ({"DAGSTER_IS_DEV_CLI": "1"}):
-        workspace = SdfWorkspace(workspace_dir=moms_flower_shop_path, target_dir=tmp_path)
+        workspace = SdfWorkspace(
+            workspace_dir=moms_flower_shop_path, target_dir=tmp_path
+        )
         info_schema = SdfInformationSchema(
             workspace_dir=workspace.workspace_dir, target_dir=workspace.target_dir
         )
@@ -25,12 +29,16 @@ def test_local_dev(tmp_path: Path) -> None:
 
 def test_opt_in_env_var(tmp_path: Path) -> None:
     with pytest.raises(CheckError):
-        workspace = SdfWorkspace(workspace_dir=moms_flower_shop_path, target_dir=tmp_path)
+        workspace = SdfWorkspace(
+            workspace_dir=moms_flower_shop_path, target_dir=tmp_path
+        )
         info_schema = SdfInformationSchema(
             workspace_dir=workspace.workspace_dir, target_dir=workspace.target_dir
         )
     with environ({"DAGSTER_SDF_COMPILE_ON_LOAD": "1"}):
-        workspace = SdfWorkspace(workspace_dir=moms_flower_shop_path, target_dir=tmp_path)
+        workspace = SdfWorkspace(
+            workspace_dir=moms_flower_shop_path, target_dir=tmp_path
+        )
         info_schema = SdfInformationSchema(
             workspace_dir=workspace.workspace_dir, target_dir=workspace.target_dir
         )

--- a/libraries/dagster-sdf/dagster_sdf_tests/test_table_metadata.py
+++ b/libraries/dagster-sdf/dagster_sdf_tests/test_table_metadata.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from dagster import AssetExecutionContext, materialize
 from dagster._core.definitions.metadata import TableSchemaMetadataValue
 from dagster_sdf.asset_decorator import sdf_assets
-from dagster_sdf.dagster_sdf_translator import DagsterSdfTranslator, DagsterSdfTranslatorSettings
+from dagster_sdf.dagster_sdf_translator import (
+    DagsterSdfTranslator,
+    DagsterSdfTranslatorSettings,
+)
 from dagster_sdf.resource import SdfCliResource
 from dagster_sdf.sdf_workspace import SdfWorkspace
 


### PR DESCRIPTION
## Summary & Motivation

Add Ruff formatter to the template, to:

1. Catch formatting errors in CI
2. Be able to use the template for `dagster-iceberg`

## How I Tested These Changes

First local CI, then CI

Locally, I get some other (unrelated) failures:

* `dagster-hightouch` (typing error with `NamedTuple`)
* `dagster-obstore-template` fails for me (no Docker Compose config)
* `dagster-sdf` (can't find executable)
