### PR TITLE
[dagster-iceberg] Add API docs for classes without

### DIFF
--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -25,6 +25,8 @@ ArrowTypes = pa.Table | pa.RecordBatchReader
 @public
 @preview
 class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
+    """Base class for a type handler that reads inputs from and writes outputs to Iceberg tables."""
+
     @abstractmethod
     def to_data_frame(
         self,

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/spark.py
@@ -130,6 +130,46 @@ class SparkIcebergDbClient(DbClient[SparkSession]):
 @public
 @preview
 class SparkIcebergIOManager(ConfigurableIOManagerFactory):
+    """An I/O manager definition that reads inputs from and writes outputs to Iceberg tables using PySpark.
+
+    This I/O manager is only designed to work with Spark Connect.
+
+    Example:
+        .. code-block:: python
+
+            from dagster import Definitions, asset
+            from dagster_iceberg.io_manager.spark import SparkIcebergIOManager
+            from pyspark.sql import SparkSession
+            from pyspark.sql.connect.dataframe import DataFrame
+
+            resources = {
+                "io_manager": SparkIcebergIOManager(
+                    catalog_name="test",
+                    namespace="dagster",
+                    remote_url="spark://localhost",
+                )
+            }
+
+
+            @asset
+            def iris_dataset() -> DataFrame:
+                spark = SparkSession.builder.remote("sc://localhost").getOrCreate()
+                return spark.read.csv(
+                    "https://docs.dagster.io/assets/iris.csv",
+                    schema=(
+                        "sepal_length_cm FLOAT, "
+                        "sepal_width_cm FLOAT, "
+                        "petal_length_cm FLOAT, "
+                        "petal_width_cm FLOAT, "
+                        "species STRING"
+                    ),
+                )
+
+
+            defs = Definitions(assets=[iris_dataset], resources=resources)
+
+    """
+
     catalog_name: str
     namespace: str
     spark_config: dict[str, Any] | None = Field(default=None)


### PR DESCRIPTION
## Summary & Motivation

Some classes included in the documentation are currently missing docstrings.

## How I Tested These Changes

Built docs locally:

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/e88aeecd-55ea-4699-a854-d0e90fd941c5" />

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/895d0c34-d724-4b8d-8735-70dacde62472" />