### PR TITLE
[pipes-java] fix JAR building and test dependencies

### DIFF
--- a/libraries/pipes/implementations/java/build.gradle
+++ b/libraries/pipes/implementations/java/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     annotationProcessor 'info.picocli:picocli-codegen:4.7.6'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
     implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.17'
 }
 

--- a/libraries/pipes/implementations/java/build.gradle
+++ b/libraries/pipes/implementations/java/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java'
+    id 'java-library'
+    id 'application'
     id 'pmd'
     id 'checkstyle'
     id "com.vanniktech.maven.publish" version "0.30.0"
@@ -55,9 +56,9 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.18.0'
     implementation 'info.picocli:picocli:4.7.6'
     annotationProcessor 'info.picocli:picocli-codegen:4.7.6'
-    implementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    implementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
-    implementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
     implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.17'
 }
 
@@ -65,13 +66,34 @@ test {
     useJUnitPlatform()
 }
 
-jar {
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } +
-            sourceSets.main.output + sourceSets.test.output
+tasks.register('testJar', Jar) {
+    archiveClassifier.set("tests")
+    from sourceSets.test.output
+}
+tasks.named('assemble') {
+    dependsOn(tasks.named('testJar'))
+}
+application {
+    mainClass.set('io.dagster.pipes.MainTest')
+}
+tasks.named('startScripts') {
+    applicationName = "mainTest"
+    classpath = files(tasks.jar.archiveFile) + files(tasks.testJar.archiveFile) + sourceSets.test.runtimeClasspath
+}
+distributions {
+    main {
+        contents {
+            // copy our test classes jar file into the install dir
+            from(tasks.named('testJar').flatMap { it.archiveFile }) {
+                into 'lib'
+            }
+            // copy the test dependencies
+            from(configurations.testRuntimeClasspath) {
+                into 'lib'
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            }
+        }
     }
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    dependsOn compileJava, compileTestJava, processTestResources
 }
 
 pmd {
@@ -88,7 +110,7 @@ checkstyle {
 checkstyleMain
     .exclude('**/types/**')
 
-tasks.withType(Pmd) {
+tasks.withType(Pmd).configureEach {
     // Exclude generated types files from analysis
     exclude '**/types/**'
     ruleSetFiles = files('config/pmd-ruleset.xml')

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContext.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContext.java
@@ -38,55 +38,195 @@ public interface PipesContext extends AutoCloseable {
         return PipesContextInstance.get();
     }
 
+
+    /**
+     * Reports an exception that should terminate execution. The exception will be
+     * propagated to Dagster when the context is closed.
+     *
+     * @param exception Exception to report
+     */
     void reportException(Exception exception);
 
+    /**
+     * Closes the context and flushes pending messages. This must be called to
+     * ensure proper cleanup and exception reporting.
+     *
+     * @throws DagsterPipesException If an error occurs during close or if a
+     *         previously reported exception exists
+     */
     @Override
     void close() throws DagsterPipesException;
 
+    /**
+     * Reports a custom message payload.
+     *
+     * @param payload Custom data to report (will be serialized)
+     * @throws DagsterPipesException If context is already closed
+     */
     void reportCustomMessage(Object payload) throws DagsterPipesException;
 
+    /**
+     * Checks if the context has been closed.
+     *
+     * @return True or false
+     */
     boolean isClosed();
 
+    /**
+     * Determines if the current step targets assets.
+     *
+     * @return True if asset keys are defined in the context, false otherwise
+     */
     boolean isAssetStep();
 
+    /**
+     * Gets the single asset key for the current step. Valid only for single-asset steps.
+     *
+     * @return Single asset key
+     * @throws DagsterPipesException If no assets or multiple assets are targeted
+     */
     String getAssetKey() throws DagsterPipesException;
 
+    /**
+     * Gets all asset keys targeted by the current step.
+     *
+     * @return List of asset keys (non-empty)
+     * @throws DagsterPipesException If no assets are targeted
+     */
     List<String> getAssetKeys() throws DagsterPipesException;
 
+    /**
+     * Gets provenance data for the single asset in the current step.
+     *
+     * @return Provenance data for the asset
+     * @throws DagsterPipesException If no assets or multiple assets are targeted
+     */
     ProvenanceByAssetKey getProvenance() throws DagsterPipesException;
 
+    /**
+     * Gets provenance data by asset key.
+     *
+     * @return Map of asset keys to provenance data (non-empty)
+     * @throws DagsterPipesException If no assets are targeted
+     */
     Map<String, ProvenanceByAssetKey> getProvenanceByAssetKey() throws DagsterPipesException;
 
+    /**
+     * Gets code version for the single asset in the current step.
+     *
+     * @return Code version string
+     * @throws DagsterPipesException If no assets or multiple assets are targeted
+     */
     String getCodeVersion() throws DagsterPipesException;
 
+    /**
+     * Gets code versions keyed by asset.
+     *
+     * @return Map of asset keys to code versions (non-empty)
+     * @throws DagsterPipesException If no assets are targeted
+     */
     Map<String, String> getCodeVersionByAssetKey() throws DagsterPipesException;
 
+    /**
+     * Determines if the current step is partitioned.
+     *
+     * @return True if partition data exists in context, false otherwise
+     */
     boolean isPartitionStep();
 
+    /**
+     * Gets the partition key for the current step.
+     *
+     * @return Current partition key
+     * @throws DagsterPipesException If no partition is defined
+     */
     String getPartitionKey() throws DagsterPipesException;
 
+    /**
+     * Gets the partition key range for the current step.
+     *
+     * @return Partition key range
+     * @throws DagsterPipesException If no partition range is defined
+     */
     PartitionKeyRange getPartitionKeyRange() throws DagsterPipesException;
 
+    /**
+     * Gets the partition time window for the current step.
+     *
+     * @return Partition time window
+     * @throws DagsterPipesException If no time window is defined
+     */
     PartitionTimeWindow getPartitionTimeWindow() throws DagsterPipesException;
 
+    /**
+     * Gets the Dagster run ID.
+     *
+     * @return Run ID string
+     */
     String getRunId();
 
+    /**
+     * Gets the Dagster job name.
+     *
+     * @return Job name string
+     */
     String getJobName();
 
+    /**
+     * Gets the current retry attempt number.
+     *
+     * @return Integer retry number
+     */
     int getRetryNumber();
 
+
+    /**
+     * Gets a specific extra context parameter by key.
+     *
+     * @param key The key to retrieve
+     * @return Parameter value
+     * @throws DagsterPipesException If key is not found in extras
+     */
     Object getExtra(String key) throws DagsterPipesException;
 
+    /**
+     * Gets all extra context parameters.
+     *
+     * @return Map of extra parameters
+     */
     Map<String, Object> getExtras();
 
+    /**
+     * Gets the {@link PipesLogger} instance.
+     *
+     * @return The {@link PipesLogger} instance
+     */
     PipesLogger getLogger();
 
+    /**
+     * Reports asset materialization.
+     *
+     * @param metadataMapping Metadata values keyed by label
+     * @param dataVersion Data version string
+     * @param assetKey Explicit asset key (null to use context's single asset)
+     * @throws DagsterPipesException If asset key is invalid or context is closed
+     * @throws IllegalStateException If asset has already been materialized
+     */
     void reportAssetMaterialization(
             Map<String, ?> metadataMapping,
             String dataVersion,
             String assetKey
     ) throws DagsterPipesException;
 
+    /**
+     * Reports an asset check result (convenience method with default ERROR severity).
+     *
+     * @param checkName Unique check identifier
+     * @param passed Whether the check succeeded
+     * @param metadataMapping Metadata keyed by label
+     * @param assetKey Explicit asset key (null to use context's single asset)
+     * @throws DagsterPipesException If asset key is invalid or context is closed
+     */
     void reportAssetCheck(
             String checkName,
             boolean passed,
@@ -94,6 +234,16 @@ public interface PipesContext extends AutoCloseable {
             String assetKey
     ) throws DagsterPipesException;
 
+    /**
+     * Reports an asset check result with custom severity.
+     *
+     * @param checkName Unique check identifier
+     * @param passed Whether the check succeeded
+     * @param severity Severity level
+     * @param metadataMapping Metadata keyed by label
+     * @param assetKey Explicit asset key (null to use context's single asset)
+     * @throws DagsterPipesException If parameters are invalid or context is closed
+     */
     void reportAssetCheck(
             String checkName,
             boolean passed,

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContext.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContext.java
@@ -1,119 +1,22 @@
 package io.dagster.pipes;
 
 import io.dagster.pipes.data.PipesAssetCheckSeverity;
-import io.dagster.pipes.data.PipesContextData;
-import io.dagster.pipes.data.PipesException;
-import io.dagster.pipes.data.PipesMetadata;
-import io.dagster.pipes.loaders.PipesContextLoader;
-import io.dagster.pipes.loaders.PipesParamsLoader;
 import io.dagster.pipes.logger.PipesLogger;
-import io.dagster.pipes.utils.PipesUtils;
-import io.dagster.pipes.writers.PipesMessageWriter;
-import io.dagster.pipes.writers.PipesMessageWriterChannel;
-import io.dagster.types.Method;
 import io.dagster.types.PartitionKeyRange;
 import io.dagster.types.PartitionTimeWindow;
 import io.dagster.types.ProvenanceByAssetKey;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Logger;
 
-/**
- * Provides execution context and communication mechanisms for Dagster pipes.
- * This singleton class manages asset materialization tracking, message writing,
- * and context data access for external execution environments.
- *
- * <p>Key responsibilities include:
- * <ul>
- *   <li>Initializing and managing communication channels with Dagster</li>
- *   <li>Tracking asset materialization state</li>
- *   <li>Providing access to execution context (assets, partitions, run info)</li>
- *   <li>Reporting results and exceptions back to Dagster</li>
- * </ul>
- */
-@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods", "PMD.ImmutableField"})
-public class PipesContext {
 
-    private static PipesContext instance;
-    private PipesContextData data;
-    private PipesMessageWriterChannel messageChannel;
-    private final Set<String> materializedAssets;
-    private boolean closed;
-    private final PipesLogger logger;
-    private Exception exception;
-
-    /**
-     * Constructor.
-     *
-     * @param paramsLoader Loader for context and message parameters
-     * @param contextLoader Loader for deserializing context data
-     * @param messageWriter Writer for opening message channels
-     * @throws DagsterPipesException If initialization fails or required parameters are missing
-     */
-    public PipesContext(
-        final PipesParamsLoader paramsLoader,
-        final PipesContextLoader contextLoader,
-        final PipesMessageWriter<? extends PipesMessageWriterChannel> messageWriter
-    ) throws DagsterPipesException {
-        final Optional<Map<String, Object>> contextParams = paramsLoader.loadContextParams();
-        final Optional<Map<String, Object>> messageParams = paramsLoader.loadMessagesParams();
-        if (contextParams.isPresent() && messageParams.isPresent()) {
-            this.data = contextLoader.loadContext(contextParams.get());
-            this.messageChannel = messageWriter.open(messageParams.get());
-            final Map<String, Object> openedPayload = messageWriter.getOpenedPayload();
-            this.messageChannel.writeMessage(PipesUtils.makeMessage(Method.OPENED, openedPayload));
-        }
-        this.materializedAssets = new HashSet<>();
-        this.closed = false;
-        this.logger = new PipesLogger(
-            Logger.getLogger(PipesContext.class.getName()), this.messageChannel
-        );
-    }
-
-    /**
-     * Reports an exception that should terminate execution. The exception will be
-     * propagated to Dagster when the context is closed.
-     *
-     * @param exception Exception to report
-     */
-    public void reportException(final Exception exception) {
-        this.exception = exception;
-    }
-
-    /**
-     * Closes the context and flushes pending messages. This must be called to
-     * ensure proper cleanup and exception reporting.
-     *
-     * @throws DagsterPipesException If an error occurs during close or if a
-     *         previously reported exception exists
-     */
-    public void close() throws DagsterPipesException {
-        if (!this.closed) {
-            final Map<String, Object> payload = new HashMap<>();
-            if (this.exception != null) {
-                payload.put("exception", new PipesException(exception));
-            }
-            this.messageChannel.writeMessage(PipesUtils.makeMessage(Method.CLOSED, payload));
-            this.messageChannel.close();
-            this.closed = true;
-            if (this.exception != null) {
-                throw new DagsterPipesException("Exception in PipesSession", this.exception);
-            }
-        }
-    }
-
+public interface PipesContext extends AutoCloseable {
     /**
      * Checks if the context has been initialized.
      *
      * @return True or false
      */
-    public static boolean isInitialized() {
-        return instance != null;
+    static boolean isInitialized() {
+        return PipesContextInstance.isInitialized();
     }
 
     /**
@@ -121,8 +24,8 @@ public class PipesContext {
      *
      * @param context Context to set
      */
-    public static void set(final PipesContext context) {
-        instance = context;
+    static void set(PipesContext context) {
+        PipesContextInstance.set(context);
     }
 
     /**
@@ -131,442 +34,72 @@ public class PipesContext {
      * @return Initialized context instance
      * @throws IllegalStateException If context has not been initialized via {@link #set(PipesContext)}
      */
-    public static PipesContext get() {
-        if (instance == null) {
-            throw new IllegalStateException(
-                "PipesContext has not been initialized. You must call openDagsterPipes()."
-            );
-        }
-        return instance;
+    static PipesContext get() {
+        return PipesContextInstance.get();
     }
 
-    /**
-     * Reports a custom message payload.
-     *
-     * @param payload Custom data to report (will be serialized)
-     * @throws DagsterPipesException If context is already closed
-     */
-    public void reportCustomMessage(final Object payload) throws DagsterPipesException {
-        final Map<String, Object> map = new HashMap<>();
-        map.put("payload", payload);
-        writeMessage(Method.REPORT_CUSTOM_MESSAGE, map);
-    }
+    void reportException(Exception exception);
 
-    private void writeMessage(
-        final Method method,
-        final Map<String, Object> params
-    ) throws DagsterPipesException {
-        if (this.closed) {
-            throw new DagsterPipesException("Cannot send message after pipes context is closed.");
-        }
-        System.out.println(PipesUtils.makeMessage(method, params));
-        this.messageChannel.writeMessage(PipesUtils.makeMessage(method, params));
-    }
+    @Override
+    void close() throws DagsterPipesException;
 
-    /**
-     * Checks if the context has been closed.
-     *
-     * @return True or false
-     */
-    public boolean isClosed() {
-        return this.closed;
-    }
+    void reportCustomMessage(Object payload) throws DagsterPipesException;
 
-    /**
-     * Determines if the current step targets assets.
-     *
-     * @return True if asset keys are defined in the context, flase otherwise
-     */
-    public boolean isAssetStep() {
-        return this.data.getAssetKeys() != null;
-    }
+    boolean isClosed();
 
-    /**
-     * Gets the single asset key for the current step. Valid only for single-asset steps.
-     *
-     * @return Single asset key
-     * @throws DagsterPipesException If no assets or multiple assets are targeted
-     */
-    public String getAssetKey() throws DagsterPipesException {
-        final List<String> assetKeys = getAssetKeys();
-        assertSingleAsset(assetKeys, "Asset key");
-        return assetKeys.get(0);
-    }
+    boolean isAssetStep();
 
-    /**
-     * Gets all asset keys targeted by the current step.
-     *
-     * @return List of asset keys (non-empty)
-     * @throws DagsterPipesException If no assets are targeted
-     */
-    public List<String> getAssetKeys() throws DagsterPipesException {
-        final List<String> assetKeys = this.data.getAssetKeys();
-        assertPresence(assetKeys, "Asset keys");
-        return assetKeys;
-    }
+    String getAssetKey() throws DagsterPipesException;
 
-    /**
-     * Gets provenance data for the single asset in the current step.
-     *
-     * @return Provenance data for the asset
-     * @throws DagsterPipesException If no assets or multiple assets are targeted
-     */
-    public ProvenanceByAssetKey getProvenance() throws DagsterPipesException {
-        final Map<String, ProvenanceByAssetKey> provenanceByAssetKey = getProvenanceByAssetKey();
-        assertSingleAsset(provenanceByAssetKey, "Provenance");
-        return provenanceByAssetKey.values().iterator().next();
-    }
+    List<String> getAssetKeys() throws DagsterPipesException;
 
-    /**
-     * Gets provenance data by asset key.
-     *
-     * @return Map of asset keys to provenance data (non-empty)
-     * @throws DagsterPipesException If no assets are targeted
-     */
-    public Map<String, ProvenanceByAssetKey> getProvenanceByAssetKey() throws DagsterPipesException {
-        final Map<String, ProvenanceByAssetKey> provenanceByAssetKey = this.data.getProvenanceByAssetKey();
-        assertPresence(provenanceByAssetKey, "Provenance by asset key");
-        return provenanceByAssetKey;
-    }
+    ProvenanceByAssetKey getProvenance() throws DagsterPipesException;
 
-    /**
-     * Gets code version for the single asset in the current step.
-     *
-     * @return Code version string
-     * @throws DagsterPipesException If no assets or multiple assets are targeted
-     */
-    public String getCodeVersion() throws DagsterPipesException {
-        final Map<String, String> codeVersionByAssetKey = getCodeVersionByAssetKey();
-        assertSingleAsset(codeVersionByAssetKey, "Code version");
-        return codeVersionByAssetKey.values().iterator().next();
-    }
+    Map<String, ProvenanceByAssetKey> getProvenanceByAssetKey() throws DagsterPipesException;
 
-    /**
-     * Gets code versions keyed by asset.
-     *
-     * @return Map of asset keys to code versions (non-empty)
-     * @throws DagsterPipesException If no assets are targeted
-     */
-    public Map<String, String> getCodeVersionByAssetKey() throws DagsterPipesException {
-        final Map<String, String> codeVersionByAssetKey = this.data.getCodeVersionByAssetKey();
-        assertPresence(codeVersionByAssetKey, "Code version by asset key");
-        return codeVersionByAssetKey;
-    }
+    String getCodeVersion() throws DagsterPipesException;
 
-    /**
-     * Determines if the current step is partitioned.
-     *
-     * @return True if partition data exists in context, false otherwise
-     */
-    public boolean isPartitionStep() {
-        return this.data.getPartitionKeyRange() != null;
-    }
+    Map<String, String> getCodeVersionByAssetKey() throws DagsterPipesException;
 
-    /**
-     * Gets the partition key for the current step.
-     *
-     * @return Current partition key
-     * @throws DagsterPipesException If no partition is defined
-     */
-    public String getPartitionKey() throws DagsterPipesException {
-        final String partitionKey = this.data.getPartitionKey();
-        assertPresence(partitionKey, "Partition key");
-        return partitionKey;
-    }
+    boolean isPartitionStep();
 
-    /**
-     * Gets the partition key range for the current step.
-     *
-     * @return Partition key range
-     * @throws DagsterPipesException If no partition range is defined
-     */
-    public PartitionKeyRange getPartitionKeyRange() throws DagsterPipesException {
-        final PartitionKeyRange partitionKeyRange = this.data.getPartitionKeyRange();
-        assertPresence(partitionKeyRange, "Partition key range");
-        return partitionKeyRange;
-    }
+    String getPartitionKey() throws DagsterPipesException;
 
-    /**
-     * Gets the partition time window for the current step.
-     *
-     * @return Partition time window
-     * @throws DagsterPipesException If no time window is defined
-     */
-    public PartitionTimeWindow getPartitionTimeWindow() throws DagsterPipesException {
-        final PartitionTimeWindow partitionTimeWindow = this.data.getPartitionTimeWindow();
-        assertPresence(partitionTimeWindow, "Partition time window");
-        return partitionTimeWindow;
-    }
+    PartitionKeyRange getPartitionKeyRange() throws DagsterPipesException;
 
-    /**
-     * Gets the Dagster run ID.
-     *
-     * @return Run ID string
-     */
-    public String getRunId() {
-        return this.data.getRunId();
-    }
+    PartitionTimeWindow getPartitionTimeWindow() throws DagsterPipesException;
 
-    /**
-     * Gets the Dagster job name.
-     *
-     * @return Job name string
-     */
-    public String getJobName() {
-        return this.data.getJobName();
-    }
+    String getRunId();
 
-    /**
-     * Gets the current retry attempt number.
-     *
-     * @return Integer retry number
-     */
-    public int getRetryNumber() {
-        return this.data.getRetryNumber();
-    }
+    String getJobName();
 
-    /**
-     * Gets a specific extra context parameter by key.
-     *
-     * @param key The key to retrieve
-     * @return Parameter value
-     * @throws DagsterPipesException If key is not found in extras
-     */
-    public Object getExtra(final String key) throws DagsterPipesException {
-        final Map<String, Object> extras = this.data.getExtras();
-        if (!extras.containsKey(key)) {
-            throw new DagsterPipesException(
-                String.format("Extra %s is undefined. Extras must be provided by user.", key)
-            );
-        }
-        return extras.get(key);
-    }
+    int getRetryNumber();
 
-    /**
-     * Gets all extra context parameters.
-     *
-     * @return Map of extra parameters
-     */
-    public Map<String, Object> getExtras() {
-        return this.data.getExtras();
-    }
+    Object getExtra(String key) throws DagsterPipesException;
 
-    /**
-     * Gets the {@link PipesLogger} instance.
-     *
-     * @return The {@link PipesLogger} instance
-     */
-    public PipesLogger getLogger() {
-        return this.logger;
-    }
+    Map<String, Object> getExtras();
 
-    private static void assertSingleAsset(
-        final Collection<?> collection,
-        final String name
-    ) throws DagsterPipesException {
-        if (collection.size() != 1) {
-            throw new DagsterPipesException(
-                String.format("%s is undefined. Current step targets multiple assets.", name)
-            );
-        }
-    }
+    PipesLogger getLogger();
 
-    private static void assertSingleAsset(final Map<?, ?> map, final String name) throws DagsterPipesException {
-        if (map.size() != 1) {
-            throw new DagsterPipesException(
-                String.format("%s is undefined. Current step targets multiple assets.", name)
-            );
-        }
-    }
+    void reportAssetMaterialization(
+            Map<String, ?> metadataMapping,
+            String dataVersion,
+            String assetKey
+    ) throws DagsterPipesException;
 
-    private static void assertPresence(final Object object, final String name) throws DagsterPipesException {
-        if (object == null) {
-            throw new DagsterPipesException(
-                String.format("%s is undefined. Current step does not target an asset.", name)
-            );
-        }
-        if (object instanceof Collection<?> && ((Collection<?>) object).isEmpty()) {
-            throw new DagsterPipesException(
-                String.format("%s is empty. Current step does not target an asset.", name)
-            );
-        }
-    }
+    void reportAssetCheck(
+            String checkName,
+            boolean passed,
+            Map<String, ?> metadataMapping,
+            String assetKey
+    ) throws DagsterPipesException;
 
-    /**
-     * Reports asset materialization.
-     *
-     * @param metadataMapping Metadata values keyed by label
-     * @param dataVersion Data version string
-     * @param assetKey Explicit asset key (null to use context's single asset)
-     * @throws DagsterPipesException If asset key is invalid or context is closed
-     * @throws IllegalStateException If asset has already been materialized
-     */
-    public void reportAssetMaterialization(
-        final Map<String, ?> metadataMapping,
-        final String dataVersion,
-        final String assetKey
-    ) throws DagsterPipesException {
-        final Map<String, PipesMetadata> resolvedMetadata = PipesUtils.resolveMetadataMapping(metadataMapping);
-        processAssetMaterialization(resolvedMetadata, dataVersion, assetKey);
-    }
-
-    private void processAssetMaterialization(
-        final Map<String, PipesMetadata> pipesMetadata,
-        final String dataVersion,
-        final String assetKey
-    ) throws DagsterPipesException {
-        final String actualAssetKey = resolveOptionallyPassedAssetKey(assetKey, Method.REPORT_ASSET_MATERIALIZATION);
-        if (this.materializedAssets.contains(actualAssetKey)) {
-            throw new IllegalStateException(
-                "Asset keys: " + actualAssetKey + " has already been materialized, cannot report additional data."
-            );
-        }
-        System.out.println("writing message...");
-        this.writeMessage(
-            Method.REPORT_ASSET_MATERIALIZATION,
-            this.createMap(actualAssetKey, dataVersion, pipesMetadata)
-        );
-        materializedAssets.add(actualAssetKey);
-    }
-
-    /**
-     * Reports an asset check result (convenience method with default ERROR severity).
-     *
-     * @param checkName Unique check identifier
-     * @param passed Whether the check succeeded
-     * @param metadataMapping Metadata keyed by label
-     * @param assetKey Explicit asset key (null to use context's single asset)
-     * @throws DagsterPipesException If asset key is invalid or context is closed
-     */
-    public void reportAssetCheck(
-        final String checkName,
-        final boolean passed,
-        final Map<String, ?> metadataMapping,
-        final String assetKey
-    ) throws DagsterPipesException {
-        reportAssetCheck(checkName, passed, PipesAssetCheckSeverity.ERROR, metadataMapping, assetKey);
-    }
-
-    /**
-     * Reports an asset check result with custom severity.
-     *
-     * @param checkName Unique check identifier
-     * @param passed Whether the check succeeded
-     * @param severity Severity level
-     * @param metadataMapping Metadata keyed by label
-     * @param assetKey Explicit asset key (null to use context's single asset)
-     * @throws DagsterPipesException If parameters are invalid or context is closed
-     */
-    public void reportAssetCheck(
-        final String checkName,
-        final boolean passed,
-        final PipesAssetCheckSeverity severity,
-        final Map<String, ?> metadataMapping,
-        final String assetKey
-    ) throws DagsterPipesException {
-        final Map<String, PipesMetadata> resolvedMetadata = PipesUtils
-            .resolveMetadataMapping(metadataMapping);
-        processAssetCheck(checkName, passed, severity, resolvedMetadata, assetKey);
-    }
-
-    private void processAssetCheck(
-        final String checkName,
-        final boolean passed,
-        final PipesAssetCheckSeverity severity,
-        final Map<String, PipesMetadata> pipesMetadata,
-        final String assetKey
-    ) throws DagsterPipesException {
-        System.out.println("was: " + checkName + " " + passed + " " + assetKey);
-        assertNotNull(checkName, Method.REPORT_ASSET_CHECK, "checkName");
-        final String actualAssetKey = resolveOptionallyPassedAssetKey(assetKey, Method.REPORT_ASSET_CHECK);
-        System.out.println("resolved:" + actualAssetKey);
-        this.writeMessage(
-            Method.REPORT_ASSET_CHECK,
-            this.createMap(actualAssetKey, checkName, passed, severity, pipesMetadata)
-        );
-    }
-
-    private void assertNotNull(
-        final Object value,
-        final Method method,
-        final String param
-    ) throws DagsterPipesException {
-        if (value == null) {
-            throw new DagsterPipesException(
-                String.format(
-                    "Null parameter `%s` for %s",
-                    param, method.toValue()
-                )
-            );
-        }
-    }
-
-    private Map<String, Object> createMap(
-        final String assetKey,
-        final String dataVersion,
-        final Map<String, PipesMetadata> pipesMetadata
-    ) {
-        final Map<String, Object> message = new HashMap<>();
-        message.put("asset_key", assetKey);
-        message.put("data_version", dataVersion);
-        message.put("metadata", pipesMetadata);
-        return message;
-    }
-
-    private Map<String, Object> createMap(
-        final String assetKey,
-        final String checkName,
-        final boolean passed,
-        final PipesAssetCheckSeverity severity,
-        final Map<String, PipesMetadata> pipesMetadata
-    ) {
-        final Map<String, Object> message = new HashMap<>();
-        message.put("asset_key", assetKey);
-        message.put("check_name", checkName);
-        message.put("passed", passed);
-        message.put("severity", severity);
-        message.put("metadata", pipesMetadata);
-        return message;
-    }
-
-    private String resolveOptionallyPassedAssetKey(
-        final String assetKey,
-        final Method method
-    ) throws DagsterPipesException {
-        final List<String> definedAssetKeys = this.data.getAssetKeys();
-        String resultAssetKey = assetKey;
-        if (assetKey == null) {
-            if (definedAssetKeys.size() != 1) {
-                throw new DagsterPipesException(
-                    String.format(
-                        "Calling %s without passing an asset key is undefined. "
-                            + "Current step targets multiple assets.",
-                        method.toValue()
-                    )
-                );
-            }
-            resultAssetKey = definedAssetKeys.get(0);
-        } else {
-            if (!definedAssetKeys.contains(assetKey)) {
-                throw new DagsterPipesException(
-                    String.format("Invalid asset key. Expected one of %s, got %s.",
-                        definedAssetKeys,
-                        assetKey
-                    )
-                );
-            }
-        }
-
-        if (resultAssetKey.isEmpty()) {
-            throw new DagsterPipesException(
-                String.format(
-                    "Calling %s without passing an asset key is undefined. "
-                        + "Current step does not target a specific asset.",
-                    method.toValue()
-                )
-            );
-        }
-
-        return resultAssetKey;
-    }
+    void reportAssetCheck(
+            String checkName,
+            boolean passed,
+            PipesAssetCheckSeverity severity,
+            Map<String, ?> metadataMapping,
+            String assetKey
+    ) throws DagsterPipesException;
 }
+

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContextImpl.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContextImpl.java
@@ -1,0 +1,562 @@
+package io.dagster.pipes;
+
+import io.dagster.pipes.data.PipesAssetCheckSeverity;
+import io.dagster.pipes.data.PipesContextData;
+import io.dagster.pipes.data.PipesException;
+import io.dagster.pipes.data.PipesMetadata;
+import io.dagster.pipes.loaders.PipesContextLoader;
+import io.dagster.pipes.loaders.PipesParamsLoader;
+import io.dagster.pipes.logger.PipesLogger;
+import io.dagster.pipes.utils.PipesUtils;
+import io.dagster.pipes.writers.PipesMessageWriter;
+import io.dagster.pipes.writers.PipesMessageWriterChannel;
+import io.dagster.types.Method;
+import io.dagster.types.PartitionKeyRange;
+import io.dagster.types.PartitionTimeWindow;
+import io.dagster.types.ProvenanceByAssetKey;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Provides execution context and communication mechanisms for Dagster pipes.
+ * This singleton class manages asset materialization tracking, message writing,
+ * and context data access for external execution environments.
+ *
+ * <p>Key responsibilities include:
+ * <ul>
+ *   <li>Initializing and managing communication channels with Dagster</li>
+ *   <li>Tracking asset materialization state</li>
+ *   <li>Providing access to execution context (assets, partitions, run info)</li>
+ *   <li>Reporting results and exceptions back to Dagster</li>
+ * </ul>
+ */
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods", "PMD.ImmutableField"})
+public class PipesContextImpl implements PipesContext {
+
+    private PipesContextData data;
+    private PipesMessageWriterChannel messageChannel;
+    private final Set<String> materializedAssets;
+    private boolean closed;
+    private final PipesLogger logger;
+    private Exception exception;
+
+    /**
+     * Constructor.
+     *
+     * @param paramsLoader Loader for context and message parameters
+     * @param contextLoader Loader for deserializing context data
+     * @param messageWriter Writer for opening message channels
+     * @throws DagsterPipesException If initialization fails or required parameters are missing
+     */
+    public PipesContextImpl(
+        final PipesParamsLoader paramsLoader,
+        final PipesContextLoader contextLoader,
+        final PipesMessageWriter<? extends PipesMessageWriterChannel> messageWriter
+    ) throws DagsterPipesException {
+        final Optional<Map<String, Object>> contextParams = paramsLoader.loadContextParams();
+        final Optional<Map<String, Object>> messageParams = paramsLoader.loadMessagesParams();
+        if (contextParams.isPresent() && messageParams.isPresent()) {
+            this.data = contextLoader.loadContext(contextParams.get());
+            this.messageChannel = messageWriter.open(messageParams.get());
+            final Map<String, Object> openedPayload = messageWriter.getOpenedPayload();
+            this.messageChannel.writeMessage(PipesUtils.makeMessage(Method.OPENED, openedPayload));
+        }
+        this.materializedAssets = new HashSet<>();
+        this.closed = false;
+        this.logger = new PipesLogger(
+            Logger.getLogger(PipesContextImpl.class.getName()), this.messageChannel
+        );
+    }
+
+    /**
+     * Reports an exception that should terminate execution. The exception will be
+     * propagated to Dagster when the context is closed.
+     *
+     * @param exception Exception to report
+     */
+    @Override
+    public void reportException(final Exception exception) {
+        this.exception = exception;
+    }
+
+    /**
+     * Closes the context and flushes pending messages. This must be called to
+     * ensure proper cleanup and exception reporting.
+     *
+     * @throws DagsterPipesException If an error occurs during close or if a
+     *         previously reported exception exists
+     */
+    @Override
+    public void close() throws DagsterPipesException {
+        if (!this.closed) {
+            final Map<String, Object> payload = new HashMap<>();
+            if (this.exception != null) {
+                payload.put("exception", new PipesException(exception));
+            }
+            this.messageChannel.writeMessage(PipesUtils.makeMessage(Method.CLOSED, payload));
+            this.messageChannel.close();
+            this.closed = true;
+            if (this.exception != null) {
+                throw new DagsterPipesException("Exception in PipesSession", this.exception);
+            }
+        }
+    }
+
+    /**
+     * Reports a custom message payload.
+     *
+     * @param payload Custom data to report (will be serialized)
+     * @throws DagsterPipesException If context is already closed
+     */
+    @Override
+    public void reportCustomMessage(final Object payload) throws DagsterPipesException {
+        final Map<String, Object> map = new HashMap<>();
+        map.put("payload", payload);
+        writeMessage(Method.REPORT_CUSTOM_MESSAGE, map);
+    }
+
+    private void writeMessage(
+        final Method method,
+        final Map<String, Object> params
+    ) throws DagsterPipesException {
+        if (this.closed) {
+            throw new DagsterPipesException("Cannot send message after pipes context is closed.");
+        }
+        System.out.println(PipesUtils.makeMessage(method, params));
+        this.messageChannel.writeMessage(PipesUtils.makeMessage(method, params));
+    }
+
+    /**
+     * Checks if the context has been closed.
+     *
+     * @return True or false
+     */
+    @Override
+    public boolean isClosed() {
+        return this.closed;
+    }
+
+    /**
+     * Determines if the current step targets assets.
+     *
+     * @return True if asset keys are defined in the context, flase otherwise
+     */
+    @Override
+    public boolean isAssetStep() {
+        return this.data.getAssetKeys() != null;
+    }
+
+    /**
+     * Gets the single asset key for the current step. Valid only for single-asset steps.
+     *
+     * @return Single asset key
+     * @throws DagsterPipesException If no assets or multiple assets are targeted
+     */
+    @Override
+    public String getAssetKey() throws DagsterPipesException {
+        final List<String> assetKeys = getAssetKeys();
+        assertSingleAsset(assetKeys, "Asset key");
+        return assetKeys.get(0);
+    }
+
+    /**
+     * Gets all asset keys targeted by the current step.
+     *
+     * @return List of asset keys (non-empty)
+     * @throws DagsterPipesException If no assets are targeted
+     */
+    @Override
+    public List<String> getAssetKeys() throws DagsterPipesException {
+        final List<String> assetKeys = this.data.getAssetKeys();
+        assertPresence(assetKeys, "Asset keys");
+        return assetKeys;
+    }
+
+    /**
+     * Gets provenance data for the single asset in the current step.
+     *
+     * @return Provenance data for the asset
+     * @throws DagsterPipesException If no assets or multiple assets are targeted
+     */
+    @Override
+    public ProvenanceByAssetKey getProvenance() throws DagsterPipesException {
+        final Map<String, ProvenanceByAssetKey> provenanceByAssetKey = getProvenanceByAssetKey();
+        assertSingleAsset(provenanceByAssetKey, "Provenance");
+        return provenanceByAssetKey.values().iterator().next();
+    }
+
+    /**
+     * Gets provenance data by asset key.
+     *
+     * @return Map of asset keys to provenance data (non-empty)
+     * @throws DagsterPipesException If no assets are targeted
+     */
+    @Override
+    public Map<String, ProvenanceByAssetKey> getProvenanceByAssetKey() throws DagsterPipesException {
+        final Map<String, ProvenanceByAssetKey> provenanceByAssetKey = this.data.getProvenanceByAssetKey();
+        assertPresence(provenanceByAssetKey, "Provenance by asset key");
+        return provenanceByAssetKey;
+    }
+
+    /**
+     * Gets code version for the single asset in the current step.
+     *
+     * @return Code version string
+     * @throws DagsterPipesException If no assets or multiple assets are targeted
+     */
+    @Override
+    public String getCodeVersion() throws DagsterPipesException {
+        final Map<String, String> codeVersionByAssetKey = getCodeVersionByAssetKey();
+        assertSingleAsset(codeVersionByAssetKey, "Code version");
+        return codeVersionByAssetKey.values().iterator().next();
+    }
+
+    /**
+     * Gets code versions keyed by asset.
+     *
+     * @return Map of asset keys to code versions (non-empty)
+     * @throws DagsterPipesException If no assets are targeted
+     */
+    @Override
+    public Map<String, String> getCodeVersionByAssetKey() throws DagsterPipesException {
+        final Map<String, String> codeVersionByAssetKey = this.data.getCodeVersionByAssetKey();
+        assertPresence(codeVersionByAssetKey, "Code version by asset key");
+        return codeVersionByAssetKey;
+    }
+
+    /**
+     * Determines if the current step is partitioned.
+     *
+     * @return True if partition data exists in context, false otherwise
+     */
+    @Override
+    public boolean isPartitionStep() {
+        return this.data.getPartitionKeyRange() != null;
+    }
+
+    /**
+     * Gets the partition key for the current step.
+     *
+     * @return Current partition key
+     * @throws DagsterPipesException If no partition is defined
+     */
+    @Override
+    public String getPartitionKey() throws DagsterPipesException {
+        final String partitionKey = this.data.getPartitionKey();
+        assertPresence(partitionKey, "Partition key");
+        return partitionKey;
+    }
+
+    /**
+     * Gets the partition key range for the current step.
+     *
+     * @return Partition key range
+     * @throws DagsterPipesException If no partition range is defined
+     */
+    @Override
+    public PartitionKeyRange getPartitionKeyRange() throws DagsterPipesException {
+        final PartitionKeyRange partitionKeyRange = this.data.getPartitionKeyRange();
+        assertPresence(partitionKeyRange, "Partition key range");
+        return partitionKeyRange;
+    }
+
+    /**
+     * Gets the partition time window for the current step.
+     *
+     * @return Partition time window
+     * @throws DagsterPipesException If no time window is defined
+     */
+    @Override
+    public PartitionTimeWindow getPartitionTimeWindow() throws DagsterPipesException {
+        final PartitionTimeWindow partitionTimeWindow = this.data.getPartitionTimeWindow();
+        assertPresence(partitionTimeWindow, "Partition time window");
+        return partitionTimeWindow;
+    }
+
+    /**
+     * Gets the Dagster run ID.
+     *
+     * @return Run ID string
+     */
+    @Override
+    public String getRunId() {
+        return this.data.getRunId();
+    }
+
+    /**
+     * Gets the Dagster job name.
+     *
+     * @return Job name string
+     */
+    @Override
+    public String getJobName() {
+        return this.data.getJobName();
+    }
+
+    /**
+     * Gets the current retry attempt number.
+     *
+     * @return Integer retry number
+     */
+    @Override
+    public int getRetryNumber() {
+        return this.data.getRetryNumber();
+    }
+
+    /**
+     * Gets a specific extra context parameter by key.
+     *
+     * @param key The key to retrieve
+     * @return Parameter value
+     * @throws DagsterPipesException If key is not found in extras
+     */
+    @Override
+    public Object getExtra(final String key) throws DagsterPipesException {
+        final Map<String, Object> extras = this.data.getExtras();
+        if (!extras.containsKey(key)) {
+            throw new DagsterPipesException(
+                String.format("Extra %s is undefined. Extras must be provided by user.", key)
+            );
+        }
+        return extras.get(key);
+    }
+
+    /**
+     * Gets all extra context parameters.
+     *
+     * @return Map of extra parameters
+     */
+    @Override
+    public Map<String, Object> getExtras() {
+        return this.data.getExtras();
+    }
+
+    /**
+     * Gets the {@link PipesLogger} instance.
+     *
+     * @return The {@link PipesLogger} instance
+     */
+    @Override
+    public PipesLogger getLogger() {
+        return this.logger;
+    }
+
+    private static void assertSingleAsset(
+        final Collection<?> collection,
+        final String name
+    ) throws DagsterPipesException {
+        if (collection.size() != 1) {
+            throw new DagsterPipesException(
+                String.format("%s is undefined. Current step targets multiple assets.", name)
+            );
+        }
+    }
+
+    private static void assertSingleAsset(final Map<?, ?> map, final String name) throws DagsterPipesException {
+        if (map.size() != 1) {
+            throw new DagsterPipesException(
+                String.format("%s is undefined. Current step targets multiple assets.", name)
+            );
+        }
+    }
+
+    private static void assertPresence(final Object object, final String name) throws DagsterPipesException {
+        if (object == null) {
+            throw new DagsterPipesException(
+                String.format("%s is undefined. Current step does not target an asset.", name)
+            );
+        }
+        if (object instanceof Collection<?> && ((Collection<?>) object).isEmpty()) {
+            throw new DagsterPipesException(
+                String.format("%s is empty. Current step does not target an asset.", name)
+            );
+        }
+    }
+
+    /**
+     * Reports asset materialization.
+     *
+     * @param metadataMapping Metadata values keyed by label
+     * @param dataVersion Data version string
+     * @param assetKey Explicit asset key (null to use context's single asset)
+     * @throws DagsterPipesException If asset key is invalid or context is closed
+     * @throws IllegalStateException If asset has already been materialized
+     */
+    @Override
+    public void reportAssetMaterialization(
+            final Map<String, ?> metadataMapping,
+            final String dataVersion,
+            final String assetKey
+    ) throws DagsterPipesException {
+        final Map<String, PipesMetadata> resolvedMetadata = PipesUtils.resolveMetadataMapping(metadataMapping);
+        processAssetMaterialization(resolvedMetadata, dataVersion, assetKey);
+    }
+
+    private void processAssetMaterialization(
+        final Map<String, PipesMetadata> pipesMetadata,
+        final String dataVersion,
+        final String assetKey
+    ) throws DagsterPipesException {
+        final String actualAssetKey = resolveOptionallyPassedAssetKey(assetKey, Method.REPORT_ASSET_MATERIALIZATION);
+        if (this.materializedAssets.contains(actualAssetKey)) {
+            throw new IllegalStateException(
+                "Asset keys: " + actualAssetKey + " has already been materialized, cannot report additional data."
+            );
+        }
+        System.out.println("writing message...");
+        this.writeMessage(
+            Method.REPORT_ASSET_MATERIALIZATION,
+            this.createMap(actualAssetKey, dataVersion, pipesMetadata)
+        );
+        materializedAssets.add(actualAssetKey);
+    }
+
+    /**
+     * Reports an asset check result (convenience method with default ERROR severity).
+     *
+     * @param checkName Unique check identifier
+     * @param passed Whether the check succeeded
+     * @param metadataMapping Metadata keyed by label
+     * @param assetKey Explicit asset key (null to use context's single asset)
+     * @throws DagsterPipesException If asset key is invalid or context is closed
+     */
+    @Override
+    public void reportAssetCheck(
+            final String checkName,
+            final boolean passed,
+            final Map<String, ?> metadataMapping,
+            final String assetKey
+    ) throws DagsterPipesException {
+        reportAssetCheck(checkName, passed, PipesAssetCheckSeverity.ERROR, metadataMapping, assetKey);
+    }
+
+    /**
+     * Reports an asset check result with custom severity.
+     *
+     * @param checkName Unique check identifier
+     * @param passed Whether the check succeeded
+     * @param severity Severity level
+     * @param metadataMapping Metadata keyed by label
+     * @param assetKey Explicit asset key (null to use context's single asset)
+     * @throws DagsterPipesException If parameters are invalid or context is closed
+     */
+    @Override
+    public void reportAssetCheck(
+            final String checkName,
+            final boolean passed,
+            final PipesAssetCheckSeverity severity,
+            final Map<String, ?> metadataMapping,
+            final String assetKey
+    ) throws DagsterPipesException {
+        final Map<String, PipesMetadata> resolvedMetadata = PipesUtils
+            .resolveMetadataMapping(metadataMapping);
+        processAssetCheck(checkName, passed, severity, resolvedMetadata, assetKey);
+    }
+
+    private void processAssetCheck(
+        final String checkName,
+        final boolean passed,
+        final PipesAssetCheckSeverity severity,
+        final Map<String, PipesMetadata> pipesMetadata,
+        final String assetKey
+    ) throws DagsterPipesException {
+        System.out.println("was: " + checkName + " " + passed + " " + assetKey);
+        assertNotNull(checkName, Method.REPORT_ASSET_CHECK, "checkName");
+        final String actualAssetKey = resolveOptionallyPassedAssetKey(assetKey, Method.REPORT_ASSET_CHECK);
+        System.out.println("resolved:" + actualAssetKey);
+        this.writeMessage(
+            Method.REPORT_ASSET_CHECK,
+            this.createMap(actualAssetKey, checkName, passed, severity, pipesMetadata)
+        );
+    }
+
+    private void assertNotNull(
+        final Object value,
+        final Method method,
+        final String param
+    ) throws DagsterPipesException {
+        if (value == null) {
+            throw new DagsterPipesException(
+                String.format(
+                    "Null parameter `%s` for %s",
+                    param, method.toValue()
+                )
+            );
+        }
+    }
+
+    private Map<String, Object> createMap(
+        final String assetKey,
+        final String dataVersion,
+        final Map<String, PipesMetadata> pipesMetadata
+    ) {
+        final Map<String, Object> message = new HashMap<>();
+        message.put("asset_key", assetKey);
+        message.put("data_version", dataVersion);
+        message.put("metadata", pipesMetadata);
+        return message;
+    }
+
+    private Map<String, Object> createMap(
+        final String assetKey,
+        final String checkName,
+        final boolean passed,
+        final PipesAssetCheckSeverity severity,
+        final Map<String, PipesMetadata> pipesMetadata
+    ) {
+        final Map<String, Object> message = new HashMap<>();
+        message.put("asset_key", assetKey);
+        message.put("check_name", checkName);
+        message.put("passed", passed);
+        message.put("severity", severity);
+        message.put("metadata", pipesMetadata);
+        return message;
+    }
+
+    private String resolveOptionallyPassedAssetKey(
+        final String assetKey,
+        final Method method
+    ) throws DagsterPipesException {
+        final List<String> definedAssetKeys = this.data.getAssetKeys();
+        String resultAssetKey = assetKey;
+        if (assetKey == null) {
+            if (definedAssetKeys.size() != 1) {
+                throw new DagsterPipesException(
+                    String.format(
+                        "Calling %s without passing an asset key is undefined. "
+                            + "Current step targets multiple assets.",
+                        method.toValue()
+                    )
+                );
+            }
+            resultAssetKey = definedAssetKeys.get(0);
+        } else {
+            if (!definedAssetKeys.contains(assetKey)) {
+                throw new DagsterPipesException(
+                    String.format("Invalid asset key. Expected one of %s, got %s.",
+                        definedAssetKeys,
+                        assetKey
+                    )
+                );
+            }
+        }
+
+        if (resultAssetKey.isEmpty()) {
+            throw new DagsterPipesException(
+                String.format(
+                    "Calling %s without passing an asset key is undefined. "
+                        + "Current step does not target a specific asset.",
+                    method.toValue()
+                )
+            );
+        }
+
+        return resultAssetKey;
+    }
+}

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContextImpl.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContextImpl.java
@@ -74,24 +74,11 @@ public class PipesContextImpl implements PipesContext {
         );
     }
 
-    /**
-     * Reports an exception that should terminate execution. The exception will be
-     * propagated to Dagster when the context is closed.
-     *
-     * @param exception Exception to report
-     */
     @Override
     public void reportException(final Exception exception) {
         this.exception = exception;
     }
 
-    /**
-     * Closes the context and flushes pending messages. This must be called to
-     * ensure proper cleanup and exception reporting.
-     *
-     * @throws DagsterPipesException If an error occurs during close or if a
-     *         previously reported exception exists
-     */
     @Override
     public void close() throws DagsterPipesException {
         if (!this.closed) {
@@ -108,12 +95,6 @@ public class PipesContextImpl implements PipesContext {
         }
     }
 
-    /**
-     * Reports a custom message payload.
-     *
-     * @param payload Custom data to report (will be serialized)
-     * @throws DagsterPipesException If context is already closed
-     */
     @Override
     public void reportCustomMessage(final Object payload) throws DagsterPipesException {
         final Map<String, Object> map = new HashMap<>();
@@ -132,32 +113,17 @@ public class PipesContextImpl implements PipesContext {
         this.messageChannel.writeMessage(PipesUtils.makeMessage(method, params));
     }
 
-    /**
-     * Checks if the context has been closed.
-     *
-     * @return True or false
-     */
+
     @Override
     public boolean isClosed() {
         return this.closed;
     }
 
-    /**
-     * Determines if the current step targets assets.
-     *
-     * @return True if asset keys are defined in the context, flase otherwise
-     */
     @Override
     public boolean isAssetStep() {
         return this.data.getAssetKeys() != null;
     }
 
-    /**
-     * Gets the single asset key for the current step. Valid only for single-asset steps.
-     *
-     * @return Single asset key
-     * @throws DagsterPipesException If no assets or multiple assets are targeted
-     */
     @Override
     public String getAssetKey() throws DagsterPipesException {
         final List<String> assetKeys = getAssetKeys();
@@ -165,12 +131,6 @@ public class PipesContextImpl implements PipesContext {
         return assetKeys.get(0);
     }
 
-    /**
-     * Gets all asset keys targeted by the current step.
-     *
-     * @return List of asset keys (non-empty)
-     * @throws DagsterPipesException If no assets are targeted
-     */
     @Override
     public List<String> getAssetKeys() throws DagsterPipesException {
         final List<String> assetKeys = this.data.getAssetKeys();
@@ -178,12 +138,6 @@ public class PipesContextImpl implements PipesContext {
         return assetKeys;
     }
 
-    /**
-     * Gets provenance data for the single asset in the current step.
-     *
-     * @return Provenance data for the asset
-     * @throws DagsterPipesException If no assets or multiple assets are targeted
-     */
     @Override
     public ProvenanceByAssetKey getProvenance() throws DagsterPipesException {
         final Map<String, ProvenanceByAssetKey> provenanceByAssetKey = getProvenanceByAssetKey();
@@ -191,12 +145,6 @@ public class PipesContextImpl implements PipesContext {
         return provenanceByAssetKey.values().iterator().next();
     }
 
-    /**
-     * Gets provenance data by asset key.
-     *
-     * @return Map of asset keys to provenance data (non-empty)
-     * @throws DagsterPipesException If no assets are targeted
-     */
     @Override
     public Map<String, ProvenanceByAssetKey> getProvenanceByAssetKey() throws DagsterPipesException {
         final Map<String, ProvenanceByAssetKey> provenanceByAssetKey = this.data.getProvenanceByAssetKey();
@@ -204,12 +152,6 @@ public class PipesContextImpl implements PipesContext {
         return provenanceByAssetKey;
     }
 
-    /**
-     * Gets code version for the single asset in the current step.
-     *
-     * @return Code version string
-     * @throws DagsterPipesException If no assets or multiple assets are targeted
-     */
     @Override
     public String getCodeVersion() throws DagsterPipesException {
         final Map<String, String> codeVersionByAssetKey = getCodeVersionByAssetKey();
@@ -217,12 +159,6 @@ public class PipesContextImpl implements PipesContext {
         return codeVersionByAssetKey.values().iterator().next();
     }
 
-    /**
-     * Gets code versions keyed by asset.
-     *
-     * @return Map of asset keys to code versions (non-empty)
-     * @throws DagsterPipesException If no assets are targeted
-     */
     @Override
     public Map<String, String> getCodeVersionByAssetKey() throws DagsterPipesException {
         final Map<String, String> codeVersionByAssetKey = this.data.getCodeVersionByAssetKey();
@@ -230,22 +166,12 @@ public class PipesContextImpl implements PipesContext {
         return codeVersionByAssetKey;
     }
 
-    /**
-     * Determines if the current step is partitioned.
-     *
-     * @return True if partition data exists in context, false otherwise
-     */
+
     @Override
     public boolean isPartitionStep() {
         return this.data.getPartitionKeyRange() != null;
     }
 
-    /**
-     * Gets the partition key for the current step.
-     *
-     * @return Current partition key
-     * @throws DagsterPipesException If no partition is defined
-     */
     @Override
     public String getPartitionKey() throws DagsterPipesException {
         final String partitionKey = this.data.getPartitionKey();
@@ -253,12 +179,6 @@ public class PipesContextImpl implements PipesContext {
         return partitionKey;
     }
 
-    /**
-     * Gets the partition key range for the current step.
-     *
-     * @return Partition key range
-     * @throws DagsterPipesException If no partition range is defined
-     */
     @Override
     public PartitionKeyRange getPartitionKeyRange() throws DagsterPipesException {
         final PartitionKeyRange partitionKeyRange = this.data.getPartitionKeyRange();
@@ -266,12 +186,6 @@ public class PipesContextImpl implements PipesContext {
         return partitionKeyRange;
     }
 
-    /**
-     * Gets the partition time window for the current step.
-     *
-     * @return Partition time window
-     * @throws DagsterPipesException If no time window is defined
-     */
     @Override
     public PartitionTimeWindow getPartitionTimeWindow() throws DagsterPipesException {
         final PartitionTimeWindow partitionTimeWindow = this.data.getPartitionTimeWindow();
@@ -279,43 +193,21 @@ public class PipesContextImpl implements PipesContext {
         return partitionTimeWindow;
     }
 
-    /**
-     * Gets the Dagster run ID.
-     *
-     * @return Run ID string
-     */
     @Override
     public String getRunId() {
         return this.data.getRunId();
     }
 
-    /**
-     * Gets the Dagster job name.
-     *
-     * @return Job name string
-     */
     @Override
     public String getJobName() {
         return this.data.getJobName();
     }
 
-    /**
-     * Gets the current retry attempt number.
-     *
-     * @return Integer retry number
-     */
     @Override
     public int getRetryNumber() {
         return this.data.getRetryNumber();
     }
 
-    /**
-     * Gets a specific extra context parameter by key.
-     *
-     * @param key The key to retrieve
-     * @return Parameter value
-     * @throws DagsterPipesException If key is not found in extras
-     */
     @Override
     public Object getExtra(final String key) throws DagsterPipesException {
         final Map<String, Object> extras = this.data.getExtras();
@@ -327,21 +219,11 @@ public class PipesContextImpl implements PipesContext {
         return extras.get(key);
     }
 
-    /**
-     * Gets all extra context parameters.
-     *
-     * @return Map of extra parameters
-     */
     @Override
     public Map<String, Object> getExtras() {
         return this.data.getExtras();
     }
 
-    /**
-     * Gets the {@link PipesLogger} instance.
-     *
-     * @return The {@link PipesLogger} instance
-     */
     @Override
     public PipesLogger getLogger() {
         return this.logger;
@@ -379,15 +261,6 @@ public class PipesContextImpl implements PipesContext {
         }
     }
 
-    /**
-     * Reports asset materialization.
-     *
-     * @param metadataMapping Metadata values keyed by label
-     * @param dataVersion Data version string
-     * @param assetKey Explicit asset key (null to use context's single asset)
-     * @throws DagsterPipesException If asset key is invalid or context is closed
-     * @throws IllegalStateException If asset has already been materialized
-     */
     @Override
     public void reportAssetMaterialization(
             final Map<String, ?> metadataMapping,
@@ -417,15 +290,6 @@ public class PipesContextImpl implements PipesContext {
         materializedAssets.add(actualAssetKey);
     }
 
-    /**
-     * Reports an asset check result (convenience method with default ERROR severity).
-     *
-     * @param checkName Unique check identifier
-     * @param passed Whether the check succeeded
-     * @param metadataMapping Metadata keyed by label
-     * @param assetKey Explicit asset key (null to use context's single asset)
-     * @throws DagsterPipesException If asset key is invalid or context is closed
-     */
     @Override
     public void reportAssetCheck(
             final String checkName,
@@ -436,16 +300,6 @@ public class PipesContextImpl implements PipesContext {
         reportAssetCheck(checkName, passed, PipesAssetCheckSeverity.ERROR, metadataMapping, assetKey);
     }
 
-    /**
-     * Reports an asset check result with custom severity.
-     *
-     * @param checkName Unique check identifier
-     * @param passed Whether the check succeeded
-     * @param severity Severity level
-     * @param metadataMapping Metadata keyed by label
-     * @param assetKey Explicit asset key (null to use context's single asset)
-     * @throws DagsterPipesException If parameters are invalid or context is closed
-     */
     @Override
     public void reportAssetCheck(
             final String checkName,

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContextInstance.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesContextInstance.java
@@ -1,0 +1,158 @@
+package io.dagster.pipes;
+
+import io.dagster.pipes.data.PipesAssetCheckSeverity;
+import io.dagster.pipes.logger.PipesLogger;
+import io.dagster.types.PartitionKeyRange;
+import io.dagster.types.PartitionTimeWindow;
+import io.dagster.types.ProvenanceByAssetKey;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+final class PipesContextInstance {
+    private static PipesContext instance;
+
+    private PipesContextInstance() {
+    }
+
+    /* default */ static boolean isInitialized() {
+        return instance != null;
+    }
+
+    /* default */ static void set(final PipesContext context) {
+        instance = context;
+    }
+
+    /* default */ static PipesContext get() {
+        if (instance == null) {
+            throw new IllegalStateException(
+                    "PipesContext has not been initialized. You must call openDagsterPipes()."
+            );
+        }
+        return instance;
+    }
+
+    /* default */ static final PipesContext NOOP = new PipesContext() {
+        @Override
+        public void reportException(final Exception exception) {
+
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public void reportCustomMessage(final Object payload) {
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public boolean isAssetStep() {
+            return false;
+        }
+
+        @Override
+        public String getAssetKey() {
+            return null;
+        }
+
+        @Override
+        public List<String> getAssetKeys() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public ProvenanceByAssetKey getProvenance() {
+            return null;
+        }
+
+        @Override
+        public Map<String, ProvenanceByAssetKey> getProvenanceByAssetKey() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public String getCodeVersion() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getCodeVersionByAssetKey() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public boolean isPartitionStep() {
+            return false;
+        }
+
+        @Override
+        public String getPartitionKey() {
+            return null;
+        }
+
+        @Override
+        public PartitionKeyRange getPartitionKeyRange() {
+            return null;
+        }
+
+        @Override
+        public PartitionTimeWindow getPartitionTimeWindow() {
+            return null;
+        }
+
+        @Override
+        public String getRunId() {
+            return null;
+        }
+
+        @Override
+        public String getJobName() {
+            return null;
+        }
+
+        @Override
+        public int getRetryNumber() {
+            return 0;
+        }
+
+        @Override
+        public Object getExtra(final String key) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getExtras() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public PipesLogger getLogger() {
+            return null;
+        }
+
+        @Override
+        public void reportAssetMaterialization(final Map<String, ?> metadataMapping, final String dataVersion,
+                                               final String assetKey) {
+
+        }
+
+        @Override
+        public void reportAssetCheck(final String checkName, final boolean passed,
+                                     final Map<String, ?> metadataMapping, final String assetKey) {
+
+        }
+
+        @Override
+        public void reportAssetCheck(final String checkName, final boolean passed,
+                                     final PipesAssetCheckSeverity severity, final Map<String, ?> metadataMapping,
+                                     final String assetKey) {
+        }
+    };
+}

--- a/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesSession.java
+++ b/libraries/pipes/implementations/java/src/main/java/io/dagster/pipes/PipesSession.java
@@ -85,12 +85,12 @@ public class PipesSession {
                 = messageWriter == null
                 ? new PipesDefaultMessageWriter() : messageWriter;
 
-            pipesContext = new PipesContext(
+            pipesContext = new PipesContextImpl(
                 actualParamsLoader, actualContextLoader, actualMessageWriter
             );
         } else {
             emitOrchestrationInactiveWarning();
-            pipesContext = org.mockito.Mockito.mock(PipesContext.class);
+            pipesContext = PipesContextInstance.NOOP;
         }
         PipesContext.set(pipesContext);
         return pipesContext;

--- a/libraries/pipes/implementations/java/tests/conftest.py
+++ b/libraries/pipes/implementations/java/tests/conftest.py
@@ -4,4 +4,4 @@ import subprocess
 
 @pytest.fixture(scope="session", autouse=True)
 def built_jar():
-    subprocess.run(["./gradlew", "build"], check=True)
+    subprocess.run(["./gradlew", "build", "installDist"], check=True)

--- a/libraries/pipes/implementations/java/tests/test_pipes.py
+++ b/libraries/pipes/implementations/java/tests/test_pipes.py
@@ -3,8 +3,5 @@ from dagster_pipes_tests import PipesTestSuite
 
 class TestJavaPipes(PipesTestSuite):
     BASE_ARGS = [
-        "java",
-        "-cp",
-        "build/libs/dagster-pipes-java.jar",
-        "io.dagster.pipes.MainTest",
+        "build/install/dagster-pipes-java/bin/mainTest"
     ]


### PR DESCRIPTION
fixes https://github.com/dagster-io/community-integrations/issues/221

- the jar building does not include the dependencies anymore

- in order to run the MainTest class in the tests the application plugin is used to build a start script and libs directory

- the test dependencies are declared separately now so that a user of the library doesn't depend on them

- mockito was needed in the library to create a mock class. to remove mockito from the library the PipesContext was converted to an interface with an empty implementation instead of the mockito mock

## Summary & Motivation

https://github.com/dagster-io/community-integrations/issues/221

## How I Tested These Changes

`uv run pytest`
