### PR TITLE
[dagster-polars] fix ImportError with patito and ensure optional deps are not imported at top level

### DIFF
--- a/libraries/dagster-polars/CHANGELOG.md
+++ b/libraries/dagster-polars/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+## Fixes
+
+- Fixed `ImportError` when `patito` is not installed
+
 ## 0.27.2
 
 ### Fixed

--- a/libraries/dagster-polars/dagster_polars/io_managers/base.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/base.py
@@ -11,6 +11,8 @@ from dagster import (
     MetadataValue,
     OutputContext,
     UPathIOManager,
+)
+from dagster import (
     _check as check,
 )
 from pydantic import PrivateAttr

--- a/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -1,3 +1,5 @@
+import importlib
+import importlib.util
 import sys
 from abc import abstractmethod
 from collections.abc import Mapping
@@ -12,6 +14,7 @@ from typing import (
     get_args,
     get_origin,
 )
+
 from dagster._core.types.dagster_type import TypeHintInferredDagsterType
 
 if sys.version_info < (3, 10):
@@ -229,13 +232,18 @@ class PatitoTypeRouter(BaseTypeRouter, Generic[T]):
         return self.typing_type.model
 
 
+# Order matters!
 TYPE_ROUTERS = [
     TypeRouter,
     OptionalTypeRouter,
     DictTypeRouter,
-    PatitoTypeRouter,
-    PolarsTypeRouter,
 ]
+
+if importlib.util.find_spec("patito") is not None:
+    TYPE_ROUTERS.append(PatitoTypeRouter)
+
+
+TYPE_ROUTERS.append(PolarsTypeRouter)
 
 
 def resolve_type_router(

--- a/libraries/dagster-polars/dagster_polars/patito.py
+++ b/libraries/dagster-polars/dagster_polars/patito.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Optional, Mapping
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 
 import polars as pl
 from dagster import (

--- a/libraries/dagster-polars/dagster_polars_tests/conftest.py
+++ b/libraries/dagster-polars/dagster_polars_tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_cases
 from _pytest.tmpdir import TempPathFactory
 from dagster import BetaWarning, DagsterInstance, PreviewWarning
+
 from dagster_polars import (
     BasePolarsUPathIOManager,
     PolarsDeltaIOManager,

--- a/libraries/dagster-polars/dagster_polars_tests/example.py
+++ b/libraries/dagster-polars/dagster_polars_tests/example.py
@@ -2,6 +2,7 @@
 
 import polars as pl
 from dagster import Definitions, asset
+
 from dagster_polars import PolarsDeltaIOManager, PolarsParquetIOManager
 
 

--- a/libraries/dagster-polars/dagster_polars_tests/test_patito.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_patito.py
@@ -4,6 +4,7 @@ import dagster as dg
 import patito as pt  # noqa: TID253
 import polars as pl
 import pytest
+
 from dagster_polars import BasePolarsUPathIOManager
 from dagster_polars.patito import get_patito_metadata, patito_model_to_dagster_type
 

--- a/libraries/dagster-polars/dagster_polars_tests/test_polars_delta.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_polars_delta.py
@@ -21,10 +21,10 @@ from dagster import (
     asset,
     materialize,
 )
+from deltalake import DeltaTable  # noqa: TID253
+
 from dagster_polars import PolarsDeltaIOManager
 from dagster_polars.io_managers.delta import DeltaWriteMode
-from deltalake import DeltaTable
-
 from dagster_polars_tests.utils import get_saved_path
 
 

--- a/libraries/dagster-polars/dagster_polars_tests/test_polars_parquet.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_polars_parquet.py
@@ -3,10 +3,10 @@ import os
 import polars as pl
 import polars.testing as pl_testing
 from dagster import asset, materialize
-from dagster_polars import PolarsParquetIOManager
 from hypothesis import given, settings
 from polars.testing.parametric import dataframes
 
+from dagster_polars import PolarsParquetIOManager
 from dagster_polars_tests.utils import get_saved_path
 
 

--- a/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers.py
@@ -19,6 +19,7 @@ from dagster import (
     asset,
     materialize,
 )
+
 from dagster_polars import (
     BasePolarsUPathIOManager,
     DataFramePartitions,
@@ -26,7 +27,6 @@ from dagster_polars import (
     PolarsDeltaIOManager,
     PolarsParquetIOManager,
 )
-
 from dagster_polars_tests.utils import get_saved_path
 
 

--- a/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers_lazy.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers_lazy.py
@@ -19,13 +19,13 @@ from dagster import (
     asset,
     materialize,
 )
+
 from dagster_polars import (
     BasePolarsUPathIOManager,
     LazyFramePartitions,
     PolarsDeltaIOManager,
     PolarsParquetIOManager,
 )
-
 from dagster_polars_tests.utils import get_saved_path
 
 

--- a/libraries/dagster-polars/pyproject.toml
+++ b/libraries/dagster-polars/pyproject.toml
@@ -60,3 +60,12 @@ version = {attr = "dagster_polars.version.__version__"}
 [tool.pyright]
 include = ["dagster_polars"]
 reportPrivateImportUsage = false
+
+
+[tool.ruff.lint]
+extend-select = ["I", "TID252", "TID253"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"
+banned-module-level-imports = ["patito", "deltalake", "dagster-gcp"]


### PR DESCRIPTION
## Summary & Motivation

This PR fixes #191 and adds a ruff rule to prevent similar errors in the future. 
It also enables import sorting for ruff which was missing. 

## How I Tested These Changes

Existing test suite

## Changelog

- Fixed `ImportError` when `patito` is not installed

