### PR TITLE
[dagster-polars] add Patito integration

### DIFF
--- a/libraries/dagster-polars/CHANGELOG.md
+++ b/libraries/dagster-polars/CHANGELOG.md
@@ -1,0 +1,3 @@
+### Added
+
+The Patito data validation library for Polars is now support in IO managers. DagsterType instances can be built with `dagster_polars.patito.patito_model_to_dagster_type`.

--- a/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -12,6 +12,7 @@ from typing import (
     get_args,
     get_origin,
 )
+from dagster._core.types.dagster_type import TypeHintInferredDagsterType
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
@@ -20,6 +21,9 @@ else:
 
 import polars as pl
 from dagster import InputContext, OutputContext
+from dagster._core.types.dagster_type import DagsterType
+
+from dagster_polars.patito import HANDLES_DATA_VALIDATION_ATTRIBUTE
 
 if TYPE_CHECKING:
     from upath import UPath
@@ -40,9 +44,12 @@ class BaseTypeRouter(Generic[T]):
     This base class trivially calls the dump/load functions if the type matches the most simple cases.
     """
 
-    def __init__(self, context: Union[InputContext, OutputContext], typing_type: Any):
+    def __init__(
+        self, context: Union[InputContext, OutputContext], dagster_type: DagsterType
+    ):
         self.context = context
-        self.typing_type = typing_type
+        self.dagster_type = dagster_type
+        self.typing_type = dagster_type.typing_type
 
     @staticmethod
     @abstractmethod
@@ -61,7 +68,9 @@ class BaseTypeRouter(Generic[T]):
 
     @property
     def parent_type_router(self) -> "TypeRouter":
-        return resolve_type_router(self.context, self.inner_type)
+        return resolve_type_router(
+            self.context, TypeHintInferredDagsterType(self.inner_type)
+        )
 
     def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
         if self.is_base_type:
@@ -157,16 +166,85 @@ class PolarsTypeRouter(BaseTypeRouter, Generic[T]):
         return True
 
 
-TYPE_ROUTERS = [TypeRouter, OptionalTypeRouter, DictTypeRouter, PolarsTypeRouter]
+class PatitoTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles Patito DataFrames. Performs validation on load and dump."""
+
+    @staticmethod
+    def match(context: Union[InputContext, OutputContext], typing_type: Any) -> bool:
+        import patito as pt
+
+        return isinstance(typing_type, type) and (
+            issubclass(typing_type, pt.DataFrame)
+            or issubclass(typing_type, pt.LazyFrame)
+        )
+
+    @property
+    def is_base_type(self) -> bool:
+        return False
+
+    @property
+    def requires_data_validation(self) -> bool:
+        return not (
+            hasattr(self.dagster_type, HANDLES_DATA_VALIDATION_ATTRIBUTE)
+            and getattr(self.dagster_type, HANDLES_DATA_VALIDATION_ATTRIBUTE)
+        ) or not getattr(self.dagster_type, HANDLES_DATA_VALIDATION_ATTRIBUTE)
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D[T]) -> None:
+        import patito as pt
+
+        if isinstance(obj, pt.DataFrame):  # lazy frames are not supported yet
+            # check if the special attribute is set
+            # so that we don't perform potentially expensive data validation
+            # twice
+            if self.requires_data_validation:
+                obj = obj.validate()  # type: ignore
+        dump_fn(cast(OutputContext, self.context), obj, path)
+
+    def load(self, path: "UPath", load_fn: F_L[T]) -> T:
+        import patito as pt
+
+        df = load_fn(path, cast(InputContext, self.context))
+        if isinstance(df, pl.DataFrame):
+            df = pt.DataFrame(df).set_model(self.model)
+            if self.requires_data_validation:
+                df = df.validate()
+            return df  # pyright: ignore[reportReturnType]
+        elif isinstance(df, pl.LazyFrame):
+            # _from_pyldf found in https://github.com/JakobGM/patito/pull/135
+            return self.model.LazyFrame._from_pyldf(df._ldf)  # noqa
+        else:
+            raise ValueError(f"Unexpected DataFrame type {type(df)}")
+
+    @property
+    def inner_type(self) -> Any:
+        if issubclass(self.typing_type, pl.DataFrame):
+            return pl.DataFrame
+        elif issubclass(self.typing_type, pl.LazyFrame):
+            return pl.LazyFrame
+        else:
+            raise ValueError(f"Unexpected Patito type {self.typing_type}")
+
+    @property
+    def model(self):
+        return self.typing_type.model
+
+
+TYPE_ROUTERS = [
+    TypeRouter,
+    OptionalTypeRouter,
+    DictTypeRouter,
+    PatitoTypeRouter,
+    PolarsTypeRouter,
+]
 
 
 def resolve_type_router(
-    context: Union[InputContext, OutputContext], type_to_resolve: Any
+    context: Union[InputContext, OutputContext], dagster_type_to_resolve: DagsterType
 ) -> TypeRouter:
     """Finds the first matching TypeRouter for the given type."""
     # try each router class in order of increasing complexity
     for router_class in TYPE_ROUTERS:
