### PR TITLE
[dagster-iceberg] Ensure partitioned reads, writes

### DIFF
--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
@@ -70,10 +70,7 @@ def table_writer(
     #  even though it's the default value.
     partition_exprs: list[str] | None = None
     partition_dimensions: Sequence[TablePartitionDimension] | None = None
-    if (
-        table_slice.partition_dimensions is not None
-        and len(table_slice.partition_dimensions) != 0
-    ):
+    if table_slice.partition_dimensions:
         partition_exprs = [p.partition_expr for p in table_slice.partition_dimensions]
         if any(p is None for p in partition_exprs):
             raise ValueError(

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/partitions.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/partitions.py
@@ -265,16 +265,13 @@ class PartitionMapper:
         # In practice, partition_dimensions is an empty list and not None
         #  But the type hint is Optional[Sequence[TablePartitionDimension]]
         partition_dimensions: Sequence[TablePartitionDimension] | None = None
-        if not (
-            self.table_slice.partition_dimensions is None
-            or len(self.table_slice.partition_dimensions) == 0
-        ):
+        if self.table_slice.partition_dimensions:
             partition_dimensions = self.table_slice.partition_dimensions
-        if partition_dimensions is None and not allow_empty_dagster_partitions:
-            raise ValueError(
-                "Partition dimensions are not set. Please set the 'partition_dimensions' field in the TableSlice.",
-            )
         if partition_dimensions is None:
+            if not allow_empty_dagster_partitions:
+                raise ValueError(
+                    "Partition dimensions are not set. Please set the 'partition_dimensions' field in the TableSlice.",
+                )
             return []
         # Check if table columns have the correct data types
         for partition in partition_dimensions:

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
@@ -39,11 +39,7 @@ class SparkIcebergTypeHandler(DbTypeHandler[DataFrame]):
         table_exists = connection.catalog.tableExists(table_name)
         writer = obj.writeTo(table_name)
         mode = "overwritePartitions" if table_exists else "create"
-        if (
-            table_slice.partition_dimensions
-            and len(table_slice.partition_dimensions) > 0
-            and mode == "create"
-        ):
+        if table_slice.partition_dimensions and mode == "create":
             writer = writer.partitionedBy(
                 *[
                     partition_dimension.partition_expr
@@ -79,10 +75,7 @@ class SparkIcebergDbClient(DbClient[SparkSession]):
     def get_select_statement(table_slice: TableSlice) -> str:
         col_str = ", ".join(table_slice.columns) if table_slice.columns else "*"
 
-        if (
-            table_slice.partition_dimensions
-            and len(table_slice.partition_dimensions) > 0
-        ):
+        if table_slice.partition_dimensions:
             query = f"SELECT {col_str} FROM {table_slice.schema}.{table_slice.table} WHERE\n"
             return query + _partition_where_clause(table_slice.partition_dimensions)
 


### PR DESCRIPTION
## Summary & Motivation

Fix bugs wherein:

- Table wasn't being created in a partition-aware manner. Now, it implements the `partitionedBy` method as in https://iceberg.apache.org/docs/1.8.0/spark-writes/#creating-tables, but it isn't set up yet to handle time-based partitions (separate PR incoming, where I'll also test that).
- Even after creating the table with partitions, it was reading the full table. This _looked_ right before this PR, because of the sequence in which things were being run (write data for `part.0`, read data for `part.0`, overwrite the whole table with data for `part.1` because there was no partitioning, read data for `part.1`; however, when we actually enabled partitioning, the second read was returning data for `part.0` and `part.1` combined). Eventually, need to add some unit tests or make sure the behavior is correct in tests.

## How I Tested These Changes

Manually. We can see the partitioned structure of the table produced by the Spark Iceberg I/O manager now:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/91d3b9ce-1994-41a6-bba1-eb69032779be" />

We also see correct row counts on re-read:

```bash
2025-03-31 21:25:27 -0600 - dagster.daemon.BackfillDaemon - INFO - Overall backfill status:
**Materialized assets:**
- partitioned_nyc_taxi_data: {part.0}
- partitioned_nyc_taxi_data_spark: {part.0}
**Failed assets and their downstream assets:**
None
**Assets requested or in progress:**
- partitioned_nyc_taxi_data: {part.1}
- reloaded_partitioned_nyc_taxi_data_spark: {part.0, part.1}
- partitioned_nyc_taxi_data_spark: {part.1}

2025-03-31 21:25:27 -0600 - dagster.daemon.QueuedRunCoordinatorDaemon - INFO - 1 runs are currently in progress. Maximum is 1, won't launch more.
+-------+------------------+------------------+------------------+-----------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+-------------------+-------------------+------------------+-------------------+---------------------+------------------+-------------+
|summary|          VendorID|   passenger_count|     trip_distance| pickup_longitude|   pickup_latitude|        RateCodeID|store_and_fwd_flag| dropoff_longitude|  dropoff_latitude|      payment_type|       fare_amount|              extra|            mta_tax|        tip_amount|       tolls_amount|improvement_surcharge|      total_amount|partition_key|
+-------+------------------+------------------+------------------+-----------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+-------------------+-------------------+------------------+-------------------+---------------------+------------------+-------------+
|  count|            837469|            837469|            837469|           837469|            837469|            837469|            837469|            837469|            837469|            837469|            837469|             837469|             837469|            837469|             837469|               837466|            837469|       837469|
|   mean|1.5341367859586443| 1.778450306817327|17.462559043976082|-72.4375410835146|39.903617520279376|1.0459049827516003|              NULL|-72.45346528052157| 39.91473384198948| 1.497164671169918|12.449328106476141| 0.3278631806072822|  0.497004068210286|1.2975351804063733|0.25718013442869236|  0.15866399352430735|15.126489326866015|         NULL|
| stddev|0.4988336165213876|1.3624639007587933|13112.840578734638| 10.5469333490201| 5.810095196814098|0.6444199221544762|              NULL|10.489860458722443| 5.796535629965943|0.5140776111183173|11.229643405709327|0.33263591034315615|0.04057108564623143|2.4462038329091875|   1.43132509910023|  0.14974966441828633|13.158039816548289|         NULL|
|    min|                 1|                 0|               0.0|-79.7322769165039|               0.0|                 1|                 N|-152.0340118408203|-9.029156684875488|                 1|            -100.0|               -1.0|               -0.5|            -92.42|               -8.0|                  0.0|            -100.3|       part.0|
|    max|                 2|                 9|             1.2E7|              0.0|57.385520935058594|                99|                 Y|  85.2740249633789| 459.5333251953125|                 4|            3005.5|                9.0|                0.5|             850.0|              533.0|                  0.3|           3006.35|       part.0|
+-------+------------------+------------------+------------------+-----------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+-------------------+-------------------+------------------+-------------------+---------------------+------------------+-------------+

2025-03-31 21:25:29 -0600 - dagster - DEBUG - __ASSET_JOB - 5fc877af-8e52-4ce5-8a88-aee8128934e9 - 2630 - reloaded_partitioned_nyc_taxi_data_spark - STEP_OUTPUT - Yielded output "result" of type "Nothing". (Type check passed).
2025-03-31 21:25:29 -0600 - dagster - DEBUG - __ASSET_JOB - 5fc877af-8e52-4ce5-8a88-aee8128934e9 - 2630 - reloaded_partitioned_nyc_taxi_data_spark - ASSET_MATERIALIZATION - Materialized value reloaded_partitioned_nyc_taxi_data_spark.
2025-03-31 21:25:29 -0600 - dagster - DEBUG - __ASSET_JOB - 5fc877af-8e52-4ce5-8a88-aee8128934e9 - 2630 - reloaded_partitioned_nyc_taxi_data_spark - STEP_SUCCESS - Finished execution of step "reloaded_partitioned_nyc_taxi_data_spark" in 4.67s.

[...]

2025-03-31 21:25:48 -0600 - dagster - DEBUG - __ASSET_JOB - 6ee95702-91cf-4d1e-86f6-b56a5f3364ad - 2658 - reloaded_partitioned_nyc_taxi_data_spark - LOADED_INPUT - Loaded input "partitioned_nyc_taxi_data_spark" using input manager "spark_iceberg_io_manager", from output "result" of step "partitioned_nyc_taxi_data_spark"
2025-03-31 21:25:48 -0600 - dagster - DEBUG - __ASSET_JOB - 6ee95702-91cf-4d1e-86f6-b56a5f3364ad - 2658 - reloaded_partitioned_nyc_taxi_data_spark - STEP_INPUT - Got input "partitioned_nyc_taxi_data_spark" of type "DataFrame". (Type check passed).
2025-03-31 21:25:53 -0600 - dagster.daemon.QueuedRunCoordinatorDaemon - INFO - 1 runs are currently in progress. Maximum is 1, won't launch more.
+-------+------------------+------------------+------------------+------------------+-----------------+------------------+------------------+------------------+-----------------+------------------+------------------+-------------------+--------------------+------------------+-------------------+---------------------+------------------+-------------+
|summary|          VendorID|   passenger_count|     trip_distance|  pickup_longitude|  pickup_latitude|        RateCodeID|store_and_fwd_flag| dropoff_longitude| dropoff_latitude|      payment_type|       fare_amount|              extra|             mta_tax|        tip_amount|       tolls_amount|improvement_surcharge|      total_amount|partition_key|
+-------+------------------+------------------+------------------+------------------+-----------------+------------------+------------------+------------------+-----------------+------------------+------------------+-------------------+--------------------+------------------+-------------------+---------------------+------------------+-------------+
|  count|            878648|            878648|            878648|            878648|           878648|            878648|            878648|            878648|           878648|            878648|            878648|             878648|              878648|            878648|             878648|               878648|            878648|       878648|
|   mean|1.5166005044113229|1.7211044695941946|16.675535242781283|-72.76287960027796|40.08509292996839| 1.045695204450474|              NULL|-72.81564419169554|40.11409149002685|1.4505877211351985|12.107031268494296|0.19164868070034868| 0.49760484289499324|1.4029898207243219|0.29616311651509536|  0.19666339649015122|14.793843530163459|         NULL|
| stddev|0.4997246316402858| 1.343999010919075| 5777.535969868754| 9.377506092037118| 5.16613734205976|0.6788634176852496|              NULL| 9.181635007822821|5.058202713714503|  0.50896642912193| 11.14530963400288| 0.2989651114701565|0.036525433839010274|2.5726973101981536| 1.3622631793862199|   0.1425571834642834| 13.47527040132384|         NULL|
|    min|                 1|                 0|               0.0|-84.05986785888672|              0.0|                 1|                 N|-93.57595825195312|              0.0|                 1|            -250.0|               -1.0|                -0.5|              -2.5|             -11.75|                  0.0|            -250.3|       part.1|
|    max|                 2|                 8|         3180000.0|               0.0|55.78241348266602|                99|                 Y|               0.0|54.48493957519531|                 4|             900.0|                7.0|                 0.5|            606.57|              95.33|                  0.3|             900.3|       part.1|
+-------+------------------+------------------+------------------+------------------+-----------------+------------------+------------------+------------------+-----------------+------------------+------------------+-------------------+--------------------+------------------+-------------------+---------------------+------------------+-------------+

2025-03-31 21:25:53 -0600 - dagster - DEBUG - __ASSET_JOB - 6ee95702-91cf-4d1e-86f6-b56a5f3364ad - 2658 - reloaded_partitioned_nyc_taxi_data_spark - STEP_OUTPUT - Yielded output "result" of type "Nothing". (Type check passed).
2025-03-31 21:25:53 -0600 - dagster - DEBUG - __ASSET_JOB - 6ee95702-91cf-4d1e-86f6-b56a5f3364ad - 2658 - reloaded_partitioned_nyc_taxi_data_spark - ASSET_MATERIALIZATION - Materialized value reloaded_partitioned_nyc_taxi_data_spark.
2025-03-31 21:25:53 -0600 - dagster - DEBUG - __ASSET_JOB - 6ee95702-91cf-4d1e-86f6-b56a5f3364ad - 2658 - reloaded_partitioned_nyc_taxi_data_spark - STEP_SUCCESS - Finished execution of step "reloaded_partitioned_nyc_taxi_data_spark" in 4.32s.
```