### PR TITLE
[dagster-iceberg] Add partitioned Polars data test

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -48,6 +48,24 @@ def test_polars():
             assert instance.get_latest_materialization_event(asset_key) is not None
 
 
+def test_polars_partitioned():
+    with instance_for_test() as instance:
+        for partition in ["part.0", "part.1"]:
+            result = invoke_materialize(
+                "*reloaded_partitioned_nyc_taxi_data", partition=partition
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for asset_key in [
+            AssetKey("partitioned_nyc_taxi_data"),
+            AssetKey("reloaded_partitioned_nyc_taxi_data"),
+        ]:
+            assert instance.get_latest_materialization_event(asset_key) is not None
+            partitions = instance.get_materialized_partitions(asset_key)
+            for partition in ["part.0", "part.1"]:
+                assert partition in partitions
+
+
 def test_spark():
     with instance_for_test() as instance:
         result = invoke_materialize("*reloaded_nyc_taxi_data_spark")


### PR DESCRIPTION
## Summary & Motivation

Make sure existing I/O managers support partitioning properly before adding it for Spark.

## How I Tested These Changes

Manually, local CI, CI.

I'm not confident it's reading back the data properly, but at least it's reading schema, and I can verify the data is there using Spark—which is currently more important. Will revisit this down the line.
