### PR TITLE
update community packages to handle dagster >= 1.10

### DIFF
--- a/libraries/dagster-anthropic/dagster_anthropic/resource.py
+++ b/libraries/dagster-anthropic/dagster_anthropic/resource.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 
 from pydantic import Field, PrivateAttr
 
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster import (
     ConfigurableResource,
     DagsterInvariantViolationError,
@@ -68,7 +68,7 @@ def with_usage_metadata(
 
 
 @public
-@experimental
+@preview
 class AnthropicResource(ConfigurableResource):
     """This resource is a wrapper over the `Anthropic library<https://github.com/anthropics/anthropic-sdk-python>`.
 

--- a/libraries/dagster-anthropic/dagster_anthropic/resource.py
+++ b/libraries/dagster-anthropic/dagster_anthropic/resource.py
@@ -1,13 +1,15 @@
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import wraps
+from packaging import version
 from typing import Optional, Generator, Union
 from weakref import WeakKeyDictionary
 
 from pydantic import Field, PrivateAttr
 
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster import (
+    __version__,
     ConfigurableResource,
     DagsterInvariantViolationError,
     InitResourceContext,
@@ -15,6 +17,11 @@ from dagster import (
     OpExecutionContext,
     AssetKey,
 )
+
+if version.parse(__version__) >= version.parse("1.10.0"):
+    from dagster._annotations import preview
+else:
+    from dagster._annotations import experimental as preview
 
 from anthropic import Anthropic
 

--- a/libraries/dagster-anthropic/dagster_anthropic/resource.py
+++ b/libraries/dagster-anthropic/dagster_anthropic/resource.py
@@ -19,9 +19,9 @@ from dagster import (
 )
 
 if version.parse(__version__) >= version.parse("1.10.0"):
-    from dagster._annotations import preview
+    from dagster._annotations import preview  # pyright: ignore[reportAttributeAccessIssue]
 else:
-    from dagster._annotations import experimental as preview
+    from dagster._annotations import experimental as preview  # pyright: ignore[reportAttributeAccessIssue]
 
 from anthropic import Anthropic
 

--- a/libraries/dagster-gemini/dagster_gemini/resource.py
+++ b/libraries/dagster-gemini/dagster_gemini/resource.py
@@ -22,9 +22,9 @@ import google.generativeai as genai
 from google.generativeai import GenerativeModel
 
 if version.parse(__version__) >= version.parse("1.10.0"):
-    from dagster._annotations import preview
+    from dagster._annotations import preview  # pyright: ignore[reportAttributeAccessIssue]
 else:
-    from dagster._annotations import experimental as preview
+    from dagster._annotations import experimental as preview  # pyright: ignore[reportAttributeAccessIssue]
 
 context_to_counters = WeakKeyDictionary()
 

--- a/libraries/dagster-gemini/dagster_gemini/resource.py
+++ b/libraries/dagster-gemini/dagster_gemini/resource.py
@@ -1,13 +1,15 @@
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import wraps
+from packaging import version
 from typing import Optional, Generator, Union
 from weakref import WeakKeyDictionary
 
 from pydantic import Field, PrivateAttr
 
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster import (
+    __version__,
     ConfigurableResource,
     DagsterInvariantViolationError,
     InitResourceContext,
@@ -18,6 +20,11 @@ from dagster import (
 
 import google.generativeai as genai
 from google.generativeai import GenerativeModel
+
+if version.parse(__version__) >= version.parse("1.10.0"):
+    from dagster._annotations import preview
+else:
+    from dagster._annotations import experimental as preview
 
 context_to_counters = WeakKeyDictionary()
 

--- a/libraries/dagster-gemini/dagster_gemini/resource.py
+++ b/libraries/dagster-gemini/dagster_gemini/resource.py
@@ -6,7 +6,7 @@ from weakref import WeakKeyDictionary
 
 from pydantic import Field, PrivateAttr
 
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster import (
     ConfigurableResource,
     DagsterInvariantViolationError,
@@ -70,7 +70,7 @@ def with_usage_metadata(
 
 
 @public
-@experimental
+@preview
 class GeminiResource(ConfigurableResource):
     """This resource is a wrapper over the `Gemini library<https://github.com/google-gemini/generative-ai-python>`.
 

--- a/libraries/dagster-hex/dagster_hex/assets.py
+++ b/libraries/dagster-hex/dagster_hex/assets.py
@@ -12,9 +12,9 @@ from typing import Optional
 from .resources import HexResource
 
 if version.parse(__version__) >= version.parse("1.10.0"):
-    from dagster._annotations import preview
+    from dagster._annotations import preview  # pyright: ignore[reportAttributeAccessIssue]
 else:
-    from dagster._annotations import experimental as preview
+    from dagster._annotations import experimental as preview  # pyright: ignore[reportAttributeAccessIssue]
 
 
 @preview

--- a/libraries/dagster-hex/dagster_hex/assets.py
+++ b/libraries/dagster-hex/dagster_hex/assets.py
@@ -1,4 +1,6 @@
+from packaging import version
 from dagster import (
+    __version__,
     AssetsDefinition,
     asset,
     AssetExecutionContext,
@@ -6,9 +8,13 @@ from dagster import (
     MetadataValue,
     Output,
 )
-from dagster._annotations import preview
 from typing import Optional
 from .resources import HexResource
+
+if version.parse(__version__) >= version.parse("1.10.0"):
+    from dagster._annotations import preview
+else:
+    from dagster._annotations import experimental as preview
 
 
 @preview

--- a/libraries/dagster-hex/dagster_hex/assets.py
+++ b/libraries/dagster-hex/dagster_hex/assets.py
@@ -6,12 +6,12 @@ from dagster import (
     MetadataValue,
     Output,
 )
-from dagster._annotations import experimental
+from dagster._annotations import preview
 from typing import Optional
 from .resources import HexResource
 
 
-@experimental
+@preview
 def build_hex_asset(
     project_id: str,
     resource: HexResource,

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/__init__.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/__init__.py
@@ -1,3 +1,5 @@
+from packaging import version
+from dagster import __version__
 from dagster_iceberg._utils.io import table_writer as table_writer
 from dagster_iceberg._utils.partitions import (
     DagsterPartitionToDaftSqlPredicateMapper as DagsterPartitionToDaftSqlPredicateMapper,
@@ -8,3 +10,8 @@ from dagster_iceberg._utils.partitions import (
 from dagster_iceberg._utils.partitions import (
     DagsterPartitionToPolarsSqlPredicateMapper as DagsterPartitionToPolarsSqlPredicateMapper,
 )
+
+if version.parse(__version__) >= version.parse("1.10.0"):
+    from dagster._annotations import preview
+else:
+    from dagster._annotations import experimental as preview  # noqa

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/__init__.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/__init__.py
@@ -11,7 +11,14 @@ from dagster_iceberg._utils.partitions import (
     DagsterPartitionToPolarsSqlPredicateMapper as DagsterPartitionToPolarsSqlPredicateMapper,
 )
 
-if version.parse(__version__) >= version.parse("1.10.0"):
-    from dagster._annotations import preview
-else:
-    from dagster._annotations import experimental as preview  # noqa
+
+def preview(wrapped=None):
+    if version.parse(__version__) >= version.parse("1.10.0"):
+        from dagster._annotations import preview as decorator  # pyright: ignore[reportAttributeAccessIssue]
+    else:
+        from dagster._annotations import experimental as decorator  # pyright: ignore[reportAttributeAccessIssue]
+
+    if wrapped is not None:
+        return decorator(wrapped)
+
+    return decorator

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -14,17 +14,16 @@ from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 from pyiceberg.catalog import Catalog
 from pyiceberg.table.snapshots import Snapshot
-from .utils import preview
 
-from dagster_iceberg._utils import table_writer
+from dagster_iceberg._utils import preview, table_writer
 
 U = TypeVar("U")
 
 ArrowTypes = Union[pa.Table, pa.RecordBatchReader]
 
 
-@preview
 @public
+@preview
 class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
     @abstractmethod
     def to_data_frame(

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -3,7 +3,7 @@ from typing import Generic, TypeVar, Union, cast
 
 import pyarrow as pa
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 from pyiceberg.catalog import Catalog
@@ -16,7 +16,7 @@ U = TypeVar("U")
 ArrowTypes = Union[pa.Table, pa.RecordBatchReader]
 
 
-@experimental
+@preview
 @public
 class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
     @abstractmethod

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -2,12 +2,19 @@ from abc import abstractmethod
 from typing import Generic, TypeVar, Union, cast
 
 import pyarrow as pa
-from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
-from dagster._annotations import preview, public
+from dagster import (
+    InputContext,
+    MetadataValue,
+    OutputContext,
+    TableColumn,
+    TableSchema,
+)
+from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 from pyiceberg.catalog import Catalog
 from pyiceberg.table.snapshots import Snapshot
+from .utils import preview
 
 from dagster_iceberg._utils import table_writer
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
@@ -1,7 +1,7 @@
 from typing import Sequence, Tuple, Type, Union
 
 import pyarrow as pa
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import expressions as E
 from pyiceberg import table as ibt
@@ -49,7 +49,7 @@ class _IcebergPyArrowTypeHandler(_handler.IcebergBaseTypeHandler[ArrowTypes]):
         return (pa.Table, pa.RecordBatchReader)
 
 
-@experimental
+@preview
 @public
 class IcebergPyarrowIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using PyArrow.

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
@@ -1,14 +1,14 @@
 from typing import Sequence, Tuple, Type, Union
 
 import pyarrow as pa
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import expressions as E
 from pyiceberg import table as ibt
 
 from dagster_iceberg import handler as _handler
 from dagster_iceberg import io_manager as _io_manager
-from dagster_iceberg._utils import DagsterPartitionToIcebergExpressionMapper
+from dagster_iceberg._utils import DagsterPartitionToIcebergExpressionMapper, preview
 
 ArrowTypes = Union[pa.Table, pa.RecordBatchReader]
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager  # noqa
 from typing import Dict, Iterator, Optional, Sequence, Type, TypedDict, cast  # noqa
 
 from dagster import OutputContext
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
@@ -19,6 +19,7 @@ from pyiceberg.catalog import Catalog, load_catalog
 
 from dagster_iceberg._db_io_manager import CustomDbIOManager
 from dagster_iceberg.config import IcebergCatalogConfig  # noqa
+from dagster_iceberg._utils import preview
 
 
 class PartitionSpecUpdateMode(enum.Enum):

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager  # noqa
 from typing import Dict, Iterator, Optional, Sequence, Type, TypedDict, cast  # noqa
 
 from dagster import OutputContext
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
@@ -49,7 +49,7 @@ class _IcebergTableIOManagerResourceConfig(TypedDict):
     schema_update_mode: SchemaUpdateMode
 
 
-@experimental
+@preview
 class IcebergDbClient(DbClient):
     @staticmethod
     def delete_table_slice(
@@ -94,7 +94,7 @@ class IcebergDbClient(DbClient):
             )
 
 
-@experimental
+@preview
 @public
 class IcebergIOManager(ConfigurableIOManagerFactory):
     """Base class for an IO manager definition that reads inputs from and writes outputs to Iceberg tables.

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
@@ -5,7 +5,7 @@ try:
 except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'daft' extra.") from e
 import pyarrow as pa
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 
@@ -48,7 +48,7 @@ class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
         return [da.DataFrame]
 
 
-@experimental
+@preview
 @public
 class IcebergDaftIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using Daft.

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
@@ -5,13 +5,13 @@ try:
 except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'daft' extra.") from e
 import pyarrow as pa
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 
 from dagster_iceberg import handler as _handler
 from dagster_iceberg import io_manager as _io_manager
-from dagster_iceberg._utils import DagsterPartitionToDaftSqlPredicateMapper
+from dagster_iceberg._utils import DagsterPartitionToDaftSqlPredicateMapper, preview
 
 
 class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
@@ -6,7 +6,7 @@ except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'pandas' extra.") from e
 import pyarrow as pa
 from dagster import InputContext
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg.catalog import Catalog
 
@@ -39,7 +39,7 @@ class _IcebergPandasTypeHandler(_IcebergPyArrowTypeHandler):
         return [pd.DataFrame]
 
 
-@experimental
+@preview
 @public
 class IcebergPandasIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using Pandas.

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
@@ -6,12 +6,13 @@ except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'pandas' extra.") from e
 import pyarrow as pa
 from dagster import InputContext
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg import io_manager as _io_manager
 from dagster_iceberg.io_manager.arrow import _IcebergPyArrowTypeHandler
+from dagster_iceberg._utils import preview
 
 
 class _IcebergPandasTypeHandler(_IcebergPyArrowTypeHandler):

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
@@ -5,13 +5,13 @@ try:
 except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'polars' extra.") from e
 import pyarrow as pa
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 
 from dagster_iceberg import handler as _handler
 from dagster_iceberg import io_manager as _io_manager
-from dagster_iceberg._utils import DagsterPartitionToPolarsSqlPredicateMapper
+from dagster_iceberg._utils import DagsterPartitionToPolarsSqlPredicateMapper, preview
 
 
 class _IcebergPolarsTypeHandler(

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
@@ -5,7 +5,7 @@ try:
 except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'polars' extra.") from e
 import pyarrow as pa
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg import table as ibt
 
@@ -55,7 +55,7 @@ class _IcebergPolarsTypeHandler(
         return (pl.LazyFrame, pl.DataFrame)
 
 
-@experimental
+@preview
 @public
 class IcebergPolarsIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using Polars.

--- a/libraries/dagster-iceberg/src/dagster_iceberg/resource.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/resource.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from dagster import ConfigurableResource
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from pydantic import Field
 from pyiceberg.catalog import load_catalog
 from pyiceberg.table import Table
@@ -10,7 +10,7 @@ from dagster_iceberg.config import IcebergCatalogConfig
 
 
 @public
-@experimental
+@preview
 class IcebergTableResource(ConfigurableResource):
     """Resource for interacting with a PyIceberg table.
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/resource.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/resource.py
@@ -1,12 +1,13 @@
 from typing import Optional
 
 from dagster import ConfigurableResource
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from pydantic import Field
 from pyiceberg.catalog import load_catalog
 from pyiceberg.table import Table
 
 from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg._utils import preview
 
 
 @public

--- a/libraries/dagster-notdiamond/dagster_notdiamond/resources.py
+++ b/libraries/dagster-notdiamond/dagster_notdiamond/resources.py
@@ -19,9 +19,9 @@ from notdiamond import NotDiamond
 from pydantic import Field, PrivateAttr
 
 if version.parse(__version__) >= version.parse("1.10.0"):
-    from dagster._annotations import preview
+    from dagster._annotations import preview  # pyright: ignore[reportAttributeAccessIssue]
 else:
-    from dagster._annotations import experimental as preview
+    from dagster._annotations import experimental as preview  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class ApiEndpointClassesEnum(Enum):

--- a/libraries/dagster-notdiamond/dagster_notdiamond/resources.py
+++ b/libraries/dagster-notdiamond/dagster_notdiamond/resources.py
@@ -4,17 +4,24 @@ from importlib import metadata
 from typing import Generator, Optional, Union
 from weakref import WeakKeyDictionary
 
+from packaging import version
 from dagster import (
+    __version__,
     AssetExecutionContext,
     AssetKey,
     ConfigurableResource,
     InitResourceContext,
     OpExecutionContext,
 )
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._core.errors import DagsterInvariantViolationError
 from notdiamond import NotDiamond
 from pydantic import Field, PrivateAttr
+
+if version.parse(__version__) >= version.parse("1.10.0"):
+    from dagster._annotations import preview
+else:
+    from dagster._annotations import experimental as preview
 
 
 class ApiEndpointClassesEnum(Enum):

--- a/libraries/dagster-notdiamond/dagster_notdiamond/resources.py
+++ b/libraries/dagster-notdiamond/dagster_notdiamond/resources.py
@@ -11,7 +11,7 @@ from dagster import (
     InitResourceContext,
     OpExecutionContext,
 )
-from dagster._annotations import experimental, public
+from dagster._annotations import preview, public
 from dagster._core.errors import DagsterInvariantViolationError
 from notdiamond import NotDiamond
 from pydantic import Field, PrivateAttr
@@ -27,7 +27,7 @@ context_to_counters = WeakKeyDictionary()
 
 
 @public
-@experimental
+@preview
 class NotDiamondResource(ConfigurableResource):
     """This resource is wrapper over the
     `notdiamond` library <https://github.com/notdiamond/notdiamond-python>.


### PR DESCRIPTION
## Summary & Motivation
We removed the `experimental` decorator, which caused import errors for the use of community packages with dagster >= 1.10.0

## How I Tested These Changes
Mostly inspection... open to suggestions.

## Changelog
- Updated community packages to be compatible with `dagster>=1.10.0`, which removed the experimental designation