### PR TITLE
[dagster-polars] fix DagsterType name generated from patito model

### DIFF
--- a/libraries/dagster-polars/dagster_polars/patito.py
+++ b/libraries/dagster-polars/dagster_polars/patito.py
@@ -91,13 +91,15 @@ def patito_model_to_dagster_type(
     """
     type_check_fn = _patito_model_to_type_check_fn(model)
 
+    model_title = model.__pydantic_core_schema__["config"]["title"]  # pyright: ignore[reportGeneralTypeIssues,reportTypedDictNotRequiredAccess]
+
     dagster_type = DagsterType(
         type_check_fn=type_check_fn,
-        name=model.__class__.__name__,
+        name=name or model_title,
         metadata=get_patito_metadata(model),
         typing_type=model.DataFrame,
         description=description
-        or f"Polars frame conforming to Patito model {model.__class__.__name__}",
+        or f"Polars frame conforming to Patito model {model_title}",
     )
 
     # this is a dirty hack --- this configures dagster-polars IOManager to skip data validation

--- a/libraries/dagster-polars/dagster_polars_tests/test_patito.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_patito.py
@@ -28,6 +28,12 @@ bad_df = pl.DataFrame(
 )
 
 
+def test_patito_model_to_dagster_type():
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
+    assert dagster_type._name == "TestingRecord"
+    assert dagster_type.typing_type == TestingRecord.DataFrame
+
+
 def test_get_patito_metadata():
     metadata = get_patito_metadata(TestingRecord)
     assert metadata["dagster/column_schema"] == dg.TableSchemaMetadataValue(


### PR DESCRIPTION
## Summary & Motivation

The current code always points to the metaclass name by default, which is always the same. This PR fixes this issue. 

## How I Tested These Changes

Added a test
