### PR TITLE
[dagster-iceberg] Ruff more and drop other configs

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -7,13 +7,13 @@ from dagster import (
     StaticPartitionsDefinition,
     asset,
 )
-from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.polars import IcebergPolarsIOManager
-from dagster_iceberg.io_manager.spark import SparkIcebergIOManager
 from dagster_polars import PolarsParquetIOManager
 from dagster_pyspark import PySparkResource
 from pyspark.sql.connect.dataframe import DataFrame
 
+from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg.io_manager.polars import IcebergPolarsIOManager
+from dagster_iceberg.io_manager.spark import SparkIcebergIOManager
 
 NUM_PARTS = 2  # TODO(deepyaman): Make this configurable.
 
@@ -22,15 +22,17 @@ NAMESPACE = "nyc"
 
 parts = StaticPartitionsDefinition([f"part.{i}" for i in range(NUM_PARTS)])
 raw_nyc_taxi_data = AssetSpec(
-    key="nyc.parquet", partitions_def=parts
+    key="nyc.parquet",
+    partitions_def=parts,
 ).with_io_manager_key("polars_parquet_io_manager")
 
 
 @asset(
     ins={
         "raw_nyc_taxi_data": AssetIn(
-            "nyc.parquet", partition_mapping=AllPartitionMapping()
-        )
+            "nyc.parquet",
+            partition_mapping=AllPartitionMapping(),
+        ),
     },
     io_manager_key="iceberg_polars_io_manager",
 )
@@ -40,7 +42,7 @@ def combined_nyc_taxi_data(raw_nyc_taxi_data: dict[str, pl.LazyFrame]) -> pl.Laz
 
 @asset(io_manager_key="iceberg_polars_io_manager")
 def reloaded_nyc_taxi_data(combined_nyc_taxi_data: pl.LazyFrame) -> None:
-    print(combined_nyc_taxi_data.describe())
+    pass
 
 
 @asset(deps=["combined_nyc_taxi_data"], io_manager_key="spark_iceberg_io_manager")
@@ -61,7 +63,7 @@ catalog_config = IcebergCatalogConfig(
         "s3.endpoint": "http://localhost:9000",
         "s3.access-key-id": "admin",
         "s3.secret-access-key": "password",
-    }
+    },
 )
 
 
@@ -75,14 +77,17 @@ defs = Definitions(
     ],
     resources={
         "polars_parquet_io_manager": PolarsParquetIOManager(
-            base_dir="https://storage.googleapis.com/anaconda-public-data/nyc-taxi/"
+            base_dir="https://storage.googleapis.com/anaconda-public-data/nyc-taxi/",
         ),
         "iceberg_polars_io_manager": IcebergPolarsIOManager(
-            name=CATALOG_NAME, config=catalog_config, namespace=NAMESPACE
+            name=CATALOG_NAME,
+            config=catalog_config,
+            namespace=NAMESPACE,
         ),
         "pyspark": PySparkResource(spark_config={}),
         "spark_iceberg_io_manager": SparkIcebergIOManager(
-            catalog_name=CATALOG_NAME, namespace=NAMESPACE
+            catalog_name=CATALOG_NAME,
+            namespace=NAMESPACE,
         ),
     },
 )

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from typing import Optional
 
 import pytest
 from click.testing import CliRunner
@@ -8,7 +7,6 @@ from dagster import AssetKey
 from dagster._cli.asset import asset_materialize_command
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
-
 
 MAKEFILE_DIR = file_relative_path(__file__, "../")
 
