### PR TITLE
feat(dagster-hex): update run_project to match Hex Parameters

### DIFF
--- a/libraries/dagster-hex/CHANGELOG.md
+++ b/libraries/dagster-hex/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
+
 ---
 
 ## 0.1.6 - UNRELEASED
 
--
+### Added
+
+- Add support for new Hex API parameters in `run_project`: `dry_run`, `update_published_results`, and `view_id`
+- Improve deprecation notice for `update_cache` to clarify both alternatives
+- Add comprehensive test coverage for new parameters
 
 ## 0.1.5
 

--- a/libraries/dagster-hex/dagster_hex_tests/test_hex.py
+++ b/libraries/dagster-hex/dagster_hex_tests/test_hex.py
@@ -25,6 +25,8 @@ def test_run_project(requests_mock):
     assert requests_mock.last_request.json() == {
         "inputParams": {"param": "var"},
         "useCachedSqlResults": True,
+        "dryRun": False,
+        "updatePublishedResults": False,
     }
 
 
@@ -40,4 +42,94 @@ def test_run_project_no_input(requests_mock):
     assert response == {"data": "mocked response"}
     assert requests_mock.last_request.json() == {
         "useCachedSqlResults": True,
+        "dryRun": False,
+        "updatePublishedResults": False,
+    }
+
+
+def test_run_project_with_new_params(requests_mock):
+    requests_mock.post(
+        "https://testurl/api/v1/project/abc-123/run",
+        headers={"Content-Type": "application/json"},
+        json={"data": "mocked response"},
+    )
+
+    hex = HexResource(api_key="abc", base_url="https://testurl/")
+    response = hex.run_project(
+        "abc-123",
+        dry_run=True,
+        update_published_results=True,
+        use_cached_sql=False,
+    )
+    assert response == {"data": "mocked response"}
+    assert requests_mock.last_request.json() == {
+        "useCachedSqlResults": False,
+        "dryRun": True,
+        "updatePublishedResults": True,
+    }
+
+
+def test_run_project_with_view_id(requests_mock):
+    requests_mock.post(
+        "https://testurl/api/v1/project/abc-123/run",
+        headers={"Content-Type": "application/json"},
+        json={"data": "mocked response"},
+    )
+
+    hex = HexResource(api_key="abc", base_url="https://testurl/")
+    response = hex.run_project(
+        "abc-123",
+        view_id="view-123",
+    )
+    assert response == {"data": "mocked response"}
+    assert requests_mock.last_request.json() == {
+        "useCachedSqlResults": True,
+        "dryRun": False,
+        "updatePublishedResults": False,
+        "viewId": "view-123",
+    }
+
+
+def test_run_project_inputs_and_view_id_raises(requests_mock):
+    hex = HexResource(api_key="abc", base_url="https://testurl/")
+
+    try:
+        hex.run_project(
+            "abc-123",
+            inputs={"param": "value"},
+            view_id="view-123",
+        )
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        assert str(e) == "Cannot specify both inputs and view_id"
+
+
+def test_run_project_with_notifications(requests_mock):
+    requests_mock.post(
+        "https://testurl/api/v1/project/abc-123/run",
+        headers={"Content-Type": "application/json"},
+        json={"data": "mocked response"},
+    )
+
+    notifications = [
+        {
+            "type": "slack",
+            "includeSuccessScreenshot": True,
+            "slackChannelIds": ["C123456"],
+            "userIds": ["U123"],
+            "groupIds": ["G456"],
+        }
+    ]
+
+    hex = HexResource(api_key="abc", base_url="https://testurl/")
+    response = hex.run_project(
+        "abc-123",
+        notifications=notifications,
+    )
+    assert response == {"data": "mocked response"}
+    assert requests_mock.last_request.json() == {
+        "useCachedSqlResults": True,
+        "dryRun": False,
+        "updatePublishedResults": False,
+        "notifications": notifications,
     }

--- a/libraries/dagster-hex/dagster_hex_tests/test_hex.py
+++ b/libraries/dagster-hex/dagster_hex_tests/test_hex.py
@@ -1,4 +1,5 @@
 from dagster_hex.resources import HexResource
+from dagster_hex.types import NotificationDetails
 
 
 def test_resource_request(requests_mock):
@@ -111,7 +112,7 @@ def test_run_project_with_notifications(requests_mock):
         json={"data": "mocked response"},
     )
 
-    notifications = [
+    notifications: list[NotificationDetails] = [
         {
             "type": "slack",
             "includeSuccessScreenshot": True,


### PR DESCRIPTION
## Summary & Motivation

- Added support for new Hex API parameters in the `run_project` method to align with the latest Hex API specification
- Updated the deprecation notice for `update_cache` to provide clearer guidance on the two alternatives
- The Hex API now supports additional parameters like `dry_run`, `update_published_results`, and `view_id` which weren't previously available in the dagster-hex integration
- These changes ensure the library stays in sync with the [Hex API Reference](https://learn.hex.tech/docs/api/api-reference#operation/RunProject)

## How I Tested These Changes

- Added test coverage for all new parameters
- Tested parameter validation (e.g., cannot use both `inputs` and `view_id`)
- Verified that existing functionality continues to work with the new parameters
- Ensured backward compatibility with existing code

## Checklist

- [x] make test
- [x] make ruff
- [x] make check
- [x] update `CHANGELOG.md`
