### PR TITLE
[dagster-iceberg] Rename I/O managers engine-first

### DIFF
--- a/libraries/dagster-iceberg/CHANGELOG.md
+++ b/libraries/dagster-iceberg/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Spark I/O manager.
+
+### Changed
+
+- Rename I/O managers from `<Storage><Engine>IOManager` to `<Engine><Storage>IOManager`.

--- a/libraries/dagster-iceberg/docs/code_reference.md
+++ b/libraries/dagster-iceberg/docs/code_reference.md
@@ -8,13 +8,13 @@
 
 ## IO Managers
 
-::: dagster_iceberg.io_manager.arrow.IcebergPyarrowIOManager
+::: dagster_iceberg.io_manager.arrow.PyArrowIcebergIOManager
 
-::: dagster_iceberg.io_manager.polars.IcebergPolarsIOManager
+::: dagster_iceberg.io_manager.polars.PolarsIcebergIOManager
 
-::: dagster_iceberg.io_manager.daft.IcebergDaftIOManager
+::: dagster_iceberg.io_manager.daft.DaftIcebergIOManager
 
-::: dagster_iceberg.io_manager.pandas.IcebergPandasIOManager
+::: dagster_iceberg.io_manager.pandas.PandasIcebergIOManager
 
 ## Base classes
 

