### PR TITLE
[dagster-iceberg] Update tests to use REST catalog

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/Makefile
+++ b/libraries/dagster-iceberg/kitchen-sink/Makefile
@@ -1,6 +1,8 @@
-catalog:
-	mkdir -p /tmp/warehouse
-	python -c 'from pyiceberg.catalog.sql import SqlCatalog; catalog = SqlCatalog("default", **{"uri": "sqlite:////tmp/warehouse/iceberg_catalog.db", "warehouse": "file:///tmp/warehouse"}); catalog.create_namespace_if_not_exists("default")'
+up:
+	docker compose up --build --wait
+
+catalog: up
+	python -c 'from pyiceberg.catalog import load_catalog; catalog = load_catalog("local", **{"type": "rest", "uri": "http://localhost:8181", "s3.endpoint": "http://localhost:9000", "s3.access-key-id": "admin", "s3.secret-access-key": "password"}); catalog.create_namespace_if_not_exists("demo.nyc")'
 
 dev: catalog
 	dagster dev -f kitchen_sink.py
@@ -8,5 +10,5 @@ dev: catalog
 test:
 	uv run pytest
 
-clean:
-	rm -rf /tmp/warehouse
+down:
+	docker compose down --remove-orphans --volumes

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -14,9 +14,8 @@ from dagster_polars import PolarsParquetIOManager
 
 NUM_PARTS = 16  # 0
 
-CATALOG_NAME = "default"
-WAREHOUSE_PATH = "/tmp/warehouse"
-NAMESPACE = "default"
+CATALOG_NAME = "local"
+NAMESPACE = "demo.nyc"
 
 parts = StaticPartitionsDefinition([f"part.{i}" for i in range(NUM_PARTS)])
 raw_nyc_taxi_data = AssetSpec(
@@ -43,8 +42,11 @@ def reloaded_nyc_taxi_data(combined_nyc_taxi_data: pl.LazyFrame) -> None:
 
 catalog_config = IcebergCatalogConfig(
     properties={
-        "uri": f"sqlite:///{WAREHOUSE_PATH}/iceberg_catalog.db",
-        "warehouse": f"file://{WAREHOUSE_PATH}",
+        "type": "rest",
+        "uri": "http://localhost:8181",
+        "s3.endpoint": "http://localhost:9000",
+        "s3.access-key-id": "admin",
+        "s3.secret-access-key": "password",
     }
 )
 

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -16,7 +16,7 @@ MAKEFILE_DIR = file_relative_path(__file__, "../")
 def catalog():
     subprocess.run(["make", "catalog"], cwd=MAKEFILE_DIR, check=True)
     yield
-    subprocess.run(["make", "clean"], cwd=MAKEFILE_DIR, check=True)
+    subprocess.run(["make", "down"], cwd=MAKEFILE_DIR, check=True)
 
 
 def invoke_materialize(


### PR DESCRIPTION
## Summary & Motivation

Make the existing tests work on the newly-created test environment (that should also support upcoming Spark I/O manager end-to-end tests).

## How I Tested These Changes

Local run and GitHub Actions; unfortunately, this doesn't work on `act` as is.