### PR TITLE
[dagster-polars] add top-level schema_mode PolarsDeltaIOManager param

### DIFF
--- a/libraries/dagster-polars/CHANGELOG.md
+++ b/libraries/dagster-polars/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## [Unreleased]
 
+## Unreleased
+
 ## Added
+
+- Added new `schema_mode` (defaults to `None`, can be set to `overwrite` or `merge`) parameter to `PolarsDeltaIOManager`. Previously schema mode had to be configured for each asset individually.
+
+## 0.27.6
 
 - Use new deltalake (>=1.0.0) syntax and arguments for delta io manager while retaining compatibility via version parsing and legacy syntax.
 


### PR DESCRIPTION
## Summary & Motivation

Adding this top-level parameter so we don't have to configure schema write mode for every asset individually (through metadata). 

## How I Tested These Changes

Added a test

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
