### PR TITLE
[dagster-iceberg] Do not require `dagster-pyspark`

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/Makefile
+++ b/libraries/dagster-iceberg/kitchen-sink/Makefile
@@ -4,11 +4,9 @@ up:
 catalog: up
 	python -c 'from pyiceberg.catalog import load_catalog; catalog = load_catalog("rest", **{"type": "rest", "uri": "http://localhost:8181", "s3.endpoint": "http://localhost:9000", "s3.access-key-id": "admin", "s3.secret-access-key": "password"}); catalog.create_namespace_if_not_exists("nyc")'
 
-dev: export SPARK_REMOTE = sc://localhost
 dev: catalog
 	dagster dev -f kitchen_sink.py
 
-test: export SPARK_REMOTE = sc://localhost
 test:
 	uv run pytest
 

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -88,7 +88,7 @@ defs = Definitions(
         "spark_iceberg_io_manager": SparkIcebergIOManager(
             catalog_name=CATALOG_NAME,
             namespace=NAMESPACE,
-            spark_config={"spark.remote": "sc://localhost"},
+            remote_url="sc://localhost",
         ),
     },
 )

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -42,7 +42,7 @@ def combined_nyc_taxi_data(raw_nyc_taxi_data: dict[str, pl.LazyFrame]) -> pl.Laz
 
 @asset(io_manager_key="iceberg_polars_io_manager")
 def reloaded_nyc_taxi_data(combined_nyc_taxi_data: pl.LazyFrame) -> None:
-    pass
+    print(combined_nyc_taxi_data.describe())  # noqa: T201
 
 
 @asset(deps=["combined_nyc_taxi_data"], io_manager_key="spark_iceberg_io_manager")

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -84,10 +84,11 @@ defs = Definitions(
             config=catalog_config,
             namespace=NAMESPACE,
         ),
-        "pyspark": PySparkResource(spark_config={}),
+        "pyspark": PySparkResource(spark_config={"spark.remote": "sc://localhost"}),
         "spark_iceberg_io_manager": SparkIcebergIOManager(
             catalog_name=CATALOG_NAME,
             namespace=NAMESPACE,
+            spark_config={"spark.remote": "sc://localhost"},
         ),
     },
 )

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 import pytest
@@ -9,8 +8,6 @@ from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 
 MAKEFILE_DIR = file_relative_path(__file__, "../")
-
-os.environ["SPARK_REMOTE"] = "sc://localhost"
 
 
 @pytest.fixture(autouse=True)

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -48,6 +48,24 @@ def test_polars():
             assert instance.get_latest_materialization_event(asset_key) is not None
 
 
+def test_polars_partitioned():
+    with instance_for_test() as instance:
+        for partition in ["part.0", "part.1"]:
+            result = invoke_materialize(
+                "*reloaded_partitioned_nyc_taxi_data", partition=partition
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for asset_key in [
+            AssetKey("partitioned_nyc_taxi_data"),
+            AssetKey("reloaded_partitioned_nyc_taxi_data"),
+        ]:
+            assert instance.get_latest_materialization_event(asset_key) is not None
+            partitions = instance.get_materialized_partitions(asset_key)
+            for partition in ["part.0", "part.1"]:
+                assert partition in partitions
+
+
 def test_spark():
     with instance_for_test() as instance:
         result = invoke_materialize("*reloaded_nyc_taxi_data_spark")

--- a/libraries/dagster-iceberg/pyproject.toml
+++ b/libraries/dagster-iceberg/pyproject.toml
@@ -42,8 +42,7 @@ polars = [
   "polars>=1.0.0",
 ]
 spark = [
-  "dagster-pyspark>=0.26.1",
-  "pyspark[connect]>=3.5.4",
+  "pyspark[connect]>=3.4.0",
 ]
 
 [tool.ruff]
@@ -128,6 +127,7 @@ docs = [
 dev = [
   "dagit>=1.8.8",
   "dagster-polars>=0.26.1",
+  "dagster-pyspark>=0.26.1",
   "fsspec[http]>=2025.2.0",
   "psycopg2-binary>=2.9.10",
   "pyright>=1.1.385",

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
@@ -89,8 +89,7 @@ class SparkIcebergDbClient(DbClient[SparkSession]):
         ):
             builder.config(map=cast(dict[str, "OptionalPrimitiveType"], spark_config))
 
-        # TODO(deepyaman): Don't hard code the Spark Connect remote URL.
-        yield builder.remote("sc://localhost").getOrCreate()
+        yield builder.getOrCreate()
 
 
 class SparkIcebergIOManager(ConfigurableIOManagerFactory):

--- a/libraries/dagster-iceberg/uv.lock
+++ b/libraries/dagster-iceberg/uv.lock
@@ -484,7 +484,6 @@ polars = [
     { name = "polars" },
 ]
 spark = [
-    { name = "dagster-pyspark" },
     { name = "pyspark", extra = ["connect"] },
 ]
 
@@ -492,6 +491,7 @@ spark = [
 dev = [
     { name = "dagit" },
     { name = "dagster-polars" },
+    { name = "dagster-pyspark" },
     { name = "fsspec", extra = ["http"] },
     { name = "psycopg2-binary" },
     { name = "pyright" },
@@ -510,13 +510,12 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "dagster", specifier = ">=1.8.2" },
-    { name = "dagster-pyspark", marker = "extra == 'spark'", specifier = ">=0.26.1" },
     { name = "getdaft", marker = "extra == 'daft'", specifier = ">=0.3.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.0.0" },
     { name = "pendulum", specifier = ">=3.0.0" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0.0" },
     { name = "pyiceberg", extras = ["pyarrow"], specifier = ">=0.8" },
-    { name = "pyspark", extras = ["connect"], marker = "extra == 'spark'", specifier = ">=3.5.4" },
+    { name = "pyspark", extras = ["connect"], marker = "extra == 'spark'", specifier = ">=3.4.0" },
     { name = "tenacity", specifier = ">=8.5.0" },
 ]
 
@@ -524,6 +523,7 @@ requires-dist = [
 dev = [
     { name = "dagit", specifier = ">=1.8.8" },
     { name = "dagster-polars", specifier = ">=0.26.1" },
+    { name = "dagster-pyspark", specifier = ">=0.26.1" },
     { name = "fsspec", extras = ["http"], specifier = ">=2025.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pyright", specifier = ">=1.1.385" },


### PR DESCRIPTION
## Summary & Motivation

Remove dependency on `dagster-pyspark` that currently only provides the `spark_session_from_config()` function.

## How I Tested These Changes

Temporarily supplied `spark.remote` via newly-added `spark_config`.