### PR TITLE
[dagster-polars] fix: sanitize config passed to polars.scan_parquet

### DIFF
--- a/libraries/dagster-polars/CHANGELOG.md
+++ b/libraries/dagster-polars/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed use of deprecated streaming engine selector in polars collect.
 - Bump polars dev dependency to support latest deltalake syntax
 - Fixed `ImportError` when `patito` is not installed
+- Fixed groupings of iomanager config allowing inclusion of s3fs and polars options.
 
 ## 0.27.2
 


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/community-integrations/issues/219
https://github.com/dagster-io/dagster/issues/28633

related issues, since it's a dictionary passed in where only string values are allowed, the solution was to remove that key from a copy of the dictionary. Should be okay to use `del` on a key for a value that is a collection if a copy is made without affecting at the call site.

## How I Tested These Changes

- I did not test, I will do this, I may need help?

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
