### PR TITLE
[dagster-iceberg] Check 2D partitioning with Spark

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
+++ b/libraries/dagster-iceberg/kitchen-sink/kitchen_sink.py
@@ -176,6 +176,20 @@ def multi_partitioned_nyc_taxi_data_spark(
     )
 
 
+@dg.asset(
+    metadata={
+        "partition_expr": {"daily": DAILY_PARTITION_KEY, "static": STATIC_PARTITION_KEY}
+    },
+    io_manager_key="spark_iceberg_io_manager",
+    partitions_def=multi_partitions,
+    group_name="spark",
+)
+def reloaded_multi_partitioned_nyc_taxi_data_spark(
+    multi_partitioned_nyc_taxi_data_spark: DataFrame,
+) -> None:
+    multi_partitioned_nyc_taxi_data_spark.describe().show()
+
+
 catalog_config = IcebergCatalogConfig(
     properties={
         "type": "rest",
@@ -201,6 +215,7 @@ defs = dg.Definitions(
         static_partitioned_nyc_taxi_data_spark,
         reloaded_static_partitioned_nyc_taxi_data_spark,
         multi_partitioned_nyc_taxi_data_spark,
+        reloaded_multi_partitioned_nyc_taxi_data_spark,
     ],
     resources={
         "polars_parquet_io_manager": PolarsParquetIOManager(

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -84,6 +84,37 @@ def test_polars_multi_partitioned():
                 assert partition in partitions
 
 
+def test_polars_daily_partitioned():
+    with instance_for_test() as instance:
+        for partition in [
+            "2015-01-01|part.0",
+            "2015-01-01|part.1",
+            "2015-01-02|part.0",
+            "2015-01-02|part.1",
+        ]:
+            result = invoke_materialize(
+                "multi_partitioned_nyc_taxi_data", partition=partition
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for partition in ["2015-01-01", "2015-01-02"]:
+            result = invoke_materialize(
+                "daily_partitioned_nyc_taxi_data,"
+                "reloaded_daily_partitioned_nyc_taxi_data",
+                partition=partition,
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for asset_key in [
+            AssetKey("daily_partitioned_nyc_taxi_data"),
+            AssetKey("reloaded_daily_partitioned_nyc_taxi_data"),
+        ]:
+            assert instance.get_latest_materialization_event(asset_key) is not None
+            partitions = instance.get_materialized_partitions(asset_key)
+            for partition in ["2015-01-01", "2015-01-02"]:
+                assert partition in partitions
+
+
 def test_spark():
     with instance_for_test() as instance:
         result = invoke_materialize("*reloaded_nyc_taxi_data_spark")

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -160,3 +160,35 @@ def test_spark_multi_partitioned():
             partitions = instance.get_materialized_partitions(asset_key)
             for partition in ["2015-01-01|part.0", "2015-01-01|part.1"]:
                 assert partition in partitions
+
+
+def test_spark_daily_partitioned():
+    with instance_for_test() as instance:
+        for partition in [
+            "2015-01-01|part.0",
+            "2015-01-01|part.1",
+            "2015-01-02|part.0",
+            "2015-01-02|part.1",
+        ]:
+            result = invoke_materialize(
+                "multi_partitioned_nyc_taxi_data", partition=partition
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for partition in ["2015-01-01", "2015-01-02"]:
+            result = invoke_materialize(
+                "daily_partitioned_nyc_taxi_data,"
+                "daily_partitioned_nyc_taxi_data_spark,"
+                "reloaded_daily_partitioned_nyc_taxi_data_spark",
+                partition=partition,
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for asset_key in [
+            AssetKey("daily_partitioned_nyc_taxi_data_spark"),
+            AssetKey("reloaded_daily_partitioned_nyc_taxi_data_spark"),
+        ]:
+            assert instance.get_latest_materialization_event(asset_key) is not None
+            partitions = instance.get_materialized_partitions(asset_key)
+            for partition in ["2015-01-01", "2015-01-02"]:
+                assert partition in partitions

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -111,3 +111,21 @@ def test_spark_static_partitioned():
             partitions = instance.get_materialized_partitions(asset_key)
             for partition in ["part.0", "part.1"]:
                 assert partition in partitions
+
+
+def test_spark_multi_partitioned():
+    with instance_for_test() as instance:
+        for partition in ["2015-01-01|part.0", "2015-01-01|part.1"]:
+            result = invoke_materialize(
+                "*reloaded_multi_partitioned_nyc_taxi_data_spark", partition=partition
+            )
+            assert "RUN_SUCCESS" in result.output
+
+        for asset_key in [
+            AssetKey("multi_partitioned_nyc_taxi_data_spark"),
+            AssetKey("reloaded_multi_partitioned_nyc_taxi_data_spark"),
+        ]:
+            assert instance.get_latest_materialization_event(asset_key) is not None
+            partitions = instance.get_materialized_partitions(asset_key)
+            for partition in ["2015-01-01|part.0", "2015-01-01|part.1"]:
+                assert partition in partitions


### PR DESCRIPTION
## Summary & Motivation

Add and test time-based and multi-partitioning support for Spark Connect Iceberg I/O manager.

## How I Tested These Changes

Manually (see https://www.loom.com/share/42cdb702811e42348883ff79af2c5f6f?sid=46b85f26-411f-41a0-ad46-4467f7014e4d, not the `date_day` partition key in MinIO storage as opposed to just `date` that shows the partition transform*) and e2e test.

*Really need to add unit tests for these things later. 😅 