-        if router_class.match(context, type_to_resolve):
-            return router_class(context, type_to_resolve)
+        if router_class.match(context, dagster_type_to_resolve.typing_type):
+            return router_class(context, dagster_type_to_resolve)
 
-    raise RuntimeError(f"Could not resolve type router for {type_to_resolve}")
+    raise RuntimeError(f"Could not resolve type router for {dagster_type_to_resolve}")

--- a/libraries/dagster-polars/dagster_polars/io_managers/utils.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/utils.py
@@ -132,7 +132,7 @@ def get_table_metadata(
 def get_polars_metadata(
     context: OutputContext, df: Union[pl.DataFrame, pl.LazyFrame]
 ) -> dict[str, MetadataValue]:
-    """Retrives some metadata on polars frames
+    """Retrieves some metadata on polars frames
     - DataFrame: stats, row_count, table or schema
     - LazyFrame: schema.
 

--- a/libraries/dagster-polars/dagster_polars/patito.py
+++ b/libraries/dagster-polars/dagster_polars/patito.py
@@ -1,0 +1,134 @@
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional, Mapping
+
+import polars as pl
+from dagster import (
+    DagsterType,
+    MetadataValue,
+    TableColumn,
+    TableColumnConstraints,
+    TableSchema,
+    TypeCheck,
+    TypeCheckContext,
+)
+
+if TYPE_CHECKING:
+    import patito as pt
+    from patito._pydantic.column_info import ColumnInfo
+
+VALID_DATAFRAME_CLASSES = (pl.DataFrame,)
+
+
+def get_patito_metadata(model: type["pt.Model"]) -> dict[str, MetadataValue]:
+    """Extracts Dagster metadata from a Patito model."""
+    table_columns: list[TableColumn] = []
+    schema_dtypes: dict[str, Any] = model.dtypes
+    column_infos: Mapping[str, ColumnInfo] = model.column_infos
+
+    for col, properties in model._schema_properties().items():  # noqa: SLF001
+        table_columns.append(
+            TableColumn(
+                name=col,
+                type=str(schema_dtypes[col]),
+                description=properties.get("description"),
+                constraints=TableColumnConstraints(
+                    unique=column_infos[col].unique  # pyright: ignore reportArgumentType
+                    if column_infos[col].unique is not None
+                    else False,
+                    nullable="anyOf" in properties,
+                    # TODO: Handle Other constraints, serialize the expressions
+                ),
+            ),
+        )
+    table_schema = TableSchema(columns=table_columns)
+
+    return {
+        "dagster/column_schema": MetadataValue.table_schema(table_schema),
+    }
+
+
+HANDLES_DATA_VALIDATION_ATTRIBUTE = "_handles_data_validation"
+
+
+def patito_model_to_dagster_type(
+    model: type["pt.Model"],
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> DagsterType:
+    """Convert patito model to dagster type checking.
+
+    Compatible with any IOManager. Logs Dagster metadata associated with
+    the Patito model, such as `dagster/column_schema`.
+
+    Args:
+        model (type[pt.Model]): the Patito model.
+        name (Optional[str]): Dagster Type name. Defaults to the model class name.
+        description (Optional[str]): Dagster Type description. By default it references the model class name.
+
+    Returns:
+        DagsterType: Dagster type with patito validation function.
+
+    Examples:
+        .. code-block:: python
+
+            import dagster as dg
+            import patito as pt
+
+            class MyTable(pt.Model):
+                col_1: str | None
+                col_2: int = pt.Field(unique=True)
+
+            @asset(
+                dagster_type=patito_model_to_dagster_type(MyTable),
+                io_manager_key="my_io_manager",
+            )
+            def my_asset() -> pl.DataFrame:
+                return pl.DataFrame({
+                    "col_1": ['a'],
+                    "col_2": [2],
+                })
+
+    """
+    type_check_fn = _patito_model_to_type_check_fn(model)
+
+    dagster_type = DagsterType(
+        type_check_fn=type_check_fn,
+        name=model.__class__.__name__,
+        metadata=get_patito_metadata(model),
+        typing_type=model.DataFrame,
+        description=description
+        or f"Polars frame conforming to Patito model {model.__class__.__name__}",
+    )
+
+    # this is a dirty hack --- this configures dagster-polars IOManager to skip data validation
+    # as it is already performed by the DagsterType. We should work on bringing this functionality
+    # into DagsterType itself
+    setattr(dagster_type, HANDLES_DATA_VALIDATION_ATTRIBUTE, True)
+
+    return dagster_type
+
+
+def _patito_model_to_type_check_fn(
+    model: type["pt.Model"],
+) -> Callable[[TypeCheckContext, object], TypeCheck]:
+    import patito as pt
+
+    def type_check_fn(context: TypeCheckContext, value: object) -> TypeCheck:
+        if isinstance(value, VALID_DATAFRAME_CLASSES):
+            try:
+                model.validate(value)
+                return TypeCheck(success=True)
+            except pt.DataFrameValidationError as e:
+                return TypeCheck(
+                    success=False,
+                    description=str(e),
+                )
+        else:
+            return TypeCheck(
+                success=False,
+                description=(
+                    f"Must be one of {VALID_DATAFRAME_CLASSES}, not {type(value).__name__}."
+                ),
+            )
+
+    return type_check_fn

--- a/libraries/dagster-polars/dagster_polars_tests/test_patito.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_patito.py
@@ -1,0 +1,397 @@
+from typing import Optional
+
+import dagster as dg
+import patito as pt  # noqa: TID253
+import polars as pl
+import pytest
+from dagster_polars import BasePolarsUPathIOManager
+from dagster_polars.patito import get_patito_metadata, patito_model_to_dagster_type
+
+
+class TestingRecord(pt.Model):
+    foo: str = pt.Field(unique=True, description="A `foo` column")
+    bar: Optional[int]
+
+
+good_df = pl.DataFrame(
+    {
+        "foo": ["a", "b", "c"],
+        "bar": [1, 2, 3],
+    }
+)
+
+bad_df = pl.DataFrame(
+    {
+        "foo": ["a", "a", "c"],
+        "bar": [1, 2, 3],
+    }
+)
+
+
+def test_get_patito_metadata():
+    metadata = get_patito_metadata(TestingRecord)
+    assert metadata["dagster/column_schema"] == dg.TableSchemaMetadataValue(
+        schema=dg.TableSchema(
+            columns=[
+                dg.TableColumn(
+                    name="foo",
+                    type="String",
+                    description="A `foo` column",
+                    constraints=dg.TableColumnConstraints(
+                        nullable=False, unique=True, other=[]
+                    ),
+                    tags={},
+                ),
+                dg.TableColumn(
+                    name="bar",
+                    type="Int64",
+                    description=None,
+                    constraints=dg.TableColumnConstraints(
+                        nullable=True, unique=False, other=[]
+                    ),
+                    tags={},
+                ),
+            ],
+            constraints=dg.TableConstraints(other=[]),
+        )
+    )
+
+
+def test_patito_eager_happy_path(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(io_manager_def=manager)
+    def upstream() -> TestingRecord.DataFrame:
+        return TestingRecord.DataFrame(good_df)
+
+    @dg.asset(io_manager_def=manager)
+    def downstream(upstream: TestingRecord.DataFrame) -> TestingRecord.DataFrame:
+        return upstream
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([upstream, downstream], instance=instance)
+        assert res.success
+
+
+def test_patito_eager_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(io_manager_def=manager)
+    def bad() -> TestingRecord.DataFrame:
+        return TestingRecord.DataFrame(bad_df)
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([bad], instance=instance, raise_on_error=False)
+        assert not res.success
+
+
+def test_patito_eager_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(io_manager_def=manager)
+    def upstream() -> TestingRecord.DataFrame:
+        return TestingRecord.DataFrame(good_df)
+
+    @dg.asset(io_manager_def=manager)
+    def bad_downstream(upstream: TestingRecord.DataFrame) -> TestingRecord.DataFrame:
+        return TestingRecord.DataFrame(bad_df)
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_lazy_happy_path(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(io_manager_def=manager)
+    def upstream() -> TestingRecord.LazyFrame:
+        return TestingRecord.DataFrame(good_df).lazy()
+
+    @dg.asset(io_manager_def=manager)
+    def downstream(upstream: TestingRecord.LazyFrame) -> TestingRecord.LazyFrame:
+        return upstream
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([upstream, downstream], instance=instance)
+        assert res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_lazy_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(io_manager_def=manager)
+    def bad() -> TestingRecord.LazyFrame:
+        return TestingRecord.DataFrame(bad_df).lazy()
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([bad], instance=instance, raise_on_error=False)
+        assert not res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_lazy_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(io_manager_def=manager)
+    def upstream() -> TestingRecord.LazyFrame:
+        return TestingRecord.DataFrame(good_df).lazy()
+
+    @dg.asset(io_manager_def=manager)
+    def bad_downstream(
+        good_upstream: TestingRecord.LazyFrame,
+    ) -> TestingRecord.LazyFrame:
+        return TestingRecord.DataFrame(bad_df).lazy()
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success
+
+
+def test_patito_type_check_happy_flow(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def upstream() -> pl.DataFrame:
+        return good_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def downstream(upstream: pl.DataFrame) -> pl.DataFrame:
+        return upstream
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([upstream, downstream], instance=instance)
+        assert res.success
+
+
+def test_patito_type_check_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def bad() -> pl.DataFrame:
+        return bad_df
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([bad], instance=instance, raise_on_error=False)
+        assert not res.success
+
+
+def test_patito_type_check_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def upstream() -> pl.DataFrame:
+        return good_df
+
+    @dg.asset(
+        name="bad_downstream",
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def bad_downstream() -> pl.DataFrame:
+        return bad_df
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success
+
+
+def test_dagster_type_with_default_io_manager():
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        dagster_type=dagster_type,
+    )
+    def upstream() -> pl.DataFrame:
+        return good_df
+
+    @dg.asset(
+        name="bad_downstream",
+        dagster_type=dagster_type,
+    )
+    def bad_downstream() -> pl.DataFrame:
+        return bad_df
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [
+                upstream,
+            ],
+            instance=instance,
+        )
+        assert res.success
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success
+
+
+class MaybeReturnConfig(dg.Config):
+    return_value: bool
+
+
+def test_io_manager_with_optional_type(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+) -> None:
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+    )
+    def good(config: MaybeReturnConfig) -> Optional[TestingRecord.DataFrame]:
+        if config.return_value:
+            return TestingRecord.DataFrame(good_df)
+        else:
+            return None
+
+    @dg.asset(
+        io_manager_def=manager,
+    )
+    def bad(config: MaybeReturnConfig) -> Optional[TestingRecord.DataFrame]:
+        if config.return_value:
+            return TestingRecord.DataFrame(bad_df)
+        else:
+            return None
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [good],
+            instance=instance,
+            run_config=dg.RunConfig({"good": MaybeReturnConfig(return_value=True)}),
+            raise_on_error=False,
+        )
+        assert res.success
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [good],
+            instance=instance,
+            run_config=dg.RunConfig({"good": MaybeReturnConfig(return_value=False)}),
+            raise_on_error=False,
+        )
+        assert res.success
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [bad],
+            instance=instance,
+            run_config=dg.RunConfig({"bad": MaybeReturnConfig(return_value=True)}),
+            raise_on_error=False,
+        )
+        assert not res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_type_check_lazy_happy_path(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def upstream() -> pl.LazyFrame:
+        return good_df.lazy()
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def downstream(upstream: pl.LazyFrame) -> pl.LazyFrame:
+        return upstream
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([upstream, downstream], instance=instance)
+        assert res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_type_check_lazy_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def bad() -> pl.LazyFrame:
+        return bad_df.lazy()
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([bad], instance=instance, raise_on_error=False)
+        assert not res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_type_check_lazy_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def upstream() -> pl.LazyFrame:
+        return good_df.lazy()
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=dagster_type,
+    )
+    def bad_downstream() -> pl.LazyFrame:
+        return bad_df.lazy()
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success

