### PR TITLE
[dagster-iceberg] Support configuring Spark remote

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -88,7 +88,7 @@ defs = Definitions(
         "spark_iceberg_io_manager": SparkIcebergIOManager(
             catalog_name=CATALOG_NAME,
             namespace=NAMESPACE,
-            spark_config={"spark.remote": "sc://localhost"},
+            remote_url="sc://localhost",
         ),
     },
 )

--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -42,7 +42,7 @@ def combined_nyc_taxi_data(raw_nyc_taxi_data: dict[str, pl.LazyFrame]) -> pl.Laz
 
 @asset(io_manager_key="iceberg_polars_io_manager")
 def reloaded_nyc_taxi_data(combined_nyc_taxi_data: pl.LazyFrame) -> None:
-    pass
+    print(combined_nyc_taxi_data.describe())  # noqa: T201
 
 
 @asset(deps=["combined_nyc_taxi_data"], io_manager_key="spark_iceberg_io_manager")

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -48,6 +48,24 @@ def test_polars():
             assert instance.get_latest_materialization_event(asset_key) is not None
 
 
+def test_polars_partitioned():
+    with instance_for_test() as instance:
+        for partition in ["part.0", "part.1"]:
+            result = invoke_materialize(
+                "*reloaded_partitioned_nyc_taxi_data", partition=partition
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for asset_key in [
+            AssetKey("partitioned_nyc_taxi_data"),
+            AssetKey("reloaded_partitioned_nyc_taxi_data"),
+        ]:
+            assert instance.get_latest_materialization_event(asset_key) is not None
+            partitions = instance.get_materialized_partitions(asset_key)
+            for partition in ["part.0", "part.1"]:
+                assert partition in partitions
+
+
 def test_spark():
     with instance_for_test() as instance:
         result = invoke_materialize("*reloaded_nyc_taxi_data_spark")


### PR DESCRIPTION
## Summary & Motivation

Add `remote_url` that gets passed to `builder.remote()`.

Since it's configured later, it will override any `spark.remote` in `spark_config`.

## How I Tested These Changes

Updated kitchen sink.