--- a/libraries/dagster-iceberg/docs/features.md
+++ b/libraries/dagster-iceberg/docs/features.md
@@ -12,9 +12,9 @@ You may also pass your catalog configuration through use of the `IcebergCatalogC
 
 ```python
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
-io_manager = IcebergPyarrowIOManager(
+io_manager = PyArrowIcebergIOManager(
     name=catalog_name,
     config=IcebergCatalogConfig(properties={
         "uri": "postgresql+psycopg2://pyiceberg:pyiceberg@postgres/catalog",

--- a/libraries/dagster-iceberg/docs/quickstart.md
+++ b/libraries/dagster-iceberg/docs/quickstart.md
@@ -11,14 +11,14 @@ To use dagster-iceberg as an I/O manager, you add it to your `Definition`:
 ```py linenums="1"
 from dagster import Definitions
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/dag/warehouse/catalog.db"
 CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/dag/warehouse"
 
 
 resources = {
-    "io_manager": IcebergPyarrowIOManager(
+    "io_manager": PyArrowIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/reference.md
+++ b/libraries/dagster-iceberg/docs/reference.md
@@ -142,7 +142,7 @@ The Iceberg I/O manager also supports storing and loading PyArrow and Polars Dat
 
     The `Iceberg` package relies heavily on Apache Arrow for efficient data transfer, so PyArrow is natively supported.
 
-    You can use `IcebergPyarrowIOManager` to read and write iceberg tables:
+    You can use `PyArrowIcebergIOManager` to read and write iceberg tables:
 
     ```python title="docs/snippets/io_manager_pyarrow.py" linenums="1"
     --8<-- "docs/snippets/io_manager_pyarrow.py"
@@ -150,7 +150,7 @@ The Iceberg I/O manager also supports storing and loading PyArrow and Polars Dat
 
 === "Pandas DataFrames"
 
-     You can use `IcebergPandasIOManager` to read and write iceberg tables using Pandas:
+     You can use `PandasIcebergIOManager` to read and write iceberg tables using Pandas:
 
     ```python title="docs/snippets/io_manager_pandas.py" linenums="1"
     --8<-- "docs/snippets/io_manager_pandas.py"
@@ -158,7 +158,7 @@ The Iceberg I/O manager also supports storing and loading PyArrow and Polars Dat
 
 === "Polars DataFrames"
 
-     You can use the `IcebergPolarsIOManager` to read and write iceberg tables using Polars using a full lazily optimized query engine:
+     You can use the `PolarsIcebergIOManager` to read and write iceberg tables using Polars using a full lazily optimized query engine:
 
     ```python title="docs/snippets/io_manager_polars.py" linenums="1"
     --8<-- "docs/snippets/io_manager_polars.py"
@@ -166,7 +166,7 @@ The Iceberg I/O manager also supports storing and loading PyArrow and Polars Dat
 
 === "Daft DataFrames"
 
-     You can use the `IcebergDaftIOManager` to read and write iceberg tables using Daft using a full lazily optimized query engine:
+     You can use the `DaftIcebergIOManager` to read and write iceberg tables using Daft using a full lazily optimized query engine:
 
     ```python title="docs/snippets/io_manager_daft.py" linenums="1"
     --8<-- "docs/snippets/io_manager_daft.py"
@@ -232,10 +232,10 @@ The `dagster-iceberg` library leans heavily on Dagster's `DbIOManager` implement
 
 ```python
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
 
-IcebergPyarrowIOManager(
+PyArrowIcebergIOManager(
     name="my_catalog",
     config=IcebergCatalogConfig(properties={...}),
     namespace="my_schema",

--- a/libraries/dagster-iceberg/docs/snippets/io_manager_daft.py
+++ b/libraries/dagster-iceberg/docs/snippets/io_manager_daft.py
@@ -3,7 +3,7 @@ import pandas as pd
 from dagster import Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.daft import IcebergDaftIOManager
+from dagster_iceberg.io_manager.daft import DaftIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
 CATALOG_WAREHOUSE = (
@@ -12,7 +12,7 @@ CATALOG_WAREHOUSE = (
 
 
 resources = {
-    "io_manager": IcebergDaftIOManager(
+    "io_manager": DaftIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/io_manager_pandas.py
+++ b/libraries/dagster-iceberg/docs/snippets/io_manager_pandas.py
@@ -2,7 +2,7 @@ import pandas as pd
 from dagster import Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
 CATALOG_WAREHOUSE = (
@@ -11,7 +11,7 @@ CATALOG_WAREHOUSE = (
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/io_manager_polars.py
+++ b/libraries/dagster-iceberg/docs/snippets/io_manager_polars.py
@@ -3,7 +3,7 @@ import polars as pl
 from dagster import Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.polars import IcebergPolarsIOManager
+from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
 CATALOG_WAREHOUSE = (
@@ -12,7 +12,7 @@ CATALOG_WAREHOUSE = (
 
 
 resources = {
-    "io_manager": IcebergPolarsIOManager(
+    "io_manager": PolarsIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/io_manager_pyarrow.py
+++ b/libraries/dagster-iceberg/docs/snippets/io_manager_pyarrow.py
@@ -3,7 +3,7 @@ import pyarrow as pa
 from dagster import Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
 CATALOG_WAREHOUSE = (
@@ -12,7 +12,7 @@ CATALOG_WAREHOUSE = (
 
 
 resources = {
-    "io_manager": IcebergPyarrowIOManager(
+    "io_manager": PyArrowIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/multiple_io_managers.py
+++ b/libraries/dagster-iceberg/docs/snippets/multiple_io_managers.py
@@ -2,7 +2,7 @@ import pandas as pd
 from dagster import Definitions, FilesystemIOManager, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/catalog.db"
 CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/examples/warehouse"
@@ -10,7 +10,7 @@ FS_BASE_DIR = "/home/vscode/workspace/.tmp/examples/images"
 
 
 resources = {
-    "dwh_io_manager": IcebergPandasIOManager(
+    "dwh_io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/multiple_schemas.py
+++ b/libraries/dagster-iceberg/docs/snippets/multiple_schemas.py
@@ -2,14 +2,14 @@ import pandas as pd
 from dagster import Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/catalog.db"
 CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/examples/warehouse"
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/partitions_multiple.py
+++ b/libraries/dagster-iceberg/docs/snippets/partitions_multiple.py
@@ -11,14 +11,14 @@ from dagster import (
 )
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/catalog.db"
 CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/examples/warehouse"
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/partitions_static.py
+++ b/libraries/dagster-iceberg/docs/snippets/partitions_static.py
@@ -2,14 +2,14 @@ import pandas as pd
 from dagster import Definitions, StaticPartitionsDefinition, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/catalog.db"
 CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/examples/warehouse"
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/partitions_time.py
+++ b/libraries/dagster-iceberg/docs/snippets/partitions_time.py
@@ -5,14 +5,14 @@ import pandas as pd
 from dagster import DailyPartitionsDefinition, Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/catalog.db"
 CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/examples/warehouse"
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/select_columns.py
+++ b/libraries/dagster-iceberg/docs/snippets/select_columns.py
@@ -2,7 +2,7 @@ import pandas as pd
 from dagster import AssetIn, Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
 CATALOG_WAREHOUSE = (
@@ -11,7 +11,7 @@ CATALOG_WAREHOUSE = (
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/docs/snippets/table_properties.py
+++ b/libraries/dagster-iceberg/docs/snippets/table_properties.py
@@ -2,7 +2,7 @@ import pandas as pd
 from dagster import Definitions, asset
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
 CATALOG_WAREHOUSE = (
@@ -11,7 +11,7 @@ CATALOG_WAREHOUSE = (
 
 
 resources = {
-    "io_manager": IcebergPandasIOManager(
+    "io_manager": PandasIcebergIOManager(
         name="test",
         config=IcebergCatalogConfig(
             properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/src/dagster_iceberg/config.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/config.py
@@ -22,11 +22,11 @@ class IcebergCatalogConfig(Config):
 
     ```python
     from dagster_iceberg.config import IcebergCatalogConfig
-    from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+    from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
     warehouse_path = "/path/to/warehouse
 
-    io_manager = IcebergPyarrowIOManager(
+    io_manager = PyArrowIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties={
             "uri": f"sqlite:///{warehouse_path}/iceberg_catalog.db",

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/arrow.py
@@ -14,7 +14,7 @@ from dagster_iceberg._utils import DagsterPartitionToIcebergExpressionMapper, pr
 ArrowTypes = Union[pa.Table, pa.RecordBatchReader]  # noqa: UP007, avoid Pyright failure
 
 
-class _IcebergPyArrowTypeHandler(_handler.IcebergBaseTypeHandler[ArrowTypes]):
+class _PyArrowIcebergTypeHandler(_handler.IcebergBaseTypeHandler[ArrowTypes]):
     """Type handler that converts data between Iceberg tables and pyarrow Tables"""
 
     def to_data_frame(
@@ -55,7 +55,7 @@ class _IcebergPyArrowTypeHandler(_handler.IcebergBaseTypeHandler[ArrowTypes]):
 
 @preview
 @public
-class IcebergPyarrowIOManager(_io_manager.IcebergIOManager):
+class PyArrowIcebergIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using PyArrow.
 
     Examples:
@@ -66,7 +66,7 @@ class IcebergPyarrowIOManager(_io_manager.IcebergIOManager):
     from dagster import Definitions, asset
 
     from dagster_iceberg.config import IcebergCatalogConfig
-    from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+    from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
     CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
     CATALOG_WAREHOUSE = (
@@ -75,7 +75,7 @@ class IcebergPyarrowIOManager(_io_manager.IcebergIOManager):
 
 
     resources = {
-        "io_manager": IcebergPyarrowIOManager(
+        "io_manager": PyArrowIcebergIOManager(
             name="test",
             config=IcebergCatalogConfig(
                 properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
@@ -133,4 +133,4 @@ class IcebergPyarrowIOManager(_io_manager.IcebergIOManager):
 
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
-        return [_IcebergPyArrowTypeHandler()]
+        return [_PyArrowIcebergTypeHandler()]

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
@@ -115,7 +115,7 @@ class IcebergIOManager(ConfigurableIOManagerFactory):
     from dagster import Definitions, asset
 
     from dagster_iceberg.config import IcebergCatalogConfig
-    from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+    from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
     CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
     CATALOG_WAREHOUSE = (
@@ -124,7 +124,7 @@ class IcebergIOManager(ConfigurableIOManagerFactory):
 
 
     resources = {
-        "io_manager": IcebergPyarrowIOManager(
+        "io_manager": PyArrowIcebergIOManager(
             name="test",
             config=IcebergCatalogConfig(
                 properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/daft.py
@@ -14,7 +14,7 @@ from dagster_iceberg import io_manager as _io_manager
 from dagster_iceberg._utils import DagsterPartitionToDaftSqlPredicateMapper, preview
 
 
-class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
+class _DaftIcebergTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
     """Type handler that converts data between Iceberg tables and polars DataFrames"""
 
     def to_data_frame(
@@ -53,7 +53,7 @@ class _IcebergDaftTypeHandler(_handler.IcebergBaseTypeHandler[da.DataFrame]):
 
 @preview
 @public
-class IcebergDaftIOManager(_io_manager.IcebergIOManager):
+class DaftIcebergIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using Daft.
 
     Examples:
@@ -64,7 +64,7 @@ class IcebergDaftIOManager(_io_manager.IcebergIOManager):
     from dagster import Definitions, asset
 
     from dagster_iceberg.config import IcebergCatalogConfig
-    from dagster_iceberg.io_manager.daft import IcebergDaftIOManager
+    from dagster_iceberg.io_manager.daft import DaftIcebergIOManager
 
     CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
     CATALOG_WAREHOUSE = (
@@ -73,7 +73,7 @@ class IcebergDaftIOManager(_io_manager.IcebergIOManager):
 
 
     resources = {
-        "io_manager": IcebergDaftIOManager(
+        "io_manager": DaftIcebergIOManager(
             name="test",
             config=IcebergCatalogConfig(
                 properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
@@ -131,4 +131,4 @@ class IcebergDaftIOManager(_io_manager.IcebergIOManager):
 
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
-        return [_IcebergDaftTypeHandler()]
+        return [_DaftIcebergTypeHandler()]

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/pandas.py
@@ -12,10 +12,10 @@ from pyiceberg.catalog import Catalog
 
 from dagster_iceberg import io_manager as _io_manager
 from dagster_iceberg._utils import preview
-from dagster_iceberg.io_manager.arrow import _IcebergPyArrowTypeHandler
+from dagster_iceberg.io_manager.arrow import _PyArrowIcebergTypeHandler
 
 
-class _IcebergPandasTypeHandler(_IcebergPyArrowTypeHandler):
+class _PandasIcebergTypeHandler(_PyArrowIcebergTypeHandler):
     """Type handler that converts data between Iceberg tables and pyarrow Tables"""
 
     def to_arrow(self, obj: pd.DataFrame) -> pa.Table:
@@ -42,7 +42,7 @@ class _IcebergPandasTypeHandler(_IcebergPyArrowTypeHandler):
 
 @preview
 @public
-class IcebergPandasIOManager(_io_manager.IcebergIOManager):
+class PandasIcebergIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using Pandas.
 
     Examples:
@@ -52,7 +52,7 @@ class IcebergPandasIOManager(_io_manager.IcebergIOManager):
     from dagster import Definitions, asset
 
     from dagster_iceberg.config import IcebergCatalogConfig
-    from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+    from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
     CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
     CATALOG_WAREHOUSE = (
@@ -61,7 +61,7 @@ class IcebergPandasIOManager(_io_manager.IcebergIOManager):
 
 
     resources = {
-        "io_manager": IcebergPandasIOManager(
+        "io_manager": PandasIcebergIOManager(
             name="test",
             config=IcebergCatalogConfig(
                 properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
@@ -117,4 +117,4 @@ class IcebergPandasIOManager(_io_manager.IcebergIOManager):
 
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
-        return [_IcebergPandasTypeHandler()]
+        return [_PandasIcebergTypeHandler()]

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
@@ -14,7 +14,7 @@ from dagster_iceberg import io_manager as _io_manager
 from dagster_iceberg._utils import DagsterPartitionToPolarsSqlPredicateMapper, preview
 
 
-class _IcebergPolarsTypeHandler(
+class _PolarsIcebergTypeHandler(
     _handler.IcebergBaseTypeHandler[pl.LazyFrame | pl.DataFrame],
 ):
     """Type handler that converts data between Iceberg tables and polars DataFrames"""
@@ -56,7 +56,7 @@ class _IcebergPolarsTypeHandler(
 
 @preview
 @public
-class IcebergPolarsIOManager(_io_manager.IcebergIOManager):
+class PolarsIcebergIOManager(_io_manager.IcebergIOManager):
     """An IO manager definition that reads inputs from and writes outputs to Iceberg tables using Polars.
 
     Examples:
@@ -67,7 +67,7 @@ class IcebergPolarsIOManager(_io_manager.IcebergIOManager):
     from dagster import Definitions, asset
 
     from dagster_iceberg.config import IcebergCatalogConfig
-    from dagster_iceberg.io_manager.polars import IcebergPolarsIOManager
+    from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
 
     CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
     CATALOG_WAREHOUSE = (
@@ -76,7 +76,7 @@ class IcebergPolarsIOManager(_io_manager.IcebergIOManager):
 
 
     resources = {
-        "io_manager": IcebergPolarsIOManager(
+        "io_manager": PolarsIcebergIOManager(
             name="test",
             config=IcebergCatalogConfig(
                 properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
@@ -134,4 +134,4 @@ class IcebergPolarsIOManager(_io_manager.IcebergIOManager):
 
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
-        return [_IcebergPolarsTypeHandler()]
+        return [_PolarsIcebergTypeHandler()]

--- a/libraries/dagster-iceberg/tests/_db_io_manager/test_db_io_manager.py
+++ b/libraries/dagster-iceberg/tests/_db_io_manager/test_db_io_manager.py
@@ -27,7 +27,7 @@ from dagster import (
 )
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
 
 @pytest.fixture
@@ -35,8 +35,8 @@ def io_manager(
     catalog_name: str,
     namespace: str,
     catalog_config_properties: dict[str, str],
-) -> IcebergPyarrowIOManager:
-    return IcebergPyarrowIOManager(
+) -> PyArrowIcebergIOManager:
+    return PyArrowIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties=catalog_config_properties),
         namespace=namespace,
@@ -209,7 +209,7 @@ def mapped_multi_partition(
 
 
 def test_unpartitioned_asset_to_unpartitioned_asset(
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -218,7 +218,7 @@ def test_unpartitioned_asset_to_unpartitioned_asset(
 
 
 def test_multi_partitioned_to_multi_partitioned_asset(
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -232,7 +232,7 @@ def test_multi_partitioned_to_multi_partitioned_asset(
 
 
 def test_multi_partitioned_to_single_partitioned_asset_colors(
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -253,7 +253,7 @@ def test_multi_partitioned_to_single_partitioned_asset_colors(
 
 
 def test_multi_partitioned_to_single_partitioned_asset_dates(
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -274,7 +274,7 @@ def test_multi_partitioned_to_single_partitioned_asset_dates(
 
 
 def test_multi_partitioned_to_non_partitioned_asset(
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -294,7 +294,7 @@ def test_multi_partitioned_to_non_partitioned_asset(
 
 
 def test_multi_partitioned_to_multi_partitioned_with_different_dimensions(
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 

--- a/libraries/dagster-iceberg/tests/io_managers/test_arrow_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_arrow_io_manager.py
@@ -14,7 +14,7 @@ from dagster import (
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 
 
 @pytest.fixture
@@ -22,8 +22,8 @@ def io_manager(
     catalog_name: str,
     namespace: str,
     catalog_config_properties: dict[str, str],
-) -> IcebergPyarrowIOManager:
-    return IcebergPyarrowIOManager(
+) -> PyArrowIcebergIOManager:
+    return PyArrowIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties=catalog_config_properties),
         namespace=namespace,
@@ -31,7 +31,7 @@ def io_manager(
 
 
 @pytest.fixture
-def custom_db_io_manager(io_manager: IcebergPyarrowIOManager):
+def custom_db_io_manager(io_manager: PyArrowIcebergIOManager):
     return io_manager.create_io_manager(None)
 
 
@@ -135,7 +135,7 @@ def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -155,7 +155,7 @@ def test_iceberg_io_manager_with_assets(
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -185,7 +185,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -215,7 +215,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPyarrowIOManager,
+    io_manager: PyArrowIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 

--- a/libraries/dagster-iceberg/tests/io_managers/test_base_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_base_io_manager.py
@@ -5,7 +5,7 @@ from pyiceberg.catalog import Catalog
 from pyiceberg.exceptions import NoSuchNamespaceError
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.arrow import IcebergPyarrowIOManager
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
 from dagster_iceberg.io_manager.base import IcebergDbClient
 
 
@@ -14,8 +14,8 @@ def io_manager(
     catalog_name: str,
     namespace: str,
     catalog_config_properties: dict[str, str],
-) -> IcebergPyarrowIOManager:
-    return IcebergPyarrowIOManager(
+) -> PyArrowIcebergIOManager:
+    return PyArrowIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties=catalog_config_properties),
         namespace=namespace,
@@ -46,7 +46,7 @@ def iceberg_db_client():
 
 
 @pytest.fixture
-def output_context(io_manager: IcebergPyarrowIOManager) -> OutputContext:
+def output_context(io_manager: PyArrowIcebergIOManager) -> OutputContext:
     return build_output_context(resources={"io_manager": io_manager})
 
 

--- a/libraries/dagster-iceberg/tests/io_managers/test_daft_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_daft_io_manager.py
@@ -14,7 +14,7 @@ from dagster import (
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.daft import IcebergDaftIOManager
+from dagster_iceberg.io_manager.daft import DaftIcebergIOManager
 
 
 @pytest.fixture
@@ -22,8 +22,8 @@ def io_manager(
     catalog_name: str,
     namespace: str,
     catalog_config_properties: dict[str, str],
-) -> IcebergDaftIOManager:
-    return IcebergDaftIOManager(
+) -> DaftIcebergIOManager:
+    return DaftIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties=catalog_config_properties),
         namespace=namespace,
@@ -31,7 +31,7 @@ def io_manager(
 
 
 @pytest.fixture
-def custom_db_io_manager(io_manager: IcebergDaftIOManager):
+def custom_db_io_manager(io_manager: DaftIcebergIOManager):
     return io_manager.create_io_manager(None)
 
 
@@ -135,7 +135,7 @@ def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergDaftIOManager,
+    io_manager: DaftIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -155,7 +155,7 @@ def test_iceberg_io_manager_with_assets(
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergDaftIOManager,
+    io_manager: DaftIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -185,7 +185,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergDaftIOManager,
+    io_manager: DaftIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -215,7 +215,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergDaftIOManager,
+    io_manager: DaftIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 

--- a/libraries/dagster-iceberg/tests/io_managers/test_pandas_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_pandas_io_manager.py
@@ -15,7 +15,7 @@ from dagster import (
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.pandas import IcebergPandasIOManager
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
 
 
 @pytest.fixture
@@ -23,8 +23,8 @@ def io_manager(
     catalog_name: str,
     namespace: str,
     catalog_config_properties: dict[str, str],
-) -> IcebergPandasIOManager:
-    return IcebergPandasIOManager(
+) -> PandasIcebergIOManager:
+    return PandasIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties=catalog_config_properties),
         namespace=namespace,
@@ -32,7 +32,7 @@ def io_manager(
 
 
 @pytest.fixture
-def custom_db_io_manager(io_manager: IcebergPandasIOManager):
+def custom_db_io_manager(io_manager: PandasIcebergIOManager):
     return io_manager.create_io_manager(None)
 
 
@@ -141,7 +141,7 @@ def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPandasIOManager,
+    io_manager: PandasIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -161,7 +161,7 @@ def test_iceberg_io_manager_with_assets(
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPandasIOManager,
+    io_manager: PandasIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -191,7 +191,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPandasIOManager,
+    io_manager: PandasIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -221,7 +221,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPandasIOManager,
+    io_manager: PandasIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 

--- a/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
@@ -14,7 +14,7 @@ from dagster import (
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg.config import IcebergCatalogConfig
-from dagster_iceberg.io_manager.polars import IcebergPolarsIOManager
+from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
 
 
 @pytest.fixture
@@ -22,8 +22,8 @@ def io_manager(
     catalog_name: str,
     namespace: str,
     catalog_config_properties: dict[str, str],
-) -> IcebergPolarsIOManager:
-    return IcebergPolarsIOManager(
+) -> PolarsIcebergIOManager:
+    return PolarsIcebergIOManager(
         name=catalog_name,
         config=IcebergCatalogConfig(properties=catalog_config_properties),
         namespace=namespace,
@@ -31,7 +31,7 @@ def io_manager(
 
 
 @pytest.fixture
-def custom_db_io_manager(io_manager: IcebergPolarsIOManager):
+def custom_db_io_manager(io_manager: PolarsIcebergIOManager):
     return io_manager.create_io_manager(None)
 
 
@@ -139,7 +139,7 @@ def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPolarsIOManager,
+    io_manager: PolarsIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -159,7 +159,7 @@ def test_iceberg_io_manager_with_assets(
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPolarsIOManager,
+    io_manager: PolarsIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -189,7 +189,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPolarsIOManager,
+    io_manager: PolarsIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 
@@ -219,7 +219,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
     catalog: Catalog,
-    io_manager: IcebergPolarsIOManager,
+    io_manager: PolarsIcebergIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
 

--- a/libraries/dagster-modal/CHANGELOG.md
+++ b/libraries/dagster-modal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.2
+## [0.0.2]
 
 ### Updated
 

--- a/libraries/dagster-notdiamond/CHANGELOG.md
+++ b/libraries/dagster-notdiamond/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Changelog
----
-
-## UNRELEASED
-
-- Adds example `examples/example_book_reviews_summary.py` showing model usage after `model_select` for book review summarization
 
 ## [0.1.2]
 
 - Removing TOML config.
+- Adds example `examples/example_book_reviews_summary.py` showing model usage after `model_select` for book review summarization
 
 ## [0.1.1]
 


### PR DESCRIPTION
## Summary & Motivation

We agreed to standardize I/O managers name to be `<Engine><Storage>IOManager` instead of `<Storage><Engine>IOManager` a while back, and this finally makes that change.

## How I Tested These Changes

Built docs manually, and existing tests pass.

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
