### PR TITLE
[dagster-iceberg] Use "rest" catalog with "nyc" db

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/Makefile
+++ b/libraries/dagster-iceberg/kitchen-sink/Makefile
@@ -2,7 +2,7 @@ up:
 	docker compose up --build --wait
 
 catalog: up
-	python -c 'from pyiceberg.catalog import load_catalog; catalog = load_catalog("demo", **{"type": "rest", "uri": "http://localhost:8181", "s3.endpoint": "http://localhost:9000", "s3.access-key-id": "admin", "s3.secret-access-key": "password"}); catalog.create_namespace_if_not_exists("nyc")'
+	python -c 'from pyiceberg.catalog import load_catalog; catalog = load_catalog("rest", **{"type": "rest", "uri": "http://localhost:8181", "s3.endpoint": "http://localhost:9000", "s3.access-key-id": "admin", "s3.secret-access-key": "password"}); catalog.create_namespace_if_not_exists("nyc")'
 
 dev: catalog
 	dagster dev -f kitchen_sink.py

--- a/libraries/dagster-iceberg/kitchen-sink/Makefile
+++ b/libraries/dagster-iceberg/kitchen-sink/Makefile
@@ -2,7 +2,7 @@ up:
 	docker compose up --build --wait
 
 catalog: up
-	python -c 'from pyiceberg.catalog import load_catalog; catalog = load_catalog("local", **{"type": "rest", "uri": "http://localhost:8181", "s3.endpoint": "http://localhost:9000", "s3.access-key-id": "admin", "s3.secret-access-key": "password"}); catalog.create_namespace_if_not_exists("demo.nyc")'
+	python -c 'from pyiceberg.catalog import load_catalog; catalog = load_catalog("demo", **{"type": "rest", "uri": "http://localhost:8181", "s3.endpoint": "http://localhost:9000", "s3.access-key-id": "admin", "s3.secret-access-key": "password"}); catalog.create_namespace_if_not_exists("nyc")'
 
 dev: catalog
 	dagster dev -f kitchen_sink.py

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -14,7 +14,7 @@ from dagster_polars import PolarsParquetIOManager
 
 NUM_PARTS = 16  # 0
 
-CATALOG_NAME = "demo"
+CATALOG_NAME = "rest"
 NAMESPACE = "nyc"
 
 parts = StaticPartitionsDefinition([f"part.{i}" for i in range(NUM_PARTS)])

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -14,8 +14,8 @@ from dagster_polars import PolarsParquetIOManager
 
 NUM_PARTS = 16  # 0
 
-CATALOG_NAME = "local"
-NAMESPACE = "demo.nyc"
+CATALOG_NAME = "demo"
+NAMESPACE = "nyc"
 
 parts = StaticPartitionsDefinition([f"part.{i}" for i in range(NUM_PARTS)])
 raw_nyc_taxi_data = AssetSpec(


### PR DESCRIPTION
## Summary & Motivation

Fix/align the catalog name to be used, especially if constructing fully-qualified table names (e.g. in I/O managers).

## How I Tested These Changes

Manual tests and CI.