### PR TITLE
Evidence resource

### DIFF
--- a/libraries/dagster-evidence/dagster_evidence/__init__.py
+++ b/libraries/dagster-evidence/dagster_evidence/__init__.py
@@ -1,10 +1,15 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_evidence.lib.evidence_project import EvidenceProject
+from dagster_evidence.resource import (
+    EvidenceResource,
+    load_evidence_asset_specs,
+    EvidenceFilter,
+)
 
 __version__ = "0.1.5"
 
-__all__ = [EvidenceProject]
+__all__ = [EvidenceProject, EvidenceResource, load_evidence_asset_specs, EvidenceFilter]
 
 DagsterLibraryRegistry.register(
     "dagster-evidence", __version__, is_dagster_package=False

--- a/libraries/dagster-evidence/dagster_evidence/__init__.py
+++ b/libraries/dagster-evidence/dagster_evidence/__init__.py
@@ -1,15 +1,11 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_evidence.lib.evidence_project import EvidenceProject
-from dagster_evidence.resource import (
-    EvidenceResource,
-    load_evidence_asset_specs,
-    EvidenceFilter,
-)
+from dagster_evidence.resource import EvidenceResource
 
 __version__ = "0.1.5"
 
-__all__ = [EvidenceProject, EvidenceResource, load_evidence_asset_specs, EvidenceFilter]
+__all__ = [EvidenceProject, EvidenceResource]
 
 DagsterLibraryRegistry.register(
     "dagster-evidence", __version__, is_dagster_package=False

--- a/libraries/dagster-evidence/dagster_evidence/resource.py
+++ b/libraries/dagster-evidence/dagster_evidence/resource.py
@@ -1,11 +1,9 @@
 import os
 import sys
 import subprocess
-from typing import Optional, Sequence, List
+from typing import Optional, Sequence
 import dagster as dg
 from pydantic import Field
-from dagster import AssetSpec, multi_asset
-from dataclasses import dataclass
 
 
 class EvidenceResource(dg.ConfigurableResource):
@@ -25,42 +23,30 @@ class EvidenceResource(dg.ConfigurableResource):
 
             evidence_resource = EvidenceResource(
                 project_path="/path/to/evidence/project",
-                deploy_command="your-deploy-command",
+                deploy_command="optional-deploy-command",  # eg. `aws s3 cp ...`
             )
 
             defs = dg.Definitions(
                 assets=[evidence_application],
                 resources={"evidence": evidence_resource}
             )
-
-        .. code-block:: python
-
-            import dagster as dg
-            from dagster_evidence import EvidenceResource, load_evidence_asset_specs
-
-            evidence_resource = EvidenceResource(
-                project_path="/path/to/evidence/project",
-                deploy_command="your-deploy-command",
-            )
-
-            evidence_specs = load_evidence_asset_specs(evidence_resource)
-
-            defs = dg.Definitions(
-                assets=evidence_specs,
-                resources={"evidence": evidence_resource}
-            )
-
     """
 
     project_path: str = Field(..., description="The path to the Evidence.dev project")
     deploy_command: Optional[str] = Field(
         None, description="Command to deploy the built assets"
     )
-    npm_executable: str = Field(
-        default="npm", description="The executable to use for npm commands"
+    executable: str = Field(
+        default="npm",
+        description="The executable to use for commands (npm, yarn, etc.)",
     )
 
     def _run_cmd(self, cmd: Sequence[str]):
+        """Run a command in the project directory.
+
+        Args:
+            cmd: The command to run as a sequence of strings.
+        """
         print(
             f"{self.project_path}$ {' '.join(cmd)}",
             file=sys.stderr,
@@ -74,71 +60,10 @@ class EvidenceResource(dg.ConfigurableResource):
         )
 
     def build(self) -> None:
-        """Build the Evidence project."""
-        self._run_cmd([self.npm_executable, "run", "build"])
+        """Build the Evidence project.
 
-    def sources(self, source: Optional[str] = None) -> None:
-        """Run sources from the specified source.
-
-        Args:
-            source: The name of the source to run. If None, runs all sources.
+        1. Run all sources to fetch data
+        2. Build the project to generate the dashboard
         """
-        cmd = [self.npm_executable, "run", "sources"]
-
-        if source:
-            cmd.append(f"--sources={source}")
-
-        self._run_cmd(cmd)
-
-
-@dataclass
-class EvidenceFilter:
-    """Filter for Evidence assets.
-
-    Args:
-        sources: List of source names to include. If None, all sources are included.
-        only_fetch_dashboards: If True, only fetch dashboards and skip other assets.
-    """
-
-    sources: Optional[List[str]] = None
-    only_fetch_dashboards: bool = False
-
-
-def load_evidence_asset_specs(
-    evidence_resource: EvidenceResource,
-    evidence_filter: Optional[EvidenceFilter] = None,
-) -> List[dg.AssetsDefinition]:
-    """Load Evidence assets as Dagster asset specs.
-
-    Args:
-        evidence_resource: The Evidence resource to use.
-        evidence_filter: Optional filter to limit which assets are loaded.
-
-    Returns:
-        List of Dagster asset definitions.
-    """
-    evidence_filter = evidence_filter or EvidenceFilter()
-
-    specs = []
-    if evidence_filter.sources is not None:
-        for source in evidence_filter.sources:
-            specs.append(
-                AssetSpec(
-                    key=source,
-                    group_name="evidence",
-                    description=f"Evidence source: {source}",
-                )
-            )
-
-    @multi_asset(
-        specs=specs,
-    )
-    def evidence_assets(evidence_resource: EvidenceResource):
-        """Evidence assets for running sources and building dashboards."""
-        if evidence_filter.sources is not None:
-            for source in evidence_filter.sources:
-                evidence_resource.sources(source=source)
-        evidence_resource.build()
-        return None
-
-    return [evidence_assets]
+        self._run_cmd([self.executable, "run", "sources"])
+        self._run_cmd([self.executable, "run", "build"])

--- a/libraries/dagster-evidence/dagster_evidence/resource.py
+++ b/libraries/dagster-evidence/dagster_evidence/resource.py
@@ -1,0 +1,147 @@
+import os
+import sys
+import subprocess
+from typing import Optional, Sequence, List
+import dagster as dg
+from pydantic import Field
+from dagster import AssetSpec, multi_asset
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class EvidenceResource(dg.ConfigurableResource):
+    """A Dagster resource for managing Evidence.dev projects.
+
+    This resource provides functionality to build and deploy Evidence.dev dashboards.
+    It assumes that you have already created an Evidence.dev project. Read [the Evidence docs](https://docs.evidence.dev/) for more information.
+
+    Examples:
+        .. code-block:: python
+            import dagster as dg
+            from dagster_evidence import EvidenceResource, load_evidence_asset_specs
+
+            @dg.asset
+            def evidence_dashboard(evidence: EvidenceResource):
+                evidence.build()
+
+            defs = dg.Definitions(
+                assets=evidence_specs,
+                resources={"evidence": evidence_resource}
+            )
+
+        .. code-block:: python
+
+            import dagster as dg
+            from dagster_evidence import EvidenceResource, load_evidence_asset_specs
+
+            evidence_resource = EvidenceResource(
+                project_path="/path/to/evidence/project",
+                deploy_command="your-deploy-command",
+            )
+
+            evidence_specs = load_evidence_asset_specs(evidence_resource)
+
+            defs = dg.Definitions(
+                assets=evidence_specs,
+                resources={"evidence": evidence_resource}
+            )
+
+    """
+
+    project_path: str = Field(..., description="The path to the Evidence.dev project")
+    deploy_command: Optional[str] = Field(
+        None, description="Command to deploy the built assets"
+    )
+    npm_executable: str = Field(
+        default="npm", description="The executable to use for npm commands"
+    )
+
+    def _run_cmd(self, cmd: Sequence[str]):
+        print(
+            f"{self.project_path}$ {' '.join(cmd)}",
+            file=sys.stderr,
+        )
+        subprocess.run(
+            cmd,
+            cwd=self.project_path,
+            check=True,
+            capture_output=False,
+            env=os.environ,
+        )
+
+    def build(self) -> None:
+        """Build the Evidence project by running the sources and build commands."""
+        self._run_cmd([self.npm_executable, "run", "sources"])
+        self._run_cmd([self.npm_executable, "run", "build"])
+
+
+@dataclass
+class EvidenceFilter:
+    """Filter for Evidence assets.
+
+    Args:
+        dashboard_directories: List of dashboard directory paths to include. If None, all dashboards are included.
+        only_fetch_dashboards: If True, only fetch dashboards and skip other assets.
+    """
+
+    dashboard_directories: Optional[List[str]] = None
+    only_fetch_dashboards: bool = False
+
+
+def load_evidence_asset_specs(
+    evidence_resource: EvidenceResource,
+    evidence_filter: Optional[EvidenceFilter] = None,
+) -> List[dg.AssetsDefinition]:
+    """Load Evidence assets as Dagster asset specs.
+
+    Args:
+        evidence_resource: The Evidence resource to use.
+        evidence_filter: Optional filter to limit which assets are loaded.
+
+    Returns:
+        List of Dagster asset definitions.
+    """
+    evidence_filter = evidence_filter or EvidenceFilter()
+
+    project_path = Path(evidence_resource.project_path)
+    pages_dir = project_path / "pages"
+
+    specs = []
+    for md_file in pages_dir.rglob("*.md"):
+        # Skip files not in filtered directories if filter is provided
+        if evidence_filter.dashboard_directories:
+            relative_path = md_file.relative_to(pages_dir)
+            parent_dir = relative_path.parent
+            if str(parent_dir) not in evidence_filter.dashboard_directories:
+                continue
+
+        asset_key = md_file.with_suffix("").name
+
+        specs.append(
+            AssetSpec(
+                key=asset_key,
+                group_name="evidence",
+                description=f"Evidence page: {md_file.relative_to(pages_dir)}",
+            )
+        )
+
+    if not evidence_filter.only_fetch_dashboards:
+        specs.extend(
+            [
+                AssetSpec(
+                    key="evidence_build",
+                    group_name="evidence",
+                    description="Build Evidence project",
+                ),
+            ]
+        )
+
+    @multi_asset(
+        specs=specs,
+    )
+    def evidence_assets(evidence_resource: EvidenceResource):
+        """Evidence assets for building and deploying dashboards."""
+        evidence_resource.build()
+        return None
+
+    return [evidence_assets]

--- a/libraries/dagster-evidence/dagster_evidence_tests/test_evidence_resource.py
+++ b/libraries/dagster-evidence/dagster_evidence_tests/test_evidence_resource.py
@@ -1,0 +1,192 @@
+from unittest.mock import patch
+import pytest
+import dagster as dg
+from dagster._core.execution.context.init import build_init_resource_context
+from dagster._utils.test import wrap_op_in_graph_and_execute
+from dagster_evidence import EvidenceResource, load_evidence_asset_specs, EvidenceFilter
+import subprocess
+import json
+
+
+@pytest.fixture
+def mock_evidence_project(tmp_path):
+    """Create a mock Evidence project structure."""
+    project_path = tmp_path / "evidence-project"
+    project_path.mkdir()
+
+    # Define directory structure
+    directories = [
+        "pages",
+        "pages/marketing-dashboard",
+        "pages/finance-dashboard",
+        "pages/ops-dashboard",
+    ]
+
+    # Create directories
+    for dir_path in directories:
+        (project_path / dir_path).mkdir()
+
+    # Define dashboard files
+    dashboard_files = [
+        "pages/marketing-dashboard/funnel.md",
+        "pages/marketing-dashboard/retention.md",
+        "pages/finance-dashboard/revenue-trends.md",
+        "pages/ops-dashboard/on-time-delivery.md",
+    ]
+
+    # Create dashboard files
+    for file_path in dashboard_files:
+        (project_path / file_path).touch()
+
+    # Create package.json
+    package_json = {
+        "name": "evidence-project",
+        "version": "1.0.0",
+        "scripts": {"sources": "evidence sources", "build": "evidence build"},
+        "dependencies": {"@evidence-dev/evidence": "^0.1.0"},
+    }
+    with open(project_path / "package.json", "w") as f:
+        json.dump(package_json, f)
+
+    return str(project_path)
+
+
+@pytest.fixture
+def mock_subprocess_run():
+    with patch("subprocess.run") as mock_run:
+        yield mock_run
+
+
+@pytest.fixture
+def evidence_resource(mock_evidence_project):
+    return EvidenceResource(
+        project_path=mock_evidence_project,
+        deploy_command="echo 'deploy'",
+        npm_executable="npm",
+    )
+
+
+def test_evidence_resource_setup(evidence_resource):
+    evidence_resource.setup_for_execution(build_init_resource_context())
+    assert evidence_resource.project_path == evidence_resource.project_path
+    assert evidence_resource.deploy_command == "echo 'deploy'"
+    assert evidence_resource.npm_executable == "npm"
+
+
+@patch("dagster.OpExecutionContext", autospec=dg.OpExecutionContext)
+def test_evidence_resource_with_op(
+    mock_context, mock_subprocess_run, evidence_resource
+):
+    @dg.op
+    def evidence_op(evidence_resource: EvidenceResource):
+        assert evidence_resource
+        evidence_resource.build()
+
+    result = wrap_op_in_graph_and_execute(
+        evidence_op,
+        resources={"evidence_resource": evidence_resource},
+    )
+    assert result.success
+    assert mock_subprocess_run.call_count == 2
+
+
+@patch("dagster.AssetExecutionContext", autospec=dg.AssetExecutionContext)
+def test_evidence_resource_with_asset(
+    mock_context, mock_subprocess_run, evidence_resource
+):
+    @dg.asset
+    def evidence_asset(evidence_resource: EvidenceResource):
+        assert evidence_resource
+        evidence_resource.build()
+
+    result = dg.materialize_to_memory(
+        [evidence_asset],
+        resources={"evidence_resource": evidence_resource},
+    )
+    assert result.success
+    assert mock_subprocess_run.call_count == 2
+
+
+@patch("dagster.AssetExecutionContext", autospec=dg.AssetExecutionContext)
+def test_evidence_resource_with_multi_asset(
+    mock_context, mock_subprocess_run, evidence_resource
+):
+    @dg.multi_asset(
+        specs=[dg.AssetSpec("build"), dg.AssetSpec("deploy")],
+    )
+    def evidence_multi_asset(evidence_resource: EvidenceResource):
+        assert evidence_resource
+        evidence_resource.build()
+        return None, None
+
+    result = dg.materialize_to_memory(
+        [evidence_multi_asset],
+        resources={"evidence_resource": evidence_resource},
+    )
+    assert result.success
+    assert mock_subprocess_run.call_count == 2
+
+
+def test_evidence_resource_error_handling(evidence_resource, mock_subprocess_run):
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+        1, "npm run sources"
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        evidence_resource.build()
+
+
+def test_load_evidence_asset_specs(mock_evidence_project):
+    """Test that load_evidence_asset_specs returns the correct asset specs."""
+    resource = EvidenceResource(project_path=mock_evidence_project)
+    specs = load_evidence_asset_specs(resource)
+
+    assert len(specs) == 1
+    asset_def = specs[0]
+    assert len(asset_def.specs) == 5
+
+    asset_keys = {spec.key for spec in asset_def.specs}
+    expected_keys = {
+        dg.AssetKey(["funnel"]),
+        dg.AssetKey(["retention"]),
+        dg.AssetKey(["revenue-trends"]),
+        dg.AssetKey(["on-time-delivery"]),
+        dg.AssetKey(["evidence_build"]),
+    }
+    assert asset_keys == expected_keys
+
+
+def test_load_evidence_asset_specs_with_filter(mock_evidence_project):
+    """Test that load_evidence_asset_specs respects the EvidenceFilter."""
+    resource = EvidenceResource(project_path=mock_evidence_project)
+
+    filter = EvidenceFilter(dashboard_directories=["marketing-dashboard"])
+    specs = load_evidence_asset_specs(resource, evidence_filter=filter)
+    assert len(specs) == 1
+    asset_def = specs[0]
+    assert len(asset_def.specs) == 3
+
+    asset_keys = {spec.key for spec in asset_def.specs}
+    expected_keys = {
+        dg.AssetKey(["funnel"]),
+        dg.AssetKey(["retention"]),
+        dg.AssetKey(["evidence_build"]),
+    }
+    assert asset_keys == expected_keys
+
+    multi_filter = EvidenceFilter(
+        dashboard_directories=["marketing-dashboard", "finance-dashboard"]
+    )
+    multi_specs = load_evidence_asset_specs(resource, evidence_filter=multi_filter)
+    assert len(multi_specs) == 1
+    asset_def_multi = multi_specs[0]
+    assert len(asset_def_multi.specs) == 4
+
+    multi_asset_keys = {spec.key for spec in asset_def_multi.specs}
+    multi_expected_keys = {
+        dg.AssetKey(["funnel"]),
+        dg.AssetKey(["retention"]),
+        dg.AssetKey(["revenue-trends"]),
+        dg.AssetKey(["evidence_build"]),
+    }
+    assert multi_asset_keys == multi_expected_keys

--- a/libraries/dagster-evidence/dagster_evidence_tests/test_evidence_resource.py
+++ b/libraries/dagster-evidence/dagster_evidence_tests/test_evidence_resource.py
@@ -138,12 +138,14 @@ def test_evidence_resource_error_handling(evidence_resource, mock_subprocess_run
 
 def test_load_evidence_asset_specs(mock_evidence_project):
     """Test that load_evidence_asset_specs returns the correct asset specs."""
-    resource = EvidenceResource(project_path=mock_evidence_project)
+    resource = EvidenceResource(
+        project_path=mock_evidence_project, deploy_command="echo 'deploy'"
+    )
     specs = load_evidence_asset_specs(resource)
 
     assert len(specs) == 1
     asset_def = specs[0]
-    assert len(asset_def.specs) == 5
+    assert len(list(asset_def.specs)) == 5
 
     asset_keys = {spec.key for spec in asset_def.specs}
     expected_keys = {
@@ -158,14 +160,17 @@ def test_load_evidence_asset_specs(mock_evidence_project):
 
 def test_load_evidence_asset_specs_with_filter(mock_evidence_project):
     """Test that load_evidence_asset_specs respects the EvidenceFilter."""
-    resource = EvidenceResource(project_path=mock_evidence_project)
+    resource = EvidenceResource(
+        project_path=mock_evidence_project, deploy_command="echo 'deploy'"
+    )
 
     filter = EvidenceFilter(dashboard_directories=["marketing-dashboard"])
     specs = load_evidence_asset_specs(resource, evidence_filter=filter)
     assert len(specs) == 1
     asset_def = specs[0]
-    assert len(asset_def.specs) == 3
+    assert len(list(asset_def.specs)) == 3
 
+    # Verify filtered assets
     asset_keys = {spec.key for spec in asset_def.specs}
     expected_keys = {
         dg.AssetKey(["funnel"]),
@@ -180,7 +185,7 @@ def test_load_evidence_asset_specs_with_filter(mock_evidence_project):
     multi_specs = load_evidence_asset_specs(resource, evidence_filter=multi_filter)
     assert len(multi_specs) == 1
     asset_def_multi = multi_specs[0]
-    assert len(asset_def_multi.specs) == 4
+    assert len(list(asset_def_multi.specs)) == 4
 
     multi_asset_keys = {spec.key for spec in asset_def_multi.specs}
     multi_expected_keys = {


### PR DESCRIPTION
## Summary & Motivation

Include a resource for the Evidence integration.

**Basic**
```python
import dagster as dg
from dagster_evidence import EvidenceResource

@dg.asset
def evidence_application(evidence: EvidenceResource):
    evidence.build()

evidence_resource = EvidenceResource(
    project_path="/path/to/evidence/project",
    deploy_command="your-deploy-command",
)

defs = dg.Definitions(
    assets=[evidence_application],
    resources={"evidence": evidence_resource}
)
```

## How I Tested These Changes

-

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