@@ -25,8 +23,8 @@ def catalog():
 
 def invoke_materialize(
     select: str,
-    partition: Optional[str] = None,
-    partition_range: Optional[str] = None,
+    partition: str | None = None,
+    partition_range: str | None = None,
 ):
     runner = CliRunner()
     options = [

--- a/libraries/dagster-iceberg/pyproject.toml
+++ b/libraries/dagster-iceberg/pyproject.toml
@@ -7,10 +7,10 @@ authors = [
 requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
-    "dagster>=1.8.2",
-    "pendulum>=3.0.0",
-    "pyiceberg[pyarrow]>=0.8",
-    "tenacity>=8.5.0",
+  "dagster>=1.8.2",
+  "pendulum>=3.0.0",
+  "pyiceberg[pyarrow]>=0.8",
+  "tenacity>=8.5.0",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -18,7 +18,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12"
@@ -34,51 +33,20 @@ path = "src/dagster_iceberg/version.py"
 
 [project.optional-dependencies]
 daft = [
-    "getdaft>=0.3.0",
+  "getdaft>=0.3.0",
 ]
 pandas = [
-    "pandas>=2.0.0",
+  "pandas>=2.0.0",
 ]
 polars = [
-    "polars>=1.0.0",
+  "polars>=1.0.0",
 ]
 spark = [
-    "dagster-pyspark>=0.26.1",
-    "pyspark[connect]>=3.5.4",
+  "dagster-pyspark>=0.26.1",
+  "pyspark[connect]>=3.5.4",
 ]
-
-[tool.black]
-line-length = 88
-exclude = '''
-^/(
-  (
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.venv
-    | _build
-    | build
-    | dist
-    | .notebooks
-    | .nox
-  )
-)
-'''
-
-[tool.isort]
-profile = "black"
-extend_skip = [".notebooks", ".nox", ".venv"]
-
-[tool.mypy]
-exclude = [
-  '^docs/'
-]
-ignore_missing_imports = true
-explicit_package_bases = true
 
 [tool.ruff]
-lint.ignore = ["E501"]
 extend-exclude = [
   "__pycache__",
   "docs",
@@ -87,6 +55,58 @@ extend-exclude = [
   ".notebooks",
   "kitchen-sink/provision.py",  # Copied from https://github.com/apache/iceberg-python
 ]
+
+[tool.ruff.lint]
+select = [
+  "F",    # Pyflakes
+  "E",    # pycodestyle: Error
+  "W",    # pycodestyle: Warning
+  "I",    # isort
+  # "D",  # pydocstyle # TODO(deepyaman): Add missing docstrings.
+  "UP",   # pyupgrade
+  # "S",  # flake8-bandit # TODO(deepyaman): Remove assert and ignore tests.
+  "BLE",  # flake8-blind-except
+  "B",    # flake8-bugbear
+  # "A",  # flake8-builtins # TODO(deepyaman): Rename modules.
+  "COM",  # flake8-commas
+  "C4",   # flake8-comprehensions
+  "T10",  # flake8-debugger
+  "FA",   # flake8-future-annotations
+  "ISC",  # flake8-implicit-str-concat
+  "ICN",  # flake8-import-conventions
+  "G",    # flake8-logging-format
+  "INP",  # flake8-no-pep420
+  "PIE",  # flake8-pie
+  "T20",  # flake8-print
+  "PT",   # flake8-pytest-style
+  "Q",    # flake8-quotes
+  "RET",  # flake8-return
+  "SLF",  # flake8-self
+  "SIM",  # flake8-simplify
+  "TID",  # flake8-tidy-imports
+  "TCH",  # flake8-type-checking
+  "PTH",  # flake8-use-pathlib
+  "TD",   # flake8-todos
+  "ERA",  # eradicate
+  "PD",   # pandas-vet
+  "PGH",# pygrep-hooks # TODO(deepyaman): Use specific rule codes when ignoring type issues.
+  "FLY",  # flynt
+  "NPY",  # NumPy-specific rules
+  "PERF", # Perflint
+  "LOG",  # flake8-logging
+  "RUF",  # Ruff-specific rules
+]
+ignore = [
+  "E501",   # line-too-long
+  "UP038",  # non-pep604-isinstance, results in slower code
+  "B905",   # zip-without-explicit-strict, stylistic choice
+  "COM812", # missing-trailing-comma
+  "SLF001", # private-member-access
+  "TD003",  # missing-todo-link
+]
+
+[tool.ruff.lint.per-file-ignores]
+"kitchen-sink/*" = ["INP001"]
 
 [tool.pytest.ini_options]
 cache_dir = "/home/vscode/workspace/.cache/pytest"
@@ -100,19 +120,19 @@ venv = ".venv"
 
 [dependency-groups]
 docs = [
-    "mkdocs>=1.6.1",
-    "mkdocs-include-markdown-plugin>=7.0.0",
-    "mkdocs-material>=9.5.42",
-    "mkdocstrings[python]>=0.26.2",
+  "mkdocs>=1.6.1",
+  "mkdocs-include-markdown-plugin>=7.0.0",
+  "mkdocs-material>=9.5.42",
+  "mkdocstrings[python]>=0.26.2",
 ]
 dev = [
-    "dagit>=1.8.8",
-    "dagster-polars>=0.26.1",
-    "fsspec[http]>=2025.2.0",
-    "psycopg2-binary>=2.9.10",
-    "pyright>=1.1.385",
-    "pytest>=8.3.2",
-    "pytest-cov>=6.0.0",
-    "ruff>=0.9.6",
-    "testcontainers[postgres]>=4.8.2",
+  "dagit>=1.8.8",
+  "dagster-polars>=0.26.1",
+  "fsspec[http]>=2025.2.0",
+  "psycopg2-binary>=2.9.10",
+  "pyright>=1.1.385",
+  "pytest>=8.3.2",
+  "pytest-cov>=6.0.0",
+  "ruff>=0.9.6",
+  "testcontainers[postgres]>=4.8.2",
 ]

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_db_io_manager/utils.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_db_io_manager/utils.py
@@ -1,5 +1,6 @@
 import datetime as dt
-from typing import List, Mapping, Sequence, Union, cast  # noqa
+from collections.abc import Mapping, Sequence
+from typing import cast
 
 from dagster import (
     AssetKey,
@@ -15,7 +16,7 @@ from dagster_iceberg._utils.transforms import date_diff
 
 
 class MultiTimePartitionsChecker:
-    def __init__(self, partitions: List[TimeWindow]):
+    def __init__(self, partitions: list[TimeWindow]):
         """Helper class that defines checks on a list of TimeWindow objects
         most importantly, partitions should be consecutive.
 
@@ -40,11 +41,11 @@ class MultiTimePartitionsChecker:
         return date_
 
     @property
-    def hourly_deltas(self) -> List[int]:
+    def hourly_deltas(self) -> list[int]:
         deltas = [date_diff(w.start, w.end).in_hours() for w in self._partitions]
         if len(set(deltas)) != 1:
             raise ValueError(
-                "TimeWindowPartitionsDefinition must have the same delta from start to end"
+                "TimeWindowPartitionsDefinition must have the same delta from start to end",
             )
         return deltas
 
@@ -52,25 +53,21 @@ class MultiTimePartitionsChecker:
     def hourly_delta(self) -> int:
         try:
             return next(iter(set(self.hourly_deltas)))
-        except StopIteration:
+        except StopIteration as exc:
             raise ValueError(
-                "TimeWindowPartitionsDefinition must have at least one partition"
-            )
+                "TimeWindowPartitionsDefinition must have at least one partition",
+            ) from exc
 
     def is_consecutive(self):
         return (
-            True
-            if len(
-                set(
-                    [
-                        pdi(self.start).add(hours=self.hourly_delta * i)
-                        for i in range(date_diff(self.start, self.end).in_days() + 1)
-                    ]
-                )
-                - set([pdi(d.start) for d in self._partitions])
+            len(
+                {
+                    pdi(self.start).add(hours=self.hourly_delta * i)
+                    for i in range(date_diff(self.start, self.end).in_days() + 1)
+                }
+                - {pdi(d.start) for d in self._partitions},
             )
             == 1
-            else False
         )
 
 
@@ -79,7 +76,7 @@ def generate_multi_partitions_dimension(
     asset_partitions_def: MultiPartitionsDefinition,
     partition_expr: Mapping[str, str],
     asset_key: AssetKey,
-) -> List[TablePartitionDimension]:
+) -> list[TablePartitionDimension]:
     """Given a MultiPartitionsDefinition, generate a list of TablePartitionDimension objects that can be
     used to create a TableSlice object.
 
@@ -97,18 +94,18 @@ def generate_multi_partitions_dimension(
     Returns:
         List[TablePartitionDimension]: List of TablePartitionDimension objects
     """
-    partition_dimensions: List[TablePartitionDimension] = []
+    partition_dimensions: list[TablePartitionDimension] = []
     multi_partition_key_mappings = [
         cast(MultiPartitionKey, partition_key).keys_by_dimension
         for partition_key in asset_partition_keys
     ]
     for part in asset_partitions_def.partitions_defs:
-        partitions: List[Union[TimeWindow, str]] = []
+        partitions: list[TimeWindow | str] = []
         for multi_partition_key_mapping in multi_partition_key_mappings:
             partition_key = multi_partition_key_mapping[part.name]
             if isinstance(part.partitions_def, TimeWindowPartitionsDefinition):
                 partitions.append(
-                    part.partitions_def.time_window_for_partition_key(partition_key)
+                    part.partitions_def.time_window_for_partition_key(partition_key),
                 )
             else:
                 partitions.append(partition_key)
@@ -120,12 +117,12 @@ def generate_multi_partitions_dimension(
                 f" 'partition_expr' metadata does not contain a {part.name} entry,"
                 " so we don't know what column to filter it on. Specify which"
                 " column of the database contains data for the"
-                f" {part.name} partition."
+                f" {part.name} partition.",
             )
         partitions_: TimeWindow | Sequence[str]
         if all(isinstance(partition, TimeWindow) for partition in partitions):
             checker = MultiTimePartitionsChecker(
-                partitions=cast(List[TimeWindow], partitions)
+                partitions=cast(list[TimeWindow], partitions),
             )
             if not checker.is_consecutive():
                 raise ValueError("Dates are not consecutive.")
@@ -134,13 +131,14 @@ def generate_multi_partitions_dimension(
                 end=checker.end,
             )
         elif all(isinstance(partition, str) for partition in partitions):
-            partitions_ = list(set(cast(List[str], partitions)))
+            partitions_ = list(set(cast(list[str], partitions)))
         else:
             raise ValueError("Unknown partition type")
         partition_dimensions.append(
             TablePartitionDimension(
-                partition_expr=cast(str, partition_expr_str), partitions=partitions_
-            )
+                partition_expr=cast(str, partition_expr_str),
+                partitions=partitions_,
+            ),
         )
     return partition_dimensions
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/__init__.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/__init__.py
@@ -1,5 +1,6 @@
-from packaging import version
 from dagster import __version__
+from packaging import version
+
 from dagster_iceberg._utils.io import table_writer as table_writer
 from dagster_iceberg._utils.partitions import (
     DagsterPartitionToDaftSqlPredicateMapper as DagsterPartitionToDaftSqlPredicateMapper,
@@ -14,9 +15,13 @@ from dagster_iceberg._utils.partitions import (
 
 def preview(wrapped=None):
     if version.parse(__version__) >= version.parse("1.10.0"):
-        from dagster._annotations import preview as decorator  # pyright: ignore[reportAttributeAccessIssue]
+        from dagster._annotations import (
+            preview as decorator,  # pyright: ignore[reportAttributeAccessIssue]
+        )
     else:
-        from dagster._annotations import experimental as decorator  # pyright: ignore[reportAttributeAccessIssue]
+        from dagster._annotations import (
+            experimental as decorator,  # pyright: ignore[reportAttributeAccessIssue]
+        )
 
     if wrapped is not None:
         return decorator(wrapped)

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/partitions.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/partitions.py
@@ -2,16 +2,10 @@ import datetime as dt
 import itertools
 import logging
 from abc import abstractmethod
+from collections.abc import Iterable, Sequence
 from typing import (
-    Dict,
     Generic,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Set,
     TypeVar,
-    Union,
     cast,
 )
 
@@ -39,7 +33,7 @@ class DagsterPartitionToPredicateMapper(Generic[K]):
         self,
         partition_dimensions: Iterable[TablePartitionDimension],
         table_schema: Schema,
-        table_partition_spec: Optional[PartitionSpec] = None,
+        table_partition_spec: PartitionSpec | None = None,
     ):
         self.partition_dimensions = partition_dimensions
         self.table_schema = table_schema
@@ -47,15 +41,17 @@ class DagsterPartitionToPredicateMapper(Generic[K]):
 
     @abstractmethod
     def _partition_filters_to_predicates(
-        self, partition_expr: str, partition_filters: Sequence[str]
+        self,
+        partition_expr: str,
+        partition_filters: Sequence[str],
     ) -> K: ...
 
     @abstractmethod
     def _time_window_partition_filters_to_predicates(
         self,
         partition_expr: str,
-        start_dt: Union[dt.date, dt.datetime],
-        end_dt: Union[dt.date, dt.datetime],
+        start_dt: dt.date | dt.datetime,
+        end_dt: dt.date | dt.datetime,
     ) -> K: ...
 
     def _partition_filter(
@@ -70,9 +66,10 @@ class DagsterPartitionToPredicateMapper(Generic[K]):
     def _time_window_partition_filter(
         self,
         table_partition: TablePartitionDimension,
-        iceberg_partition_spec_field_type: Union[
-            T.DateType, T.TimestampType, T.TimeType, T.TimestamptzType
-        ],
+        iceberg_partition_spec_field_type: T.DateType
+        | T.TimestampType
+        | T.TimeType
+        | T.TimestamptzType,
     ) -> K:
         """Create an iceberg filter for a dagster time window partition
 
@@ -101,24 +98,27 @@ class DagsterPartitionToPredicateMapper(Generic[K]):
             end_dt=end_dt,
         )
 
-    def partition_dimensions_to_filters(self) -> List[K]:
+    def partition_dimensions_to_filters(self) -> list[K]:
         """Converts dagster partitions to iceberg filters"""
         predicates = []
-        partition_spec_fields: Optional[Dict[int, str]] = None
+        partition_spec_fields: dict[int, str] | None = None
         if self.table_partition_spec is not None:  # Only None when writing new tables
             partition_spec_fields = map_partition_spec_to_fields(
-                partition_spec=self.table_partition_spec, table_schema=self.table_schema
+                partition_spec=self.table_partition_spec,
+                table_schema=self.table_schema,
             )
         for partition_dimension in self.partition_dimensions:
             field = self.table_schema.find_field(partition_dimension.partition_expr)
-            if partition_spec_fields is not None:
-                if field.field_id not in partition_spec_fields.keys():
-                    raise ValueError(
-                        f"Table is not partitioned by field '{field.name}' with id"
-                        f"'{field.field_id}'. Available partition fields: "
-                        f"{partition_spec_fields}"
-                    )
-            # TODO: add timestamp tz type and time type
+            if (
+                partition_spec_fields is not None
+                and field.field_id not in partition_spec_fields
+            ):
+                raise ValueError(
+                    f"Table is not partitioned by field '{field.name}' with id"
+                    f"'{field.field_id}'. Available partition fields: "
+                    f"{partition_spec_fields}",
+                )
+            # TODO(JasperHG90): add timestamp tz type and time type
             predicate_: K
             if isinstance(field.field_type, time_partition_dt_types):
                 predicate_ = self._time_window_partition_filter(
@@ -129,54 +129,56 @@ class DagsterPartitionToPredicateMapper(Generic[K]):
                 predicate_ = self._partition_filter(table_partition=partition_dimension)
             else:
                 raise ValueError(
-                    f"Partitioning by field type '{str(field.field_type)}' not supported"
+                    f"Partitioning by field type '{field.field_type!s}' not supported",
                 )
             predicates.append(predicate_)
         return predicates
 
 
 class DagsterPartitionToIcebergExpressionMapper(
-    DagsterPartitionToPredicateMapper[E.BooleanExpression]
+    DagsterPartitionToPredicateMapper[E.BooleanExpression],
 ):
     def _partition_filters_to_predicates(
-        self, partition_expr: str, partition_filters: Sequence[str]
+        self,
+        partition_expr: str,
+        partition_filters: Sequence[str],
     ) -> E.BooleanExpression | E.LiteralPredicate[str]:
         predicates = [E.EqualTo(partition_expr, p) for p in partition_filters]
         if len(predicates) > 1:
             return E.Or(*predicates)
-        else:
-            return predicates[0]
+        return predicates[0]
 
     def _time_window_partition_filters_to_predicates(
         self,
         partition_expr: str,
-        start_dt: Union[dt.date, dt.datetime],
-        end_dt: Union[dt.date, dt.datetime],
+        start_dt: dt.date | dt.datetime,
+        end_dt: dt.date | dt.datetime,
     ) -> E.BooleanExpression:
         return E.And(
             *[
                 E.GreaterThanOrEqual(partition_expr, start_dt.isoformat()),
                 E.LessThan(partition_expr, end_dt.isoformat()),
-            ]
+            ],
         )
 
 
 class DagsterPartitionToSqlPredicateMapper(DagsterPartitionToPredicateMapper[str]):
     def _partition_filters_to_predicates(
-        self, partition_expr: str, partition_filters: Sequence[str]
+        self,
+        partition_expr: str,
+        partition_filters: Sequence[str],
     ) -> str:
         predicates = [f"{partition_expr} = '{p}'" for p in partition_filters]
         if len(predicates) > 1:
             return f"({' OR '.join(predicates)})"
-        else:
-            return predicates[0]
+        return predicates[0]
 
     @abstractmethod
     def _time_window_partition_filters_to_predicates(
         self,
         partition_expr: str,
-        start_dt: Union[dt.date, dt.datetime],
-        end_dt: Union[dt.date, dt.datetime],
+        start_dt: dt.date | dt.datetime,
+        end_dt: dt.date | dt.datetime,
     ) -> str: ...
 
 
@@ -184,8 +186,8 @@ class DagsterPartitionToPolarsSqlPredicateMapper(DagsterPartitionToSqlPredicateM
     def _time_window_partition_filters_to_predicates(
         self,
         partition_expr: str,
-        start_dt: Union[dt.date, dt.datetime],
-        end_dt: Union[dt.date, dt.datetime],
+        start_dt: dt.date | dt.datetime,
+        end_dt: dt.date | dt.datetime,
     ) -> str:
         return f"{partition_expr} >= '{start_dt.isoformat()}' AND {partition_expr} < '{end_dt.isoformat()}'"
 
@@ -194,8 +196,8 @@ class DagsterPartitionToDaftSqlPredicateMapper(DagsterPartitionToSqlPredicateMap
     def _time_window_partition_filters_to_predicates(
         self,
         partition_expr: str,
-        start_dt: Union[dt.date, dt.datetime],
-        end_dt: Union[dt.date, dt.datetime],
+        start_dt: dt.date | dt.datetime,
+        end_dt: dt.date | dt.datetime,
     ) -> str:
         # See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
         parse_fmt = "%+" if isinstance(start_dt, dt.datetime) else "%F"
@@ -206,10 +208,13 @@ class DagsterPartitionToDaftSqlPredicateMapper(DagsterPartitionToSqlPredicateMap
 
 
 def update_table_partition_spec(
-    table: Table, table_slice: TableSlice, partition_spec_update_mode: str
+    table: Table,
+    table_slice: TableSlice,
+    partition_spec_update_mode: str,
 ):
     partition_dimensions = cast(
-        Sequence[TablePartitionDimension], table_slice.partition_dimensions
+        Sequence[TablePartitionDimension],
+        table_slice.partition_dimensions,
     )
     PyIcebergPartitionSpecUpdaterWithRetry(table=table).execute(
         # 3 retries per partition dimension
@@ -253,7 +258,8 @@ class PartitionMapper:
         self.table_slice = table_slice
 
     def get_table_slice_partition_dimensions(
-        self, allow_empty_dagster_partitions: bool = False
+        self,
+        allow_empty_dagster_partitions: bool = False,
     ) -> Sequence[TablePartitionDimension]:
         """Retrieve dagster table slice partition dimensions."""
         # In practice, partition_dimensions is an empty list and not None
@@ -266,39 +272,39 @@ class PartitionMapper:
             partition_dimensions = self.table_slice.partition_dimensions
         if partition_dimensions is None and not allow_empty_dagster_partitions:
             raise ValueError(
-                "Partition dimensions are not set. Please set the 'partition_dimensions' field in the TableSlice."
+                "Partition dimensions are not set. Please set the 'partition_dimensions' field in the TableSlice.",
             )
-        elif partition_dimensions is None:
+        if partition_dimensions is None:
             return []
-        else:
-            # Check if table columns have the correct data types
-            for partition in partition_dimensions:
-                field = self.iceberg_table_schema.find_field(partition.partition_expr)
-                if isinstance(partition.partitions, TimeWindow):
-                    if not isinstance(field.field_type, time_partition_dt_types):
-                        raise ValueError(
-                            f"You have partitioned by some time-based partition window on column '{partition.partition_expr}'"
-                            f". But the table column type associated with this partition is '{str(field.field_type)}'"
-                            f". Please cast the column to an appropriate time-based type"
-                            " (e.g. datetime.date, datetime.datetime)."
-                        )
-                elif isinstance(partition.partitions, list):
-                    if not isinstance(field.field_type, partition_types):
-                        raise ValueError(
-                            f"You have defined a static partition on column '{partition.partition_expr}'"
-                            f". But the table column type associated with this partition is '{str(field.field_type)}'"
-                            f". Please cast the column to an appropriate type (e.g. string)."
-                        )
-                else:
+        # Check if table columns have the correct data types
+        for partition in partition_dimensions:
+            field = self.iceberg_table_schema.find_field(partition.partition_expr)
+            if isinstance(partition.partitions, TimeWindow):
+                if not isinstance(field.field_type, time_partition_dt_types):
                     raise ValueError(
-                        f"Partition dimension of type '{type(partition.partitions)}' not supported"
+                        f"You have partitioned by some time-based partition window on column '{partition.partition_expr}'"
+                        f". But the table column type associated with this partition is '{field.field_type!s}'"
+                        f". Please cast the column to an appropriate time-based type"
+                        " (e.g. datetime.date, datetime.datetime).",
                     )
+            elif isinstance(partition.partitions, list):
+                if not isinstance(field.field_type, partition_types):
+                    raise ValueError(
+                        f"You have defined a static partition on column '{partition.partition_expr}'"
+                        f". But the table column type associated with this partition is '{field.field_type!s}'"
+                        f". Please cast the column to an appropriate type (e.g. string).",
+                    )
+            else:
+                raise ValueError(
+                    f"Partition dimension of type '{type(partition.partitions)}' not supported",
+                )
 
-            return partition_dimensions
+        return partition_dimensions
 
     def get_iceberg_partition_field_by_name(
-        self, name: str
-    ) -> Optional[PartitionField]:
+        self,
+        name: str,
+    ) -> PartitionField | None:
         """Retrieve an iceberg partition field by its partition field spec name."""
         partition_field: PartitionField | None = None
         for field in self.iceberg_partition_spec.fields:
@@ -308,8 +314,9 @@ class PartitionMapper:
         return partition_field
 
     def get_dagster_partition_dimension_names(
-        self, allow_empty_dagster_partitions: bool = False
-    ) -> List[str]:
+        self,
+        allow_empty_dagster_partitions: bool = False,
+    ) -> list[str]:
         """Retrieve dagster partition dimension names.
 
         These are set in asset metadata using 'partition_expr', e.g.
@@ -323,12 +330,12 @@ class PartitionMapper:
         return [
             p.partition_expr
             for p in self.get_table_slice_partition_dimensions(
-                allow_empty_dagster_partitions=allow_empty_dagster_partitions
+                allow_empty_dagster_partitions=allow_empty_dagster_partitions,
             )
         ]
 
     @property
-    def iceberg_table_partition_field_names(self) -> Dict[int, str]:
+    def iceberg_table_partition_field_names(self) -> dict[int, str]:
         """TODO: rename property as this is a mapping"""
         return map_partition_spec_to_fields(
             partition_spec=self.iceberg_partition_spec,
@@ -336,24 +343,24 @@ class PartitionMapper:
         )
 
     @property
-    def new_partition_field_names(self) -> Set[str]:
+    def new_partition_field_names(self) -> set[str]:
         """Retrieve new partition field names passed to a dagster asset that are
         not present in the iceberg table partition spec."""
         return set(self.get_dagster_partition_dimension_names()) - set(
-            self.iceberg_table_partition_field_names.values()
+            self.iceberg_table_partition_field_names.values(),
         )
 
     @property
-    def deleted_partition_field_names(self) -> Set[str]:
+    def deleted_partition_field_names(self) -> set[str]:
         """Retrieve partition field names that have been removed from a dagster asset."""
         return set(self.iceberg_table_partition_field_names.values()) - set(
             self.get_dagster_partition_dimension_names(
-                allow_empty_dagster_partitions=True
-            )
+                allow_empty_dagster_partitions=True,
+            ),
         )
 
     @property
-    def dagster_time_partitions(self) -> List[TablePartitionDimension]:
+    def dagster_time_partitions(self) -> list[TablePartitionDimension]:
         """Retrieve dagster time partitions if present."""
         time_partitions = [
             p
@@ -362,7 +369,7 @@ class PartitionMapper:
         ]
         if len(time_partitions) > 1:
             raise ValueError(
-                f"Multiple time partitions found: {time_partitions}. Only one time partition is allowed."
+                f"Multiple time partitions found: {time_partitions}. Only one time partition is allowed.",
             )
         return time_partitions
 
@@ -376,41 +383,40 @@ class PartitionMapper:
         if time_partition is not None:
             time_partition_partitions = cast(TimeWindow, time_partition.partitions)
             time_partition_transformation = diff_to_transformation(
-                time_partition_partitions.start, time_partition_partitions.end
+                time_partition_partitions.start,
+                time_partition_partitions.end,
             )
             # Check if field is present in iceberg partition spec
             current_time_partition_field = self.get_iceberg_partition_field_by_name(
-                time_partition.partition_expr
+                time_partition.partition_expr,
             )
-            if current_time_partition_field is not None:
-                if (
-                    time_partition_transformation
-                    != current_time_partition_field.transform
-                ):
-                    updated_field_name = time_partition.partition_expr
+            if current_time_partition_field is not None and (
+                time_partition_transformation != current_time_partition_field.transform
+            ):
+                updated_field_name = time_partition.partition_expr
         return updated_field_name
 
-    def new(self) -> List[TablePartitionDimension]:
+    def new(self) -> list[TablePartitionDimension]:
         """Retrieve partition dimensions that are not yet present in the iceberg table."""
         return [
             p
             for p in self.get_table_slice_partition_dimensions(
-                allow_empty_dagster_partitions=True
+                allow_empty_dagster_partitions=True,
             )
             if p.partition_expr in self.new_partition_field_names
         ]
 
-    def updated(self) -> List[TablePartitionDimension]:
+    def updated(self) -> list[TablePartitionDimension]:
         """Retrieve partition dimensions that have been updated."""
         return [
             p
             for p in self.get_table_slice_partition_dimensions(
-                allow_empty_dagster_partitions=True
+                allow_empty_dagster_partitions=True,
             )
             if p.partition_expr == self.updated_dagster_time_partition_field
         ]
 
-    def deleted(self) -> List[PartitionField]:
+    def deleted(self) -> list[PartitionField]:
         """Retrieve partition fields need to be removed from the iceberg table."""
         return [
             p
@@ -428,12 +434,12 @@ class IcebergTableSpecUpdater:
         self.partition_spec_update_mode = partition_spec_update_mode
         self.partition_mapping = partition_mapping
         self.logger = logging.getLogger(
-            "dagster_iceberg._utils.partitions.IcebergTableSpecUpdater"
+            "dagster_iceberg._utils.partitions.IcebergTableSpecUpdater",
         )
 
     def _changes(
         self,
-    ) -> Dict[str, List[TablePartitionDimension] | List[PartitionField]]:
+    ) -> dict[str, list[TablePartitionDimension] | list[PartitionField]]:
         return {
             "new": self.partition_mapping.new(),
             "updated": self.partition_mapping.updated(),
@@ -468,49 +474,47 @@ class IcebergTableSpecUpdater:
     @property
     def has_changes(self) -> bool:
         """Return the number of changes to the Iceberg table spec."""
-        return (
-            True
-            if len([*itertools.chain.from_iterable(self._changes().values())]) > 0
-            else False
-        )
+        return len([*itertools.chain.from_iterable(self._changes().values())]) > 0
 
     def update_table_spec(self, table: Table):
         if self.partition_spec_update_mode == "error" and self.has_changes:
             raise ValueError(
-                "Partition spec update mode is set to 'error' but there are partition spec changes to the Iceberg table"
+                "Partition spec update mode is set to 'error' but there are partition spec changes to the Iceberg table",
             )
         # If there are no changes, do nothing
-        elif not self.has_changes:
+        if not self.has_changes:
             return
-        else:
-            with table.update_spec() as update:
-                for type_, partitions in self._changes().items():
-                    if not partitions:  # Empty list
-                        continue
-                    else:
-                        for partition in partitions:
-                            match type_:
-                                case "new":
-                                    partition_ = cast(
-                                        TablePartitionDimension, partition
-                                    )
-                                    self._spec_new(update=update, partition=partition_)
-                                case "updated":
-                                    partition_ = cast(
-                                        TablePartitionDimension, partition
-                                    )
-                                    self._spec_update(
-                                        update=update, partition=partition_
-                                    )
-                                case "deleted":
-                                    partition_ = cast(PartitionField, partition)
-                                    self._spec_delete(
-                                        update=update, partition_name=partition_.name
-                                    )
-                                case _:
-                                    raise ValueError(
-                                        f"Unsupported spec update type: {type_}"
-                                    )
+        with table.update_spec() as update:
+            for type_, partitions in self._changes().items():
+                if not partitions:  # Empty list
+                    continue
+                for partition in partitions:
+                    match type_:
+                        case "new":
+                            partition_ = cast(
+                                TablePartitionDimension,
+                                partition,
+                            )
+                            self._spec_new(update=update, partition=partition_)
+                        case "updated":
+                            partition_ = cast(
+                                TablePartitionDimension,
+                                partition,
+                            )
+                            self._spec_update(
+                                update=update,
+                                partition=partition_,
+                            )
+                        case "deleted":
+                            partition_ = cast(PartitionField, partition)
+                            self._spec_delete(
+                                update=update,
+                                partition_name=partition_.name,
+                            )
+                        case _:
+                            raise ValueError(
+                                f"Unsupported spec update type: {type_}",
+                            )
 
 
 def map_partition_spec_to_fields(partition_spec: PartitionSpec, table_schema: Schema):
@@ -523,8 +527,8 @@ def map_partition_spec_to_fields(partition_spec: PartitionSpec, table_schema: Sc
                     column.name
                     for column in table_schema.fields
                     if column.field_id == field.source_id
-                ]
-            )
+                ],
+            ),
         )
         partition_spec_fields[field.source_id] = field_name
     return partition_spec_fields

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/properties.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/properties.py
@@ -1,6 +1,5 @@
 import logging
 from functools import cached_property
-from typing import List
 
 from pyiceberg import table
 from pyiceberg.exceptions import CommitFailedException
@@ -9,7 +8,9 @@ from dagster_iceberg._utils.retries import IcebergOperationWithRetry
 
 
 def update_table_properties(
-    table: table.Table, current_table_properties: dict, new_table_properties: dict
+    table: table.Table,
+    current_table_properties: dict,
+    new_table_properties: dict,
 ):
     """Update existing table properties with new table properties passed by user"""
     IcebergPropertiesUpdaterWithRetry(table=table).execute(
@@ -46,37 +47,35 @@ class TablePropertiesDiffer:
     @property
     def has_changes(self) -> bool:
         return (
-            not (
-                len(self.updated_properties)
-                + len(self.deleted_properties)
-                + len(self.new_properties)
-            )
-            == 0
+            len(self.updated_properties)
+            + len(self.deleted_properties)
+            + len(self.new_properties)
+            != 0
         )
 
     @cached_property
-    def updated_properties(self) -> List[str]:
+    def updated_properties(self) -> list[str]:
         updated = []
-        for k in self.new_table_properties.keys():
+        for k in self.new_table_properties:
             if (
                 k in self.current_table_properties
                 and self.current_table_properties[k] != self.new_table_properties[k]
             ):
-                updated.append(k)
+                updated.append(k)  # noqa: PERF401, long `if` clause
         return updated
 
     @cached_property
-    def deleted_properties(self) -> List[str]:
+    def deleted_properties(self) -> list[str]:
         return list(
             set(self.current_table_properties.keys())
-            - set(self.new_table_properties.keys())
+            - set(self.new_table_properties.keys()),
         )
 
     @cached_property
-    def new_properties(self) -> List[str]:
+    def new_properties(self) -> list[str]:
         return list(
             set(self.new_table_properties.keys())
-            - set(self.current_table_properties.keys())
+            - set(self.current_table_properties.keys()),
         )
 
 
@@ -87,7 +86,7 @@ class IcebergTablePropertiesUpdater:
     ):
         self.table_properties_differ = table_properties_differ
         self.logger = logging.getLogger(
-            "dagster_iceberg._utils.schema.IcebergTablePropertiesUpdater"
+            "dagster_iceberg._utils.schema.IcebergTablePropertiesUpdater",
         )
 
     @property
@@ -103,14 +102,15 @@ class IcebergTablePropertiesUpdater:
         """
         if not self.table_properties_differ.has_changes:
             return
-        else:
-            self.logger.debug("Updating table properties")
-            with table.transaction() as tx:
-                self.logger.debug(
-                    f"Deleting table properties '{self.deleted_properties}'"
-                )
-                tx.remove_properties(*self.deleted_properties)
-                self.logger.debug(
-                    f"Updating table properties if applicable using '{table_properties}'"
-                )
-                tx.set_properties(table_properties)
+        self.logger.debug("Updating table properties")
+        with table.transaction() as tx:
+            self.logger.debug(
+                "Deleting table properties '%s'",
+                self.deleted_properties,
+            )
+            tx.remove_properties(*self.deleted_properties)
+            self.logger.debug(
+                "Updating table properties if applicable using '%s'",
+                table_properties,
+            )
+            tx.set_properties(table_properties)

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/retries.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/retries.py
@@ -1,6 +1,5 @@
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Tuple
 
 from pyiceberg.table import Table
 from tenacity import (
@@ -19,7 +18,7 @@ class IcebergOperationWithRetry(metaclass=ABCMeta):
     def __init__(self, table: Table):
         self.table = table
         self.logger = logging.getLogger(
-            f"dagster_iceberg._utils.{self.__class__.__name__}"
+            f"dagster_iceberg._utils.{self.__class__.__name__}",
         )
 
     @abstractmethod
@@ -31,7 +30,7 @@ class IcebergOperationWithRetry(metaclass=ABCMeta):
     def execute(
         self,
         retries: int,
-        exception_types: type[BaseException] | Tuple[type[BaseException], ...],
+        exception_types: type[BaseException] | tuple[type[BaseException], ...],
         *args,
         **kwargs,
     ):
@@ -54,5 +53,5 @@ class IcebergOperationWithRetry(metaclass=ABCMeta):
                         raise e
         except RetryError as e:
             raise IcebergOperationException(
-                f"Max retries exceeded for class {str(self.__class__)}"
+                f"Max retries exceeded for class {self.__class__!s}",
             ) from e

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
@@ -12,7 +12,8 @@ def date_diff(start: dt.datetime, end: dt.datetime) -> pendulum.Interval:
 
 
 def diff_to_transformation(
-    start: dt.datetime, end: dt.datetime
+    start: dt.datetime,
+    end: dt.datetime,
 ) -> transforms.Transform:
     """Based on the interval between two dates, return a transformation"""
     delta = date_diff(start, end)
@@ -26,7 +27,6 @@ def diff_to_transformation(
         case _:
             if delta.in_months() == 1:
                 return transforms.MonthTransform()
-            else:
-                raise NotImplementedError(
-                    f"Unsupported time window: {delta.in_words()}"
-                )
+            raise NotImplementedError(
+                f"Unsupported time window: {delta.in_words()}",
+            )

--- a/libraries/dagster-iceberg/src/dagster_iceberg/config.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from dagster import Config
 from dagster._annotations import public
@@ -37,4 +37,4 @@ class IcebergCatalogConfig(Config):
     ```
     """
 
-    properties: Dict[str, Any]
+    properties: dict[str, Any]

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Generic, TypeVar, Union, cast
+from typing import Generic, TypeVar, cast
 
 import pyarrow as pa
 from dagster import (
@@ -19,7 +19,7 @@ from dagster_iceberg._utils import preview, table_writer
 
 U = TypeVar("U")
 
-ArrowTypes = Union[pa.Table, pa.RecordBatchReader]
+ArrowTypes = pa.Table | pa.RecordBatchReader
 
 
 @public
@@ -27,7 +27,10 @@ ArrowTypes = Union[pa.Table, pa.RecordBatchReader]
 class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
     @abstractmethod
     def to_data_frame(
-        self, table: ibt.Table, table_slice: TableSlice, target_type: type
+        self,
+        table: ibt.Table,
+        table_slice: TableSlice,
+        target_type: type,
     ) -> U:
         pass
 
@@ -73,11 +76,11 @@ class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
                         columns=[
                             TableColumn(name=f["name"], type=str(f["type"]))
                             for f in table_.schema().model_dump()["fields"]
-                        ]
-                    )
+                        ],
+                    ),
                 ),
                 **current_snapshot.model_dump(),
-            }
+            },
         )
 
     def load_input(

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
@@ -1,4 +1,5 @@
-from typing import Sequence, Tuple, Type, Union
+from collections.abc import Sequence
+from typing import Union
 
 import pyarrow as pa
 from dagster._annotations import public
@@ -10,16 +11,19 @@ from dagster_iceberg import handler as _handler
 from dagster_iceberg import io_manager as _io_manager
 from dagster_iceberg._utils import DagsterPartitionToIcebergExpressionMapper, preview
 
-ArrowTypes = Union[pa.Table, pa.RecordBatchReader]
+ArrowTypes = Union[pa.Table, pa.RecordBatchReader]  # noqa: UP007, avoid Pyright failure
 
 
 class _IcebergPyArrowTypeHandler(_handler.IcebergBaseTypeHandler[ArrowTypes]):
     """Type handler that converts data between Iceberg tables and pyarrow Tables"""
 
     def to_data_frame(
-        self, table: ibt.Table, table_slice: TableSlice, target_type: Type[ArrowTypes]
+        self,
+        table: ibt.Table,
+        table_slice: TableSlice,
+        target_type: type[ArrowTypes],
     ) -> ArrowTypes:
-        selected_fields: Tuple[str, ...] = (
+        selected_fields: tuple[str, ...] = (
             tuple(table_slice.columns) if table_slice.columns is not None else ("*",)
         )
         row_filter: E.BooleanExpression
@@ -45,7 +49,7 @@ class _IcebergPyArrowTypeHandler(_handler.IcebergBaseTypeHandler[ArrowTypes]):
         return obj
 
     @property
-    def supported_types(self) -> Sequence[Type[object]]:
+    def supported_types(self) -> Sequence[type[object]]:
         return (pa.Table, pa.RecordBatchReader)
 
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Type
+from collections.abc import Sequence
 
 try:
     import daft as da
@@ -18,7 +18,10 @@ class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
     """Type handler that converts data between Iceberg tables and polars DataFrames"""
 
     def to_data_frame(
-        self, table: ibt.Table, table_slice: TableSlice, target_type: Type[da.DataFrame]
+        self,
+        table: ibt.Table,
+        table_slice: TableSlice,
+        target_type: type[da.DataFrame],
     ) -> da.DataFrame:
         selected_fields: str = (
             ",".join(table_slice.columns) if table_slice.columns is not None else "*"
@@ -32,7 +35,7 @@ class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
             ).partition_dimensions_to_filters()
             row_filter = " AND ".join(expressions)
 
-        ddf = table.to_daft()  # type: ignore # noqa
+        ddf = table.to_daft()  # noqa: F841, `daft.sql` detects `daft.DataFrame` objects
 
         stmt = f"SELECT {selected_fields} FROM ddf"
         if row_filter is not None:
@@ -44,7 +47,7 @@ class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
         return obj.to_arrow()
 
     @property
-    def supported_types(self) -> Sequence[Type[object]]:
+    def supported_types(self) -> Sequence[type[object]]:
         return [da.DataFrame]
 
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Type
+from collections.abc import Sequence
 
 try:
     import pandas as pd
@@ -11,8 +11,8 @@ from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg import io_manager as _io_manager
-from dagster_iceberg.io_manager.arrow import _IcebergPyArrowTypeHandler
 from dagster_iceberg._utils import preview
+from dagster_iceberg.io_manager.arrow import _IcebergPyArrowTypeHandler
 
 
 class _IcebergPandasTypeHandler(_IcebergPyArrowTypeHandler):
@@ -36,7 +36,7 @@ class _IcebergPandasTypeHandler(_IcebergPyArrowTypeHandler):
         return tbl.read_pandas()
 
     @property
-    def supported_types(self) -> Sequence[Type[object]]:
+    def supported_types(self) -> Sequence[type[object]]:
         return [pd.DataFrame]
 
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
@@ -1,21 +1,20 @@
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Optional, Union
 
 try:
-    from pyspark.sql.connect.session import SparkSession
     from pyspark.sql.connect.dataframe import DataFrame
+    from pyspark.sql.connect.session import SparkSession
 except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'spark' extra.") from e
 from dagster import ConfigurableIOManagerFactory
+from dagster._core.execution.context.input import InputContext
+from dagster._core.execution.context.output import OutputContext
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
     TableSlice,
 )
-from dagster._core.execution.context.input import InputContext
-from dagster._core.execution.context.output import OutputContext
 from dagster_pyspark.resources import spark_session_from_config
 
 
@@ -31,11 +30,14 @@ class SparkIcebergTypeHandler(DbTypeHandler[DataFrame]):
     ):
         """Writes a PySpark dataframe to an Iceberg table."""
         obj.writeTo(
-            SparkIcebergDbClient.get_table_name(table_slice)  # pyright: ignore [reportArgumentType]
+            SparkIcebergDbClient.get_table_name(table_slice),  # pyright: ignore [reportArgumentType]
         ).create()  # TODO(deepyaman): Ensure table exists, and `overwritePartitions()`.
 
     def load_input(
-        self, context: InputContext, table_slice: TableSlice, connection: SparkSession
+        self,
+        context: InputContext,
+        table_slice: TableSlice,
+        connection: SparkSession,
     ) -> DataFrame:
         """Reads a PySpark dataframe from an Iceberg table."""
         return connection.table(SparkIcebergDbClient.get_table_name(table_slice))  # pyright: ignore [reportArgumentType]
@@ -48,7 +50,9 @@ class SparkIcebergTypeHandler(DbTypeHandler[DataFrame]):
 class SparkIcebergDbClient(DbClient[SparkSession]):
     @staticmethod
     def delete_table_slice(
-        context: OutputContext, table_slice: TableSlice, connection: SparkSession
+        context: OutputContext,
+        table_slice: TableSlice,
+        connection: SparkSession,
     ) -> None: ...
 
     @staticmethod
@@ -56,7 +60,9 @@ class SparkIcebergDbClient(DbClient[SparkSession]):
 
     @staticmethod
     def ensure_schema_exists(
-        context: OutputContext, table_slice: TableSlice, connection: SparkSession
+        context: OutputContext,
+        table_slice: TableSlice,
+        connection: SparkSession,
     ) -> None:
         """Ensures that the schema for an Iceberg table exists."""
         schema_name = (
@@ -69,19 +75,20 @@ class SparkIcebergDbClient(DbClient[SparkSession]):
     @staticmethod
     @contextmanager
     def connect(
-        context: Union[OutputContext, InputContext], table_slice: TableSlice
+        context: OutputContext | InputContext,
+        table_slice: TableSlice,
     ) -> Iterator[SparkSession]:
         yield spark_session_from_config(
             context.resource_config.get("spark_config")
             if context.resource_config
-            else None
+            else None,
         )
 
 
 class SparkIcebergIOManager(ConfigurableIOManagerFactory):
     catalog_name: str
     namespace: str
-    spark_config: Optional[Mapping[str, str]] = None
+    spark_config: Mapping[str, str] | None = None
 
     def create_io_manager(self, context) -> DbIOManager:
         return DbIOManager(

--- a/libraries/dagster-iceberg/src/dagster_iceberg/resource.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/resource.py
@@ -1,13 +1,11 @@
-from typing import Optional
-
 from dagster import ConfigurableResource
 from dagster._annotations import public
 from pydantic import Field
 from pyiceberg.catalog import load_catalog
 from pyiceberg.table import Table
 
-from dagster_iceberg.config import IcebergCatalogConfig
 from dagster_iceberg._utils import preview
+from dagster_iceberg.config import IcebergCatalogConfig
 
 
 @public
@@ -50,12 +48,12 @@ class IcebergTableResource(ConfigurableResource):
     table: str = Field(
         description="Name of the iceberg table to interact with.",
     )
-    schema_: Optional[str] = Field(
+    schema_: str | None = Field(
         default=None,
         alias="namespace",
         description="Name of the iceberg catalog namespace to use.",
     )  # schema is a reserved word for pydantic
-    snapshot_id: Optional[int] = Field(
+    snapshot_id: int | None = Field(
         default=None,
         description="Snapshot ID that you would like to load. Default is latest.",
     )
@@ -63,4 +61,4 @@ class IcebergTableResource(ConfigurableResource):
     def load(self) -> Table:
         config_ = self.config.model_dump()
         catalog = load_catalog(name=self.name, **config_["properties"])
-        return catalog.load_table(identifier="%s.%s" % (self.schema_, self.table))
+        return catalog.load_table(identifier=f"{self.schema_}.{self.table}")

--- a/libraries/dagster-iceberg/tests/_db_io_manager/conftest.py
+++ b/libraries/dagster-iceberg/tests/_db_io_manager/conftest.py
@@ -30,7 +30,7 @@ def multi_partition_with_letter(
         partitions_defs={
             "date": daily_partitions_definition,
             "letter": letter_partitions_definition,
-        }
+        },
     )
 
 
@@ -43,5 +43,5 @@ def multi_partition_with_color(
         partitions_defs={
             "date": daily_partitions_definition,
             "color": color_partitions_definition,
-        }
+        },
     )

--- a/libraries/dagster-iceberg/tests/_db_io_manager/test_db_io_manager.py
+++ b/libraries/dagster-iceberg/tests/_db_io_manager/test_db_io_manager.py
@@ -8,7 +8,6 @@ TODO:
 """
 
 import datetime as dt
-from typing import Dict
 
 import pyarrow as pa
 import pytest
@@ -33,7 +32,9 @@ from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
 
 @pytest.fixture
 def io_manager(
-    catalog_name: str, namespace: str, catalog_config_properties: Dict[str, str]
+    catalog_name: str,
+    namespace: str,
+    catalog_config_properties: dict[str, str],
 ) -> IcebergPyarrowIOManager:
     return IcebergPyarrowIOManager(
         name=catalog_name,
@@ -44,7 +45,8 @@ def io_manager(
 
 
 daily_partitions_def = DailyPartitionsDefinition(
-    start_date="2022-01-01", end_date="2022-01-10"
+    start_date="2022-01-01",
+    end_date="2022-01-10",
 )
 
 letter_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
@@ -55,14 +57,14 @@ multi_partition_with_letter = MultiPartitionsDefinition(
     partitions_defs={
         "date": daily_partitions_def,
         "letter": letter_partitions_def,
-    }
+    },
 )
 
 multi_partition_with_color = MultiPartitionsDefinition(
     partitions_defs={
         "date": daily_partitions_def,
         "color": color_partitions_def,
-    }
+    },
 )
 
 
@@ -74,7 +76,7 @@ def asset_1() -> pa.Table:
         {
             "value": [1],
             "b": [1],
-        }
+        },
     )
 
 
@@ -93,7 +95,7 @@ def asset_2(asset_1: pa.Table) -> pa.Table:
         "partition_expr": {
             "date": "date_column",
             "color": "color_column",
-        }
+        },
     },
 )
 def multi_partitioned_asset_1(context: AssetExecutionContext) -> pa.Table:
@@ -106,7 +108,7 @@ def multi_partitioned_asset_1(context: AssetExecutionContext) -> pa.Table:
             "value": [1],
             "b": [1],
             "color_column": [color],
-        }
+        },
     )
 
 
@@ -118,7 +120,7 @@ def multi_partitioned_asset_1(context: AssetExecutionContext) -> pa.Table:
         "partition_expr": {
             "date": "date_column",
             "color": "color_column",
-        }
+        },
     },
 )
 def multi_partitioned_asset_2(multi_partitioned_asset_1: pa.Table) -> pa.Table:
@@ -140,9 +142,9 @@ def non_partitioned_asset(multi_partitioned_asset_1: pa.Table) -> pa.Table:
         "multi_partitioned_asset": AssetIn(
             ["my_schema", "multi_partitioned_asset_1"],
             partition_mapping=MultiToSingleDimensionPartitionMapping(
-                partition_dimension_name="date"
+                partition_dimension_name="date",
             ),
-        )
+        ),
     },
     metadata={
         "partition_expr": "date_column",
@@ -159,9 +161,9 @@ def single_partitioned_asset_date(multi_partitioned_asset: pa.Table) -> pa.Table
         "multi_partitioned_asset": AssetIn(
             ["my_schema", "multi_partitioned_asset_1"],
             partition_mapping=MultiToSingleDimensionPartitionMapping(
-                partition_dimension_name="color"
+                partition_dimension_name="color",
             ),
-        )
+        ),
     },
     metadata={
         "partition_expr": "color_column",
@@ -183,27 +185,27 @@ def single_partitioned_asset_color(multi_partitioned_asset: pa.Table) -> pa.Tabl
                     "color": DimensionPartitionMapping(
                         dimension_name="letter",
                         partition_mapping=StaticPartitionMapping(
-                            {"blue": "a", "red": "b", "yellow": "c"}
+                            {"blue": "a", "red": "b", "yellow": "c"},
                         ),
                     ),
                     "date": DimensionPartitionMapping(
                         dimension_name="date",
                         partition_mapping=SpecificPartitionsPartitionMapping(
-                            ["2022-01-01", "2024-01-01"]
+                            ["2022-01-01", "2024-01-01"],
                         ),
                     ),
-                }
+                },
             ),
-        )
+        ),
     },
 )
 def mapped_multi_partition(
-    context: AssetExecutionContext, multi_partitioned_asset: pa.Table
+    context: AssetExecutionContext,
+    multi_partitioned_asset: pa.Table,
 ) -> pa.Table:
     letter, _ = context.partition_key.split("|")
 
-    table_ = multi_partitioned_asset.append_column("letter", pa.array([letter]))
-    return table_
+    return multi_partitioned_asset.append_column("letter", pa.array([letter]))
 
 
 def test_unpartitioned_asset_to_unpartitioned_asset(

--- a/libraries/dagster-iceberg/tests/_db_io_manager/test_db_io_manager_utils.py
+++ b/libraries/dagster-iceberg/tests/_db_io_manager/test_db_io_manager_utils.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import List
 
 import pytest
 from dagster import AssetKey, MultiPartitionKey, MultiPartitionsDefinition, TimeWindow
@@ -10,7 +9,7 @@ from dagster_iceberg._db_io_manager import utils
 
 # NB: dagster uses dt.datetime even for dates
 @pytest.fixture
-def daily_partitions_time_window_consecutive() -> List[TimeWindow]:
+def daily_partitions_time_window_consecutive() -> list[TimeWindow]:
     return [
         TimeWindow(
             start=dt.datetime(2022, 1, 1, 0),
@@ -28,7 +27,7 @@ def daily_partitions_time_window_consecutive() -> List[TimeWindow]:
 
 
 @pytest.fixture
-def daily_partitions_time_window_not_consecutive() -> List[TimeWindow]:
+def daily_partitions_time_window_not_consecutive() -> list[TimeWindow]:
     return [
         TimeWindow(
             start=dt.datetime(2022, 1, 1, 0),
@@ -46,10 +45,10 @@ def daily_partitions_time_window_not_consecutive() -> List[TimeWindow]:
 
 
 def test_multi_time_partitions_checker_consecutive(
-    daily_partitions_time_window_consecutive: List[TimeWindow],
+    daily_partitions_time_window_consecutive: list[TimeWindow],
 ):
     checker = utils.MultiTimePartitionsChecker(
-        partitions=daily_partitions_time_window_consecutive
+        partitions=daily_partitions_time_window_consecutive,
     )
     assert checker.start == dt.datetime(2022, 1, 1, 0)
     assert checker.end == dt.datetime(2022, 1, 4, 0)
@@ -58,10 +57,10 @@ def test_multi_time_partitions_checker_consecutive(
 
 
 def test_multi_time_partitions_checker_non_consecutive(
-    daily_partitions_time_window_not_consecutive: List[TimeWindow],
+    daily_partitions_time_window_not_consecutive: list[TimeWindow],
 ):
     checker = utils.MultiTimePartitionsChecker(
-        partitions=daily_partitions_time_window_not_consecutive
+        partitions=daily_partitions_time_window_not_consecutive,
     )
     assert checker.hourly_delta == 24
     assert checker.start == dt.datetime(2022, 1, 1, 0)
@@ -105,10 +104,10 @@ def test_generate_partition_dimensions_color_varying(
         asset_partition_keys=[
             MultiPartitionKey(keys_by_dimension={"color": "red", "date": "2022-01-01"}),
             MultiPartitionKey(
-                keys_by_dimension={"color": "blue", "date": "2022-01-01"}
+                keys_by_dimension={"color": "blue", "date": "2022-01-01"},
             ),
             MultiPartitionKey(
-                keys_by_dimension={"color": "yellow", "date": "2022-01-01"}
+                keys_by_dimension={"color": "yellow", "date": "2022-01-01"},
             ),
         ],
         asset_partitions_def=multi_partition_with_color,
@@ -121,10 +120,18 @@ def test_generate_partition_dimensions_color_varying(
     assert partition_dimensions[0].partition_expr == "color_column"
     assert partition_dimensions[1].partition_expr == "date_column"
     assert partition_dimensions[1].partitions.start == dt.datetime(
-        2022, 1, 1, 0, tzinfo=dt.timezone.utc
+        2022,
+        1,
+        1,
+        0,
+        tzinfo=dt.timezone.utc,
     )
     assert partition_dimensions[1].partitions.end == dt.datetime(
-        2022, 1, 2, 0, tzinfo=dt.timezone.utc
+        2022,
+        1,
+        2,
+        0,
+        tzinfo=dt.timezone.utc,
     )
     assert sorted(partition_dimensions[0].partitions) == ["blue", "red", "yellow"]
 
@@ -150,9 +157,17 @@ def test_generate_partition_dimensions_date_varying(
     assert partition_dimensions[0].partition_expr == "color_column"
     assert partition_dimensions[1].partition_expr == "date_column"
     assert partition_dimensions[1].partitions.start == dt.datetime(
-        2022, 1, 1, 0, tzinfo=dt.timezone.utc
+        2022,
+        1,
+        1,
+        0,
+        tzinfo=dt.timezone.utc,
     )
     assert partition_dimensions[1].partitions.end == dt.datetime(
-        2022, 1, 4, 0, tzinfo=dt.timezone.utc
+        2022,
+        1,
+        4,
+        0,
+        tzinfo=dt.timezone.utc,
     )
     assert partition_dimensions[0].partitions == ["red"]

--- a/libraries/dagster-iceberg/tests/_utils/conftest.py
+++ b/libraries/dagster-iceberg/tests/_utils/conftest.py
@@ -11,24 +11,24 @@ from pyiceberg import types as T
 from pyiceberg.catalog import Catalog
 
 
-@pytest.fixture()
+@pytest.fixture
 def time_window() -> TimeWindow:
     return TimeWindow(dt.datetime(2023, 1, 1, 0), dt.datetime(2023, 1, 1, 1))
 
 
-@pytest.fixture()
+@pytest.fixture
 def datetime_table_partition_dimension(
     time_window: TimeWindow,
 ) -> TablePartitionDimension:
     return TablePartitionDimension("timestamp", time_window)
 
 
-@pytest.fixture()
+@pytest.fixture
 def category_table_partition_dimension() -> TablePartitionDimension:
     return TablePartitionDimension("category", ["A"])
 
 
-@pytest.fixture()
+@pytest.fixture
 def category_table_partition_dimension_multiple() -> TablePartitionDimension:
     return TablePartitionDimension("category", ["A", "B"])
 
@@ -48,7 +48,7 @@ def table_partitioned_update_name() -> str:
     return "handler_data_partitioned_update"
 
 
-@pytest.fixture()
+@pytest.fixture
 def partitioned_table_slice(
     datetime_table_partition_dimension: TablePartitionDimension,
     category_table_partition_dimension: TablePartitionDimension,
@@ -65,7 +65,7 @@ def partitioned_table_slice(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def table_slice(table_name: str, namespace: str) -> TableSlice:
     return TableSlice(
         table=table_name,
@@ -74,7 +74,7 @@ def table_slice(table_name: str, namespace: str) -> TableSlice:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def table_slice_with_selected_columns(table_name: str, namespace: str) -> TableSlice:
     return TableSlice(
         table=table_name,
@@ -84,7 +84,7 @@ def table_slice_with_selected_columns(table_name: str, namespace: str) -> TableS
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def iceberg_table_schema() -> iceberg_schema.Schema:
     return iceberg_schema.Schema(
         T.NestedField(
@@ -100,36 +100,42 @@ def iceberg_table_schema() -> iceberg_schema.Schema:
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table_identifier(namespace: str, table_name: str) -> str:
     return f"{namespace}.{table_name}"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table_partitioned_identifier(namespace: str, table_partitioned_name: str) -> str:
     return f"{namespace}.{table_partitioned_name}"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table_partitioned_update_identifier(
-    namespace: str, table_partitioned_update_name: str
+    namespace: str,
+    table_partitioned_update_name: str,
 ) -> str:
     return f"{namespace}.{table_partitioned_update_name}"
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def create_table_in_catalog(
-    catalog: Catalog, table_identifier: str, data_schema: pa.Schema
+    catalog: Catalog,
+    table_identifier: str,
+    data_schema: pa.Schema,
 ):
     catalog.create_table(table_identifier, schema=data_schema)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def create_partitioned_table_in_catalog(
-    catalog: Catalog, table_partitioned_identifier: str, data_schema: pa.Schema
+    catalog: Catalog,
+    table_partitioned_identifier: str,
+    data_schema: pa.Schema,
 ):
     partitioned_table = catalog.create_table(
-        table_partitioned_identifier, schema=data_schema
+        table_partitioned_identifier,
+        schema=data_schema,
     )
     with partitioned_table.update_spec() as update:
         update.add_field(
@@ -144,14 +150,15 @@ def create_partitioned_table_in_catalog(
         )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def create_partitioned_update_table_in_catalog(
     catalog: Catalog,
     table_partitioned_update_identifier: str,
     data_schema: pa.Schema,
 ):
     partitioned_update_table = catalog.create_table(
-        table_partitioned_update_identifier, schema=data_schema
+        table_partitioned_update_identifier,
+        schema=data_schema,
     )
     with partitioned_update_table.update_spec() as update:
         update.add_field(
@@ -166,14 +173,17 @@ def create_partitioned_update_table_in_catalog(
         )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def append_data_to_table(
-    create_table_in_catalog, catalog: Catalog, table_identifier: str, data: pa.Table
+    create_table_in_catalog,
+    catalog: Catalog,
+    table_identifier: str,
+    data: pa.Table,
 ):
     catalog.load_table(table_identifier).append(data)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def append_data_to_partitioned_table(
     create_partitioned_table_in_catalog,
     catalog: Catalog,
@@ -183,7 +193,7 @@ def append_data_to_partitioned_table(
     catalog.load_table(table_partitioned_identifier).append(data)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def append_data_to_partitioned_update_table(
     create_partitioned_update_table_in_catalog,
     catalog: Catalog,
@@ -193,20 +203,22 @@ def append_data_to_partitioned_update_table(
     catalog.load_table(table_partitioned_update_identifier).append(data)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table(catalog: Catalog, table_identifier: str) -> iceberg_table.Table:
     return catalog.load_table(table_identifier)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table_partitioned(
-    catalog: Catalog, table_partitioned_identifier: str
+    catalog: Catalog,
+    table_partitioned_identifier: str,
 ) -> iceberg_table.Table:
     return catalog.load_table(table_partitioned_identifier)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table_partitioned_update(
-    catalog: Catalog, table_partitioned_update_identifier: str
+    catalog: Catalog,
+    table_partitioned_update_identifier: str,
 ) -> iceberg_table.Table:
     return catalog.load_table(table_partitioned_update_identifier)

--- a/libraries/dagster-iceberg/tests/_utils/test_io.py
+++ b/libraries/dagster-iceberg/tests/_utils/test_io.py
@@ -48,7 +48,7 @@ def test_table_writer_partitioned(namespace: str, catalog: Catalog, data: pa.Tab
     identifier_ = f"{namespace}.{table_}"
     data = data.filter(
         (pc.field("timestamp") >= dt.datetime(2023, 1, 1, 0))
-        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1))
+        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1)),
     )
     io.table_writer(
         table_slice=TableSlice(
@@ -74,7 +74,9 @@ def test_table_writer_partitioned(namespace: str, catalog: Catalog, data: pa.Tab
 
 
 def test_table_writer_multi_partitioned(
-    namespace: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     # Works similar to # https://docs.dagster.io/integrations/deltalake/reference#storing-multi-partitioned-assets
     # Need to subset the data.
@@ -83,7 +85,7 @@ def test_table_writer_multi_partitioned(
     data = data.filter(
         (pc.field("category") == "A")
         & (pc.field("timestamp") >= dt.datetime(2023, 1, 1, 0))
-        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1))
+        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1)),
     )
     io.table_writer(
         table_slice=TableSlice(
@@ -113,7 +115,9 @@ def test_table_writer_multi_partitioned(
 
 
 def test_table_writer_multi_partitioned_update(
-    namespace: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     # Works similar to # https://docs.dagster.io/integrations/deltalake/reference#storing-multi-partitioned-assets
     # Need to subset the data.
@@ -122,7 +126,7 @@ def test_table_writer_multi_partitioned_update(
     data = data.filter(
         (pc.field("category") == "A")
         & (pc.field("timestamp") >= dt.datetime(2023, 1, 1, 0))
-        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1))
+        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1)),
     ).to_pydict()
     data["value"] = pa.array([10.0] * len(data["value"]))
     data = pa.Table.from_pydict(data)
@@ -156,16 +160,19 @@ def test_table_writer_multi_partitioned_update(
                     E.LessThan("timestamp", "2023-01-01T01:00:00"),
                 ),
                 E.EqualTo("category", "A"),
-            )
+            ),
         )
         .to_arrow()
         .to_pydict()
     )
-    assert all([v == 10 for v in data_out["value"]])
+    assert all(v == 10 for v in data_out["value"])
 
 
 def test_table_writer_multi_partitioned_update_partition_spec_change(
-    namespace: str, warehouse_path: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    warehouse_path: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     table_ = "handler_data_table_writer_multi_partitioned_update_partition_spec_change"
     identifier_ = f"{namespace}.{table_}"
@@ -189,7 +196,7 @@ def test_table_writer_multi_partitioned_update_partition_spec_change(
     data_ = data.filter(
         (pc.field("category") == "A")
         & (pc.field("timestamp") >= dt.datetime(2023, 1, 1, 0))
-        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1))
+        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1)),
     )
     io.table_writer(
         table_slice=TableSlice(
@@ -228,7 +235,9 @@ def test_table_writer_multi_partitioned_update_partition_spec_change(
 
 
 def test_table_writer_multi_partitioned_update_partition_spec_error(
-    namespace: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     table_ = "handler_data_multi_partitioned_update_partition_spec_error"
     io.table_writer(
@@ -251,10 +260,11 @@ def test_table_writer_multi_partitioned_update_partition_spec_error(
     data_ = data.filter(
         (pc.field("category") == "A")
         & (pc.field("timestamp") >= dt.datetime(2023, 1, 1, 0))
-        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1))
+        & (pc.field("timestamp") < dt.datetime(2023, 1, 1, 1)),
     )
     with pytest.raises(
-        ValueError, match="Partition spec update mode is set to 'error' but there"
+        ValueError,
+        match="Partition spec update mode is set to 'error' but there",
     ):
         io.table_writer(
             table_slice=TableSlice(
@@ -264,7 +274,8 @@ def test_table_writer_multi_partitioned_update_partition_spec_error(
                     TablePartitionDimension(
                         "timestamp",
                         TimeWindow(
-                            dt.datetime(2023, 1, 1, 0), dt.datetime(2023, 1, 1, 1)
+                            dt.datetime(2023, 1, 1, 0),
+                            dt.datetime(2023, 1, 1, 1),
                         ),
                     ),
                     TablePartitionDimension(
@@ -282,7 +293,9 @@ def test_table_writer_multi_partitioned_update_partition_spec_error(
 
 
 def test_iceberg_table_writer_with_table_properties(
-    namespace: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     table_ = "handler_data_iceberg_table_writer_with_table_properties"
     identifier_ = f"{namespace}.{table_}"
@@ -308,7 +321,9 @@ def test_iceberg_table_writer_with_table_properties(
 
 
 def test_iceberg_table_writer_drop_partition_spec_column(
-    namespace: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     table_ = "handler_data_iceberg_table_writer_drop_partition_spec"
     # First write
@@ -340,7 +355,8 @@ def test_iceberg_table_writer_drop_partition_spec_column(
                     TablePartitionDimension(
                         "timestamp",
                         TimeWindow(
-                            dt.datetime(2023, 1, 1, 0), dt.datetime(2023, 1, 1, 1)
+                            dt.datetime(2023, 1, 1, 0),
+                            dt.datetime(2023, 1, 1, 1),
                         ),
                     ),
                 ],
@@ -354,7 +370,9 @@ def test_iceberg_table_writer_drop_partition_spec_column(
 
 
 def test_write_from_any_to_zero_partition_spec_fields(
-    namespace: str, catalog: Catalog, data: pa.Table
+    namespace: str,
+    catalog: Catalog,
+    data: pa.Table,
 ):
     table_ = "handler_data_write_from_any_to_zero_partition_spec_fields"
     # First write

--- a/libraries/dagster-iceberg/tests/_utils/test_partitions.py
+++ b/libraries/dagster-iceberg/tests/_utils/test_partitions.py
@@ -38,11 +38,12 @@ def test_time_window_partition_filter(
         *[
             E.GreaterThanOrEqual("timestamp", "2023-01-01T00:00:00"),
             E.LessThan("timestamp", "2023-01-01T01:00:00"),
-        ]
+        ],
     )
     filter_ = (
         dagster_partition_to_pyiceberg_expression_mapper._time_window_partition_filter(
-            datetime_table_partition_dimension, T.TimestampType
+            datetime_table_partition_dimension,
+            T.TimestampType,
         )
     )
     assert filter_ == expected_filter
@@ -54,7 +55,7 @@ def test_partition_filter(
 ):
     expected_filter = E.EqualTo("category", "A")
     filter_ = dagster_partition_to_pyiceberg_expression_mapper._partition_filter(
-        category_table_partition_dimension
+        category_table_partition_dimension,
     )
     assert filter_ == expected_filter
 
@@ -65,7 +66,7 @@ def test_partition_filter_with_multiple(
 ):
     expected_filter = E.Or(*[E.EqualTo("category", "A"), E.EqualTo("category", "B")])
     filter_ = dagster_partition_to_pyiceberg_expression_mapper._partition_filter(
-        category_table_partition_dimension_multiple
+        category_table_partition_dimension_multiple,
     )
     assert filter_ == expected_filter
 
@@ -89,7 +90,7 @@ def test_partition_dimensions_to_filters(
             *[
                 E.GreaterThanOrEqual("timestamp", "2023-01-01T00:00:00"),
                 E.LessThan("timestamp", "2023-01-01T01:00:00"),
-            ]
+            ],
         ),
         E.EqualTo("category", "A"),
     ]
@@ -105,7 +106,7 @@ def test_partition_dimensions_to_filters_multiple_categories(
             *[
                 E.GreaterThanOrEqual("timestamp", "2023-01-01T00:00:00"),
                 E.LessThan("timestamp", "2023-01-01T01:00:00"),
-            ]
+            ],
         ),
         E.Or(*[E.EqualTo("category", "A"), E.EqualTo("category", "B")]),
     ]
@@ -119,7 +120,10 @@ def test_iceberg_to_dagster_partition_mapper_new_fields(
     table_ = "handler_data_multi_partitioned_update_schema_change"
     spec = iceberg_partitioning.PartitionSpec(
         iceberg_partitioning.PartitionField(
-            1, 1, name="timestamp", transform=transforms.HourTransform()
+            1,
+            1,
+            name="timestamp",
+            transform=transforms.HourTransform(),
         ),
     )
     table_slice = TableSlice(
@@ -152,7 +156,10 @@ def test_iceberg_to_dagster_partition_mapper_changed_time_partition(
     table_ = "handler_data_multi_partitioned_update_schema_change"
     spec = iceberg_partitioning.PartitionSpec(
         iceberg_partitioning.PartitionField(
-            1, 1, name="timestamp", transform=transforms.HourTransform()
+            1,
+            1,
+            name="timestamp",
+            transform=transforms.HourTransform(),
         ),
     )
     table_slice = TableSlice(
@@ -182,10 +189,16 @@ def test_iceberg_to_dagster_partition_mapper_deleted(
     table_ = "handler_data_multi_partitioned_update_schema_change"
     spec = iceberg_partitioning.PartitionSpec(
         iceberg_partitioning.PartitionField(
-            1, 1, name="timestamp", transform=transforms.HourTransform()
+            1,
+            1,
+            name="timestamp",
+            transform=transforms.HourTransform(),
         ),
         iceberg_partitioning.PartitionField(
-            2, 2, name="category", transform=transforms.IdentityTransform()
+            2,
+            2,
+            name="category",
+            transform=transforms.IdentityTransform(),
         ),
     )
     table_slice = TableSlice(
@@ -210,10 +223,16 @@ def test_iceberg_table_spec_updater_delete_field(
     table_ = "handler_spec_updater_delete"
     spec = iceberg_partitioning.PartitionSpec(
         iceberg_partitioning.PartitionField(
-            1, 1, name="timestamp", transform=transforms.HourTransform()
+            1,
+            1,
+            name="timestamp",
+            transform=transforms.HourTransform(),
         ),
         iceberg_partitioning.PartitionField(
-            2, 2, name="category", transform=transforms.IdentityTransform()
+            2,
+            2,
+            name="category",
+            transform=transforms.IdentityTransform(),
         ),
     )
     table_slice = TableSlice(
@@ -238,7 +257,7 @@ def test_iceberg_table_spec_updater_delete_field(
     spec_updater.update_table_spec(table=mock_iceberg_table)
     mock_iceberg_table.update_spec.assert_called_once()
     mock_iceberg_table.update_spec.return_value.__enter__.return_value.remove_field.assert_called_once_with(
-        name="category"
+        name="category",
     )
 
 
@@ -249,7 +268,10 @@ def test_iceberg_table_spec_updater_update_field(
     table_ = "handler_spec_updater_update"
     spec = iceberg_partitioning.PartitionSpec(
         iceberg_partitioning.PartitionField(
-            1, 1, name="timestamp", transform=transforms.HourTransform()
+            1,
+            1,
+            name="timestamp",
+            transform=transforms.HourTransform(),
         ),
     )
     table_slice = TableSlice(
@@ -274,7 +296,7 @@ def test_iceberg_table_spec_updater_update_field(
     spec_updater.update_table_spec(table=mock_iceberg_table)
     mock_iceberg_table.update_spec.assert_called_once()
     mock_iceberg_table.update_spec.return_value.__enter__.return_value.remove_field.assert_called_once_with(
-        name="timestamp"
+        name="timestamp",
     )
     mock_iceberg_table.update_spec.return_value.__enter__.return_value.add_field.assert_called_once_with(
         source_column_name="timestamp",
@@ -421,7 +443,8 @@ def test_iceberg_table_spec_updater_fails_with_bad_static_partition_data_type(
 
 
 def test_update_table_partition_spec(
-    table: iceberg_table.Table, partitioned_table_slice: TableSlice
+    table: iceberg_table.Table,
+    partitioned_table_slice: TableSlice,
 ):
     partitions.update_table_partition_spec(
         table=table,
@@ -433,7 +456,8 @@ def test_update_table_partition_spec(
 
 
 def test_update_table_partition_spec_with_retries(
-    table: iceberg_table.Table, partitioned_table_slice: TableSlice
+    table: iceberg_table.Table,
+    partitioned_table_slice: TableSlice,
 ):
     mock_table = mock.MagicMock()
     mock_update_method = mock.MagicMock()
@@ -458,7 +482,6 @@ def test_update_table_partition_spec_with_retries(
         table_slice=partitioned_table_slice,
         partition_spec_update_mode="update",
     )
-    partitioned_table_slice.partition_dimensions
     assert mock_update_method.add_field.call_count == 7
 
 
@@ -546,7 +569,7 @@ def test_dagster_partition_to_pyiceberg_expression_mapper_with_multiple_categori
             *[
                 E.GreaterThanOrEqual("timestamp", "2023-01-01T00:00:00"),
                 E.LessThan("timestamp", "2023-01-01T01:00:00"),
-            ]
+            ],
         ),
         E.Or(*[E.EqualTo("category", "A"), E.EqualTo("category", "B")]),
     ]

--- a/libraries/dagster-iceberg/tests/_utils/test_properties.py
+++ b/libraries/dagster-iceberg/tests/_utils/test_properties.py
@@ -96,12 +96,13 @@ def test_iceberg_table_property_updater_many_changes():
     )
     mock_iceberg_table = mock.MagicMock()
     table_property_updater.update_table_properties(
-        table=mock_iceberg_table, table_properties=properties_new
+        table=mock_iceberg_table,
+        table_properties=properties_new,
     )
     mock_iceberg_table.transaction.assert_called_once()
     mock_iceberg_table.transaction.return_value.__enter__.return_value.remove_properties.assert_called_once_with(
-        *["c"]
+        *["c"],
     )
     mock_iceberg_table.transaction.return_value.__enter__.return_value.set_properties.assert_called_once_with(
-        properties_new
+        properties_new,
     )

--- a/libraries/dagster-iceberg/tests/_utils/test_schema.py
+++ b/libraries/dagster-iceberg/tests/_utils/test_schema.py
@@ -12,12 +12,12 @@ def test_schema_differ_removed_fields():
         [
             pa.field("timestamp", pa.timestamp("ns")),
             pa.field("category", pa.string()),
-        ]
+        ],
     )
     schema_new = pa.schema(
         [
             pa.field("timestamp", pa.timestamp("ns")),
-        ]
+        ],
     )
     schema_differ = schema.SchemaDiffer(
         current_table_schema=schema_current,
@@ -32,14 +32,14 @@ def test_iceberg_schema_updater_add_column():
         [
             pa.field("timestamp", pa.timestamp("ns")),
             pa.field("category", pa.string()),
-        ]
+        ],
     )
     schema_new = pa.schema(
         [
             pa.field("timestamp", pa.timestamp("ns")),
             pa.field("category", pa.string()),
             pa.field("value", pa.float64()),
-        ]
+        ],
     )
     schema_updater = schema.IcebergTableSchemaUpdater(
         schema_differ=schema.SchemaDiffer(
@@ -52,7 +52,7 @@ def test_iceberg_schema_updater_add_column():
     schema_updater.update_table_schema(table=mock_iceberg_table)
     mock_iceberg_table.update_schema.assert_called_once()
     mock_iceberg_table.update_schema.return_value.__enter__.return_value.union_by_name.assert_called_once_with(
-        schema_new
+        schema_new,
     )
 
 
@@ -62,13 +62,13 @@ def test_iceberg_schema_updater_delete_column():
             pa.field("timestamp", pa.timestamp("ns")),
             pa.field("category", pa.string()),
             pa.field("value", pa.float64()),
-        ]
+        ],
     )
     schema_new = pa.schema(
         [
             pa.field("timestamp", pa.timestamp("ns")),
             pa.field("category", pa.string()),
-        ]
+        ],
     )
     schema_updater = schema.IcebergTableSchemaUpdater(
         schema_differ=schema.SchemaDiffer(
@@ -81,7 +81,7 @@ def test_iceberg_schema_updater_delete_column():
     schema_updater.update_table_schema(table=mock_iceberg_table)
     mock_iceberg_table.update_schema.assert_called_once()
     mock_iceberg_table.update_schema.return_value.__enter__.return_value.delete_column.assert_called_once_with(
-        "value"
+        "value",
     )
 
 
@@ -89,13 +89,13 @@ def test_iceberg_schema_updater_fails_with_error_update_mode():
     schema_current = pa.schema(
         [
             pa.field("timestamp", pa.timestamp("ns")),
-        ]
+        ],
     )
     schema_new = pa.schema(
         [
             pa.field("timestamp", pa.timestamp("ns")),
             pa.field("category", pa.string()),
-        ]
+        ],
     )
     schema_updater = schema.IcebergTableSchemaUpdater(
         schema_differ=schema.SchemaDiffer(
@@ -105,7 +105,10 @@ def test_iceberg_schema_updater_fails_with_error_update_mode():
         schema_update_mode="error",
     )
     mock_iceberg_table = mock.MagicMock()
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Schema spec update mode is set to 'error' but there are schema changes to the Iceberg table",
+    ):
         schema_updater.update_table_schema(table=mock_iceberg_table)
 
 
@@ -117,7 +120,7 @@ def test_update_table_schema(table: Table):
                 pa.field("timestamp", pa.timestamp("us")),
                 pa.field("category", pa.string()),
                 pa.field("new_value", pa.float64()),
-            ]
+            ],
         ),
         schema_update_mode="update",
     )
@@ -141,7 +144,7 @@ def test_update_table_schema_with_retries():
                 pa.field("timestamp", pa.timestamp("us")),
                 pa.field("category", pa.string()),
                 pa.field("new_value", pa.float64()),
-            ]
+            ],
         ),
         schema_update_mode="update",
     )
@@ -168,7 +171,7 @@ def test_update_table_schema_with_retries_fails():
                     pa.field("timestamp", pa.timestamp("us")),
                     pa.field("category", pa.string()),
                     pa.field("new_value", pa.float64()),
-                ]
+                ],
             ),
             schema_update_mode="update",
         )

--- a/libraries/dagster-iceberg/tests/_utils/test_transforms.py
+++ b/libraries/dagster-iceberg/tests/_utils/test_transforms.py
@@ -7,7 +7,7 @@ from dagster_iceberg._utils import transforms
 
 
 @pytest.mark.parametrize(
-    "start, end, expected_transformation",
+    ("start", "end", "expected_transformation"),
     [
         (
             dt.datetime(2023, 1, 1, 0, 0, 0),

--- a/libraries/dagster-iceberg/tests/io_managers/test_arrow_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_arrow_io_manager.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import Dict
 
 import pyarrow as pa
 import pytest
@@ -20,7 +19,9 @@ from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
 
 @pytest.fixture
 def io_manager(
-    catalog_name: str, namespace: str, catalog_config_properties: Dict[str, str]
+    catalog_name: str,
+    namespace: str,
+    catalog_config_properties: dict[str, str],
 ) -> IcebergPyarrowIOManager:
     return IcebergPyarrowIOManager(
         name=catalog_name,
@@ -35,27 +36,27 @@ def custom_db_io_manager(io_manager: IcebergPyarrowIOManager):
 
 
 # NB: iceberg table identifiers are namespace + asset names (see below)
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_df_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_df"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_plus_one_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_plus_one"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_hourly_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.hourly_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_daily_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.daily_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_multi_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.multi_partitioned"
 
@@ -101,17 +102,18 @@ def daily_partitioned(context: AssetExecutionContext) -> pa.Table:
     partitions_def=MultiPartitionsDefinition(
         partitions_defs={
             "date": DailyPartitionsDefinition(
-                start_date="2022-01-01", end_date="2022-01-10"
+                start_date="2022-01-01",
+                end_date="2022-01-10",
             ),
             "category": StaticPartitionsDefinition(["a", "b", "c"]),
-        }
+        },
     ),
     config_schema={"value": str},
     metadata={
         "partition_expr": {
             "date": "date_this",
             "category": "category_this",
-        }
+        },
     },
 )
 def multi_partitioned(context: AssetExecutionContext) -> pa.Table:
@@ -125,7 +127,7 @@ def multi_partitioned(context: AssetExecutionContext) -> pa.Table:
             "value": [value],
             "b": [1],
             "category_this": [category],
-        }
+        },
     )
 
 
@@ -163,7 +165,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -193,7 +195,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -230,7 +232,7 @@ def test_iceberg_io_manager_with_multipartitioned_assets(
             partition_key=key,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success

--- a/libraries/dagster-iceberg/tests/io_managers/test_base_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_base_io_manager.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import pytest
 from dagster import OutputContext, build_output_context
 from dagster._core.storage.db_io_manager import TableSlice
@@ -13,7 +11,9 @@ from dagster_iceberg.io_manager.base import IcebergDbClient
 
 @pytest.fixture
 def io_manager(
-    catalog_name: str, namespace: str, catalog_config_properties: Dict[str, str]
+    catalog_name: str,
+    namespace: str,
+    catalog_config_properties: dict[str, str],
 ) -> IcebergPyarrowIOManager:
     return IcebergPyarrowIOManager(
         name=catalog_name,
@@ -22,7 +22,7 @@ def io_manager(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def table_slice_unknown_schema() -> TableSlice:
     return TableSlice(
         table="some_table",
@@ -31,7 +31,7 @@ def table_slice_unknown_schema() -> TableSlice:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def table_slice_known_schema(namespace_name: str) -> TableSlice:
     return TableSlice(
         table="some_table",
@@ -57,7 +57,9 @@ def test_iceberg_db_client_with_known_schema(
     catalog: Catalog,
 ):
     iceberg_db_client.ensure_schema_exists(
-        context=output_context, table_slice=table_slice_known_schema, connection=catalog
+        context=output_context,
+        table_slice=table_slice_known_schema,
+        connection=catalog,
     )
 
 

--- a/libraries/dagster-iceberg/tests/io_managers/test_daft_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_daft_io_manager.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import Dict
 
 import daft as da
 import pytest
@@ -20,7 +19,9 @@ from dagster_iceberg.io_manager.daft import IcebergDaftIOManager
 
 @pytest.fixture
 def io_manager(
-    catalog_name: str, namespace: str, catalog_config_properties: Dict[str, str]
+    catalog_name: str,
+    namespace: str,
+    catalog_config_properties: dict[str, str],
 ) -> IcebergDaftIOManager:
     return IcebergDaftIOManager(
         name=catalog_name,
@@ -35,27 +36,27 @@ def custom_db_io_manager(io_manager: IcebergDaftIOManager):
 
 
 # NB: iceberg table identifiers are namespace + asset names (see below)
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_df_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_df"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_plus_one_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_plus_one"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_hourly_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.hourly_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_daily_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.daily_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_multi_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.multi_partitioned"
 
@@ -101,17 +102,18 @@ def daily_partitioned(context: AssetExecutionContext) -> da.DataFrame:
     partitions_def=MultiPartitionsDefinition(
         partitions_defs={
             "date": DailyPartitionsDefinition(
-                start_date="2022-01-01", end_date="2022-01-10"
+                start_date="2022-01-01",
+                end_date="2022-01-10",
             ),
             "category": StaticPartitionsDefinition(["a", "b", "c"]),
-        }
+        },
     ),
     config_schema={"value": str},
     metadata={
         "partition_expr": {
             "date": "date_this",
             "category": "category_this",
-        }
+        },
     },
 )
 def multi_partitioned(context: AssetExecutionContext) -> da.DataFrame:
@@ -125,7 +127,7 @@ def multi_partitioned(context: AssetExecutionContext) -> da.DataFrame:
             "value": [value],
             "b": [1],
             "category_this": [category],
-        }
+        },
     )
 
 
@@ -163,7 +165,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -193,7 +195,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -230,7 +232,7 @@ def test_iceberg_io_manager_with_multipartitioned_assets(
             partition_key=key,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success

--- a/libraries/dagster-iceberg/tests/io_managers/test_pandas_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_pandas_io_manager.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import Dict
 
 import pandas as pd
 import pyarrow as pa
@@ -21,7 +20,9 @@ from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
 
 @pytest.fixture
 def io_manager(
-    catalog_name: str, namespace: str, catalog_config_properties: Dict[str, str]
+    catalog_name: str,
+    namespace: str,
+    catalog_config_properties: dict[str, str],
 ) -> IcebergPandasIOManager:
     return IcebergPandasIOManager(
         name=catalog_name,
@@ -36,27 +37,27 @@ def custom_db_io_manager(io_manager: IcebergPandasIOManager):
 
 
 # NB: iceberg table identifiers are namespace + asset names (see below)
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_df_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_df"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_plus_one_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_plus_one"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_hourly_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.hourly_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_daily_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.daily_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_multi_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.multi_partitioned"
 
@@ -83,7 +84,7 @@ def hourly_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     value = context.op_execution_context.op_config["value"]
 
     return pa.Table.from_pydict(
-        {"partition": [partition], "value": [value], "b": [1]}
+        {"partition": [partition], "value": [value], "b": [1]},
     ).to_pandas()
 
 
@@ -98,7 +99,7 @@ def daily_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     value = context.op_execution_context.op_config["value"]
 
     return pa.Table.from_pydict(
-        {"partition": [partition], "value": [value], "b": [1]}
+        {"partition": [partition], "value": [value], "b": [1]},
     ).to_pandas()
 
 
@@ -107,17 +108,18 @@ def daily_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
     partitions_def=MultiPartitionsDefinition(
         partitions_defs={
             "date": DailyPartitionsDefinition(
-                start_date="2022-01-01", end_date="2022-01-10"
+                start_date="2022-01-01",
+                end_date="2022-01-10",
             ),
             "category": StaticPartitionsDefinition(["a", "b", "c"]),
-        }
+        },
     ),
     config_schema={"value": str},
     metadata={
         "partition_expr": {
             "date": "date_this",
             "category": "category_this",
-        }
+        },
     },
 )
 def multi_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
@@ -131,7 +133,7 @@ def multi_partitioned(context: AssetExecutionContext) -> pd.DataFrame:
             "value": [value],
             "b": [1],
             "category_this": [category],
-        }
+        },
     ).to_pandas()
 
 
@@ -169,7 +171,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -199,7 +201,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -236,7 +238,7 @@ def test_iceberg_io_manager_with_multipartitioned_assets(
             partition_key=key,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success

--- a/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import Dict
 
 import polars as pl
 import pytest
@@ -20,7 +19,9 @@ from dagster_iceberg.io_manager.polars import IcebergPolarsIOManager
 
 @pytest.fixture
 def io_manager(
-    catalog_name: str, namespace: str, catalog_config_properties: Dict[str, str]
+    catalog_name: str,
+    namespace: str,
+    catalog_config_properties: dict[str, str],
 ) -> IcebergPolarsIOManager:
     return IcebergPolarsIOManager(
         name=catalog_name,
@@ -35,27 +36,27 @@ def custom_db_io_manager(io_manager: IcebergPolarsIOManager):
 
 
 # NB: iceberg table identifiers are namespace + asset names (see below)
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_df_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_df"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_b_plus_one_table_identifier(namespace: str) -> str:
     return f"{namespace}.b_plus_one"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_hourly_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.hourly_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_daily_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.daily_partitioned"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def asset_multi_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.multi_partitioned"
 
@@ -105,17 +106,18 @@ def daily_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
     partitions_def=MultiPartitionsDefinition(
         partitions_defs={
             "date": DailyPartitionsDefinition(
-                start_date="2022-01-01", end_date="2022-01-10"
+                start_date="2022-01-01",
+                end_date="2022-01-10",
             ),
             "category": StaticPartitionsDefinition(["a", "b", "c"]),
-        }
+        },
     ),
     config_schema={"value": str},
     metadata={
         "partition_expr": {
             "date": "date_this",
             "category": "category_this",
-        }
+        },
     },
 )
 def multi_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
@@ -129,7 +131,7 @@ def multi_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
             "value": [value],
             "b": [1],
             "category_this": [category],
-        }
+        },
     )
 
 
@@ -167,7 +169,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -197,7 +199,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
             partition_key=date,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success
@@ -234,7 +236,7 @@ def test_iceberg_io_manager_with_multipartitioned_assets(
             partition_key=key,
             resources=resource_defs,
             run_config={
-                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}
+                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}},
             },
         )
         assert res.success

--- a/libraries/dagster-iceberg/tests/test_resource.py
+++ b/libraries/dagster-iceberg/tests/test_resource.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import pyarrow as pa
 import pytest
 from dagster import asset, materialize
@@ -15,36 +13,40 @@ def table_name() -> str:
     return "resource_data"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def table_identifier(namespace: str, table_name: str) -> str:
     return f"{namespace}.{table_name}"
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def create_table_in_catalog(
-    catalog: Catalog, table_identifier: str, data_schema: pa.Schema
+    catalog: Catalog,
+    table_identifier: str,
+    data_schema: pa.Schema,
 ):
     catalog.create_table(table_identifier, data_schema)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def iceberg_table(
-    create_table_in_catalog, catalog: Catalog, table_identifier: str
+    create_table_in_catalog,
+    catalog: Catalog,
+    table_identifier: str,
 ) -> Table:
     return catalog.load_table(table_identifier)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def append_data_to_table(iceberg_table: Table, data: pa.Table):
     iceberg_table.append(df=data)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def pyiceberg_table_resource(
     catalog_name: str,
     namespace: str,
     table_name: str,
-    catalog_config_properties: Dict[str, str],
+    catalog_config_properties: dict[str, str],
 ) -> IcebergTableResource:
     return IcebergTableResource(
         name=catalog_name,

--- a/libraries/dagster-notdiamond/examples/example_book_reviews_summary.py
+++ b/libraries/dagster-notdiamond/examples/example_book_reviews_summary.py
@@ -61,7 +61,7 @@ def book_reviews_summary(
     prompt = f"""
     Given the book reviews for {book_review_data["title"]}, provide a detailed summary:
 
-    {'|'.join([r['content'] for r in book_review_data["reviews"]])}
+    {"|".join([r["content"] for r in book_review_data["reviews"]])}
     """
 
     with notdiamond.get_client(context) as client:


### PR DESCRIPTION
## Summary & Motivation

I planned to just drop config for other tools:

```toml
[tool.black]
line-length = 88
exclude = '''
^/(
  (
      \.eggs         # exclude a few common directories in the
    | \.git          # root of the project
    | \.hg
    | \.mypy_cache
    | \.venv
    | _build
    | build
    | dist
    | .notebooks
    | .nox
  )
)
'''

[tool.isort]
profile = "black"
extend_skip = [".notebooks", ".nox", ".venv"]

[tool.mypy]
exclude = [
  '^docs/'
]
ignore_missing_imports = true
explicit_package_bases = true
```

...but then I ended up adding a bunch of Ruff rules and fixing resulting violations. Should be a general positive (e.g. don't use f-strings in logging, some things are more Pythonic or more performant, removed random `# noqa`s, etc.).

## How I Tested These Changes

CI