--- a/libraries/dagster-polars/pyproject.toml
+++ b/libraries/dagster-polars/pyproject.toml
@@ -25,6 +25,9 @@ dynamic = ["version"]
 [project.optional-dependencies]
 deltalake = ["deltalake>=0.25.0"]
 gcp = ["dagster-gcp>=0.19.5"]
+patito = [
+    "patito>=0.8.3",
+]
 
 [project.urls]
 Repository = "https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-polars"

--- a/libraries/dagster-polars/uv.lock
+++ b/libraries/dagster-polars/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -145,7 +146,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -190,10 +191,10 @@ dependencies = [
     { name = "grpcio-health-checking" },
     { name = "jinja2" },
     { name = "protobuf" },
-    { name = "psutil", marker = "platform_system == 'Windows'" },
+    { name = "psutil", marker = "sys_platform == 'win32'" },
     { name = "python-dotenv" },
     { name = "pytz" },
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "rich" },
     { name = "setuptools" },
@@ -204,7 +205,7 @@ dependencies = [
     { name = "tomli" },
     { name = "toposort" },
     { name = "tqdm" },
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "universal-pathlib" },
     { name = "watchdog" },
 ]
@@ -255,7 +256,6 @@ wheels = [
 
 [[package]]
 name = "dagster-polars"
-version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -271,6 +271,9 @@ deltalake = [
 ]
 gcp = [
     { name = "dagster-gcp" },
+]
+patito = [
+    { name = "patito" },
 ]
 
 [package.dev-dependencies]
@@ -290,11 +293,13 @@ requires-dist = [
     { name = "dagster" },
     { name = "dagster-gcp", marker = "extra == 'gcp'", specifier = ">=0.19.5" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.25.0" },
+    { name = "patito", marker = "extra == 'patito'", specifier = ">=0.8.3" },
     { name = "polars", specifier = ">=0.20.0" },
     { name = "pyarrow", specifier = ">=8.0.0" },
     { name = "typing-extensions", specifier = ">=4.7.0" },
     { name = "universal-pathlib", specifier = ">=0.1.4" },
 ]
+provides-extras = ["deltalake", "gcp", "patito"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1073,6 +1078,20 @@ wheels = [
 ]
 
 [[package]]
+name = "patito"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/77/376b341a49cf5fb2db16daae561f248fb504d65453f137eeda2a1cbbb443/patito-0.8.3.tar.gz", hash = "sha256:aba7ac6bb640a075e1c22862dd577519a615724db0694ac3ae81a6a3f3993fb1", size = 42640 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/f1/4a71d8a974d8f5625045b5351e91e4f93b9a3c14aacbd2777de63c53a851/patito-0.8.3-py3-none-any.whl", hash = "sha256:cc4dd90ec8a867806548a5161af4cf195f3d223fcae24d879285cc003ab89ed4", size = 43331 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1734,7 +1753,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
## Summary & Motivation

Moving https://github.com/dagster-io/dagster/pull/28690 here. 

[Patito](https://patito.readthedocs.io/en/latest/index.html) is a minimalistic data validation library for Polars based on Pydantic. 

Since it can dynamically generate model-specific `DataFrame` and `LazyFrame` classes, we can use it for type annotations in Dagster code right now ([generics](https://github.com/dagster-io/dagster/issues/22694) are not supported by Dagster at the moment). This makes Patito a good option for seamless data validation based on type annotations (in line with the rest of `dagster-polars`), unlike `pandera`, which uses generics. 

This PR:
- allows `dagster-polars` IOManagers to work with Patito DataFrames. Eager frames are automatically validated. Lazy frames aren't (the user would have to call `.validate()` on the eager frame once it's constructed). See https://github.com/JakobGM/patito/issues/145 for `LazyFrame.validate` support. 
- allows building `DagsterType`s from Patito models. Thanks @gfvioli!  

TODO: 
- [X] add docs
- [x] add more tests 
- [x] add tests for nested types like `Optional[MyModel.DataFrame]`

## Summary & Motivation

I would like to finally bring some data validation to `dagster-polars`. 

Patiito type annotation with IOMangers from `dagster-polars`:

```python
import dagster as dg
import patito as pt
import polars as pl

class User(pt.Model):
    uid: str = pt.Field(unique=True)
    age: int = pt.Field(gt=18)


@dg.asset(io_manager_key="polars_parquet_io_manager")
def upstream() -> User.DataFrame:
     return User.DataFrame(my_data)
```

Dagster type builder with any IOManager:

```python
import dagster as dg
import patito as pt
import polars as pl
from dagster_polars.patito import patito_model_to_dagster_type


@dg.asset(dagster_type=patito_model_to_dagster_type(User))
def upstream() -> pl.DataFrame:
     return pl.DataFrame(my_data)
```

## How I Tested These Changes

Added tests

[dagster-polars] The Patito data validation library for Polars is now support in IO managers. DagsterType instances can be built with dagster_polars.patito.patito_model_to_dagster_type.
