### PR TITLE
Update Java pipes to support integration with Scala-Spark

### DIFF
--- a/libraries/pipes/implementations/java/build.gradle
+++ b/libraries/pipes/implementations/java/build.gradle
@@ -7,8 +7,14 @@ plugins {
 
 import com.vanniktech.maven.publish.SonatypeHost
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 mavenPublishing {
-    coordinates("io.dagster", "pipes", "1.0.0")
+    coordinates("io.dagster", "pipes", "1.1.0")
     signAllPublications()
 
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
@@ -50,7 +56,7 @@ dependencies {
     annotationProcessor 'info.picocli:picocli-codegen:4.7.6'
     implementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
     implementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
-    implementation group: 'org.mockito', name: 'mockito-core', version: '2.7.5'
+    implementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
     implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.17'
 }
 

--- a/libraries/pipes/implementations/java/build.gradle
+++ b/libraries/pipes/implementations/java/build.gradle
@@ -9,7 +9,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(8)
     }
 }
 

--- a/libraries/pipes/implementations/java/settings.gradle
+++ b/libraries/pipes/implementations/java/settings.gradle
@@ -1,1 +1,6 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+}
+
 rootProject.name = 'dagster-pipes-java'
+

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/loaders/PipesCliArgsParamsLoader.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/loaders/PipesCliArgsParamsLoader.java
@@ -1,0 +1,45 @@
+package io.dagster.pipes.loaders;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.dagster.pipes.DagsterPipesException;
+import io.dagster.pipes.utils.PipesUtils;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+public class PipesCliArgsParamsLoader implements PipesParamsLoader {
+    @Option(
+        names = "--dagster-pipes-context", 
+        description = "base64 encoded and zlib-compressed context loader params",
+        defaultValue = "")
+    String pipes_context_params;
+
+    @Option(
+        names = "--dagster-pipes-messages", 
+        description = "base64 encoded and zlib-compressed messages params",
+        defaultValue = "")
+    String pipes_messages_params;
+    
+    public PipesCliArgsParamsLoader(String[] args) {
+        CommandLine commandLine = new CommandLine(this);
+        commandLine.setUnmatchedArgumentsAllowed(true);
+        commandLine.setUnmatchedOptionsArePositionalParams(true);
+
+        commandLine.parseArgs(args);
+    }
+
+    public boolean isDagsterPipesProcess() {
+        return !pipes_context_params.equals("");
+    }
+
+    @Override
+    public Optional<Map<String, Object>> loadContextParams() throws DagsterPipesException {
+        return Optional.of(PipesUtils.decodeParam(pipes_context_params));
+    }
+
+    @Override
+    public Optional<Map<String, Object>> loadMessagesParams() throws DagsterPipesException {
+        return Optional.of(PipesUtils.decodeParam(pipes_messages_params));
+    }
+}

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/utils/PipesUtils.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/utils/PipesUtils.java
@@ -1,6 +1,14 @@
 package io.dagster.pipes.utils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
 import java.util.Map;
+import java.util.zip.InflaterInputStream;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.dagster.pipes.DagsterPipesException;
 import io.dagster.pipes.data.PipesConstants;
@@ -48,5 +56,35 @@ public final class PipesUtils {
         return containsNonPipesMetadata
             ? MetadataBuilder.buildFrom(metadataMapping)
             : (Map<String, PipesMetadata>) metadataMapping;
+    }
+
+    public static Map<String, Object> decodeParam(String rawValue) throws DagsterPipesException {
+        try {
+            byte[] base64Decoded = Base64.getDecoder().decode(rawValue);
+            byte[] zlibDecompressed = zlibDecompress(base64Decoded);
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(
+                    zlibDecompressed,
+                    new TypeReference<Map<String, Object>>() {}
+            );
+        } catch (IOException ioe) {
+            throw new DagsterPipesException("Failed to decompress parameters", ioe);
+        }
+    }
+
+    public static byte[] zlibDecompress(byte[] data) throws IOException {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+             InflaterInputStream filterStream = new InflaterInputStream(inputStream);
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+            byte[] buffer = new byte[1024];
+            int readChunk;
+
+            while ((readChunk = filterStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, readChunk);
+            }
+
+            return outputStream.toByteArray();
+        }
     }
 }

--- a/libraries/pipes/nix/shells/java/default.nix
+++ b/libraries/pipes/nix/shells/java/default.nix
@@ -11,7 +11,7 @@ in
     # Create your shell
     packages = with pkgs; [
       zsh
-      jdk21
+      jdk17
       uv
       python
     ];


### PR DESCRIPTION
## Summary & Motivation

A) change the compilation target to java17 (Apache Spark doesn't support anything newer).
B) Upgrade the mockito version (`2.7.5->4.11.0`). mockito 2.7.5 is VERY old, and fails when trying to mock newer java classes.
C) Add `PipesCliArgsParamsLoader` (setting environment variables in spark jobs can be complicated - so CLI arguments is preferred for spark workloads).

## How I Tested These Changes

I used the resulting binary to succesfully run and test a scala-spark workload on a local spark cluster. 

## Changelog

change the compilation target to java17
Upgrade the mockito version (`2.7.5->4.11.0`)
Add the PipesCliArgsParamsLoader class