### PR TITLE
[dagster-contrib-gcp] Bug: job dict mutation

### DIFF
--- a/libraries/dagster-contrib-gcp/CHANGELOG.md
+++ b/libraries/dagster-contrib-gcp/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Updated
 
+- (pull/181) Fixed mutation of job configuration preventing repeat launches of the same job due to KeyError
+
+## 0.0.4
+
+### Updated
+
 - (pull/145) Added support for launching CloudRun runs in multiple GCP Projects
 
 

--- a/libraries/dagster-contrib-gcp/dagster_contrib_gcp/__init__.py
+++ b/libraries/dagster-contrib-gcp/dagster_contrib_gcp/__init__.py
@@ -1,5 +1,5 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 DagsterLibraryRegistry.register("dagster-contrib-gcp", __version__)

--- a/libraries/dagster-contrib-gcp/dagster_contrib_gcp/cloud_run/run_launcher.py
+++ b/libraries/dagster-contrib-gcp/dagster_contrib_gcp/cloud_run/run_launcher.py
@@ -153,9 +153,11 @@ class CloudRunRunLauncher(RunLauncher, ConfigurableClass):
         if isinstance(job, str):
             return None
 
-        job.pop("name")
         env = {}
         for setting_name in job:
+            # job names are expected to be explicit
+            if setting_name == "name":
+                continue
             node_config = job.get(setting_name)
             try:
                 node_config = check.dict_param(node_config, "node_config")

--- a/libraries/dagster-contrib-gcp/uv.lock
+++ b/libraries/dagster-contrib-gcp/uv.lock
@@ -222,7 +222,6 @@ wheels = [
 
 [[package]]
 name = "dagster-contrib-gcp"
-version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary & Motivation
Run launcher logic is errantly mutating the "job" dict. Since the daemon invokes this run launcher, and the daemon is a long-running process, multiple runs of a job will result in the `KeyError: name` 

See below for screenshots confirming behavior in deployed GCP project

## How I Tested These Changes
Deployed changes to running GCP dagster project and validated behavior. 
Separately, `make test`

**Failure**
<img width="1726" alt="Failed-Launch" src="https://github.com/user-attachments/assets/95cc6560-06ef-46a2-ac9a-bfbe84fc8502" />

**Success w/ this proposed change**
<img width="1724" alt="Successful-Launch" src="https://github.com/user-attachments/assets/2331417a-ef5e-451f-ae07-07033a398332" />

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
