### PR TITLE
[dagster-iceberg] Set database to the catalog name

### DIFF
--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
@@ -206,12 +206,13 @@ class IcebergIOManager(ConfigurableIOManagerFactory):
             else CustomDbIOManager
         )
         return IoManagerImplementation(
-            db_client=IcebergDbClient(),
-            database="iceberg",
-            schema=self.schema_,
             type_handlers=self.type_handlers(),
-            default_load_type=self.default_load_type(),
+            db_client=IcebergDbClient(),
+            # TODO(deepyaman): Qualify table name for Spark I/O manager with `database`.
+            database=context.resource_config["name"],
+            schema=self.schema_,
             io_manager_name="IcebergIOManager",
+            default_load_type=self.default_load_type(),
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

Don't hardcode the catalog name; at least for Spark, you can qualify tables using the catalog name as the database name.

This shouldn't break anything, since the base `_get_table_name` (that actually uses `database`) isn't used.

## How I Tested These Changes

Ensure existing tests don't break; no additional functionality for now.