### PR TITLE
[dagster-polars] Fix package discovery when building

### DIFF
--- a/libraries/dagster-polars/pyproject.toml
+++ b/libraries/dagster-polars/pyproject.toml
@@ -48,8 +48,10 @@ dev-dependencies = [
 requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["dagster_polars"]
+[tool.setuptools.packages.find]
+include = ["dagster_polars*"]
+exclude = ["dagster_polars_tests*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 dagster_polars = ["py.typed"]


### PR DESCRIPTION
21d3447 removed setuptools-scm, which was responsible to include package files tracked by Git into the sdist. This lead version 0.27.5 missing 'dagster_polars.io_managers', b/c the default setuptools discovery does not include subpackages.

Assuming that removing setuptools-scm was done for a reason, another way to make sure subpackages are included is by using 'setuptools.packages.find'.

## Summary & Motivation

Fixes #224.

## How I Tested These Changes

By running `uv build` and checking the wheel generated with `unzip -l` to see that `dagster_polars/io_managers` is included.

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
