### PR TITLE
[dagster-teradata] Fix formatting, and check in CI

### DIFF
--- a/.github/workflows/quality-check-dagster-teradata.yml
+++ b/.github/workflows/quality-check-dagster-teradata.yml
@@ -24,11 +24,15 @@ jobs:
         working-directory: ./libraries/dagster-teradata
         run: uv sync --all-extras
 
-      - name: Ruff
+      - name: Lint
         working-directory: ./libraries/dagster-teradata
         run: uv run ruff check
 
-      - name: Pyright
+      - name: Check formatting
+        working-directory: ./libraries/dagster-teradata
+        run: uv run ruff format --check
+
+      - name: Type check
         working-directory: ./libraries/dagster-teradata
         run: uv run pyright
 

--- a/.github/workflows/template-quality-check.yml
+++ b/.github/workflows/template-quality-check.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         run: uv run ruff check
 
-      - name: Format
+      - name: Check formatting
         working-directory: ${{ inputs.working_directory }}
         run: uv run ruff format --check
 

--- a/libraries/dagster-teradata/dagster_teradata/resources.py
+++ b/libraries/dagster-teradata/dagster_teradata/resources.py
@@ -341,6 +341,7 @@ class TeradataDagsterConnection:
 
     if TYPE_CHECKING:
         from dagster_azure.adls2 import ADLS2Resource
+
     @public
     def azure_blob_to_teradata(
         self,


### PR DESCRIPTION
## Summary & Motivation

Was trying to bring `dagster-teradata` in line with the rest/using the same template, but not going to bother for now since the functional tests don't pass/would require passing an arg to `pytest`. However, I did find that there was a formatting issue not being caught, since the updated template isn't being used.

Nit: Also changed "Format" to "Check formatting", since it technically shouldn't apply formatting in CI.

## How I Tested These Changes

CI (and local CI)