### PR TITLE
[dagster-iceberg] Reuse shared quality check steps

### DIFF
--- a/.github/workflows/quality-check-dagster-iceberg.yml
+++ b/.github/workflows/quality-check-dagster-iceberg.yml
@@ -7,35 +7,6 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-
-      - name: Install python
-        working-directory: ./libraries/dagster-iceberg
-        run: uv python install 3.12
-
-      - name: Sync dependencies
-        working-directory: ./libraries/dagster-iceberg
-        run: uv sync --all-extras --group docs
-
-      - name: Ruff check
-        working-directory: ./libraries/dagster-iceberg
-        run: uv run ruff check
-
-      - name: Ruff format
-        working-directory: ./libraries/dagster-iceberg
-        run: uv run ruff format --check
-
-      - name: Pyright
-        working-directory: ./libraries/dagster-iceberg
-        run: uv run pyright
-
-      - name: Pytest
-        working-directory: ./libraries/dagster-iceberg
-        run: uv run pytest
+    uses: ./.github/workflows/template-quality-check.yml
+    with:
+      working_directory: ./libraries/dagster-iceberg

--- a/.github/workflows/template-quality-check.yml
+++ b/.github/workflows/template-quality-check.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Sync dependencies
         working-directory: ${{ inputs.working_directory }}
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Lint
         working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
## Summary & Motivation

It doesn't seem necessary to maintain a separate workflow. There isn't a docs build currently in the `community-integrations` CI, so don't even need to worry about adding a flag to install that dependency group.

## How I Tested These Changes

Local CI