### PR TITLE
[dagster-iceberg] Add append mode support

### DIFF
--- a/libraries/dagster-iceberg/CHANGELOG.md
+++ b/libraries/dagster-iceberg/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Spark I/O manager.
+- Support for append mode in Iceberg I/O manager.
 
 ### Changed
 

--- a/libraries/dagster-iceberg/CHANGELOG.md
+++ b/libraries/dagster-iceberg/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Spark I/O manager.
-- Support for append mode in Iceberg I/O manager.
+- Support for append mode in Iceberg I/O manager. Write mode options can be set via asset definition metadata using the `write_mode` key, or at runtime via output metadata with the same key. Runtime output metadata setting overrides asset definition metadata setting.
 
 ### Changed
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
@@ -1,5 +1,7 @@
 import logging
 from collections.abc import Sequence
+from enum import StrEnum
+from typing import Final
 
 import pyarrow as pa
 from dagster._core.storage.db_io_manager import TablePartitionDimension, TableSlice
@@ -27,6 +29,14 @@ from dagster_iceberg.version import __version__ as dagster_iceberg_version
 logger = logging.getLogger("dagster_iceberg._utils.io")
 
 
+class WriteMode(StrEnum):
+    append = "append"
+    overwrite = "overwrite"
+
+
+DEFAULT_WRITE_MODE: Final[WriteMode] = WriteMode.overwrite
+
+
 def table_writer(
     table_slice: TableSlice,
     data: pa.Table,
@@ -36,6 +46,7 @@ def table_writer(
     dagster_run_id: str,
     dagster_partition_key: str | None = None,
     table_properties: dict[str, str] | None = None,
+    write_mode: WriteMode = DEFAULT_WRITE_MODE,
 ) -> None:
     """Writes data to an iceberg table
 
@@ -136,16 +147,28 @@ def table_writer(
     else:
         row_filter = iceberg_table.ALWAYS_TRUE
 
-    overwrite_table(
-        table=table,
-        data=data,
-        overwrite_filter=row_filter,
-        snapshot_properties=(
-            base_properties | {"dagster-partition-key": dagster_partition_key}
+    if write_mode == WriteMode.append:
+        append_to_table(
+            table=table,
+            data=data,
+            snapshot_properties=base_properties
+            | {"dagster-partition-key": dagster_partition_key}
             if dagster_partition_key is not None
-            else base_properties
-        ),
-    )
+            else base_properties,
+        )
+    elif write_mode == WriteMode.overwrite:
+        overwrite_table(
+            table=table,
+            data=data,
+            overwrite_filter=row_filter,
+            snapshot_properties=(
+                base_properties | {"dagster-partition-key": dagster_partition_key}
+                if dagster_partition_key is not None
+                else base_properties
+            ),
+        )
+    else:
+        raise ValueError(f"Unexpected write mode: {write_mode}")
 
 
 def get_expression_row_filter(
@@ -256,6 +279,32 @@ def overwrite_table(
         overwrite_filter=overwrite_filter,
         snapshot_properties=snapshot_properties,
     )
+
+
+def append_to_table(
+    table: iceberg_table.Table,
+    data: pa.Table,
+    snapshot_properties: dict[str, str] | None = None,
+):
+    IcebergTableAppenderWithRetry(table=table).execute(
+        retries=3,
+        exception_types=CommitFailedException,
+        data=data,
+        snapshot_properties=snapshot_properties,
+    )
+
+
+class IcebergTableAppenderWithRetry(IcebergOperationWithRetry):
+    def operation(
+        self,
+        data: pa.Table,
+        snapshot_properties: dict[str, str] | None = None,
+    ):
+        self.logger.debug("Appending to table")
+        self.table.append(
+            df=data,
+            snapshot_properties=snapshot_properties,
+        )
 
 
 class IcebergTableOverwriterWithRetry(IcebergOperationWithRetry):

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
@@ -147,25 +147,19 @@ def table_writer(
     else:
         row_filter = iceberg_table.ALWAYS_TRUE
 
+    snapshot_properties = base_properties | {"dagster-partition-key": dagster_partition_key} if dagster_partition_key is not None else base_properties
     if write_mode == WriteMode.append:
         append_to_table(
             table=table,
             data=data,
-            snapshot_properties=base_properties
-            | {"dagster-partition-key": dagster_partition_key}
-            if dagster_partition_key is not None
-            else base_properties,
+            snapshot_properties=snapshot_properties
         )
     elif write_mode == WriteMode.overwrite:
         overwrite_table(
             table=table,
             data=data,
             overwrite_filter=row_filter,
-            snapshot_properties=(
-                base_properties | {"dagster-partition-key": dagster_partition_key}
-                if dagster_partition_key is not None
-                else base_properties
-            ),
+            snapshot_properties=snapshot_properties,
         )
     else:
         raise ValueError(f"Unexpected write mode: {write_mode}")

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
@@ -294,6 +294,8 @@ class IcebergTableAppenderWithRetry(IcebergOperationWithRetry):
         data: pa.Table,
         snapshot_properties: dict[str, str] | None = None,
     ):
+        if snapshot_properties is None:
+            snapshot_properties = {}
         self.logger.debug("Appending to table")
         self.table.append(
             df=data,

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from enum import StrEnum
+from enum import Enum
 from typing import Final
 
 import pyarrow as pa
@@ -29,7 +29,7 @@ from dagster_iceberg.version import __version__ as dagster_iceberg_version
 logger = logging.getLogger("dagster_iceberg._utils.io")
 
 
-class WriteMode(StrEnum):
+class WriteMode(Enum):
     append = "append"
     overwrite = "overwrite"
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/io.py
@@ -147,13 +147,13 @@ def table_writer(
     else:
         row_filter = iceberg_table.ALWAYS_TRUE
 
-    snapshot_properties = base_properties | {"dagster-partition-key": dagster_partition_key} if dagster_partition_key is not None else base_properties
+    snapshot_properties = (
+        base_properties | {"dagster-partition-key": dagster_partition_key}
+        if dagster_partition_key is not None
+        else base_properties
+    )
     if write_mode == WriteMode.append:
-        append_to_table(
-            table=table,
-            data=data,
-            snapshot_properties=snapshot_properties
-        )
+        append_to_table(table=table, data=data, snapshot_properties=snapshot_properties)
     elif write_mode == WriteMode.overwrite:
         overwrite_table(
             table=table,

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -93,8 +93,12 @@ class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
 
     def _get_write_mode(self, context: OutputContext) -> WriteMode:
         try:
-            definition_write_mode = WriteMode(context.definition_metadata.get("write_mode", DEFAULT_WRITE_MODE))
-            return WriteMode(context.output_metadata.get("write_mode", definition_write_mode).value)
+            definition_write_mode = WriteMode(
+                context.definition_metadata.get("write_mode", DEFAULT_WRITE_MODE)
+            )
+            return WriteMode(
+                context.output_metadata.get("write_mode", definition_write_mode).value
+            )
         except ValueError as ve:
             error_msg = f"Invalid write mode: {context.output_metadata.get('write_mode')}. Valid modes are {[mode.value for mode in WriteMode]}"
             raise ValueError(error_msg) from ve

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -15,7 +15,7 @@ from pyiceberg import table as ibt
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg._utils import preview, table_writer
-from dagster_iceberg._utils.io import DEFAULT_WRITE_MODE
+from dagster_iceberg._utils.io import DEFAULT_WRITE_MODE, WriteMode
 
 if TYPE_CHECKING:
     from pyiceberg.table.snapshots import Snapshot
@@ -56,11 +56,8 @@ class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
         table_properties_usr = metadata.get("table_properties", {})
         partition_spec_update_mode = metadata.get("partition_spec_update_mode", "error")
         schema_update_mode = metadata.get("schema_update_mode", "error")
-        definition_write_mode = metadata.get("write_mode", DEFAULT_WRITE_MODE)
 
-        write_mode_with_output_override = context.output_metadata.get(
-            "write_mode", definition_write_mode
-        )
+        write_mode_with_output_override = self._get_write_mode(context)
 
         table_writer(
             table_slice=table_slice,
@@ -93,6 +90,14 @@ class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
                 **current_snapshot.model_dump(),
             },
         )
+
+    def _get_write_mode(self, context: OutputContext) -> WriteMode:
+        try:
+            definition_write_mode = WriteMode(context.definition_metadata.get("write_mode", DEFAULT_WRITE_MODE))
+            return WriteMode(context.output_metadata.get("write_mode", definition_write_mode).value)
+        except ValueError as ve:
+            error_msg = f"Invalid write mode: {context.output_metadata.get('write_mode')}. Valid modes are {[mode.value for mode in WriteMode]}"
+            raise ValueError(error_msg) from ve
 
     def load_input(
         self,

--- a/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/handler.py
@@ -15,6 +15,7 @@ from pyiceberg import table as ibt
 from pyiceberg.catalog import Catalog
 
 from dagster_iceberg._utils import preview, table_writer
+from dagster_iceberg._utils.io import DEFAULT_WRITE_MODE
 
 if TYPE_CHECKING:
     from pyiceberg.table.snapshots import Snapshot
@@ -55,6 +56,11 @@ class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
         table_properties_usr = metadata.get("table_properties", {})
         partition_spec_update_mode = metadata.get("partition_spec_update_mode", "error")
         schema_update_mode = metadata.get("schema_update_mode", "error")
+        definition_write_mode = metadata.get("write_mode", DEFAULT_WRITE_MODE)
+
+        write_mode_with_output_override = context.output_metadata.get(
+            "write_mode", definition_write_mode
+        )
 
         table_writer(
             table_slice=table_slice,
@@ -67,6 +73,7 @@ class IcebergBaseTypeHandler(DbTypeHandler[U], Generic[U]):
                 context.partition_key if context.has_asset_partitions else None
             ),
             table_properties=table_properties_usr,
+            write_mode=write_mode_with_output_override,
         )
 
         table_ = connection.load_table(f"{table_slice.schema}.{table_slice.table}")

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/base.py
@@ -177,6 +177,25 @@ class IcebergIOManager(ConfigurableIOManagerFactory):
                 # my_table will just contain the data from column "a"
                 ...
 
+        To select a write mode, set the ``write_mode`` key in the asset definition metadata or at runtime via output metadata.
+        Write mode set at runtime takes precedence over the one set in the definition metadata.
+        Valid modes are ``append`` and ``overwrite``; default is ``overwrite``.
+
+        .. code-block:: python
+            # set at definition time via definition metadata
+            @asset(
+                metadata={"write_mode": "append"}
+            )
+            def my_table_a(my_table: pa.Table):
+                return my_table
+
+            # set at runtime via output metadata
+            @asset
+            def my_table_a(context: AssetExecutionContext, my_table: pa.Table):
+                # my_table will be written with append mode
+                context.add_output_metadata({"write_mode": "append"})
+                return my_table
+
     """
 
     name: str = Field(description="The name of the iceberg catalog.")

--- a/libraries/dagster-iceberg/tests/conftest.py
+++ b/libraries/dagster-iceberg/tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime as dt
 import random
 import shutil
@@ -118,7 +119,10 @@ def namespace_name() -> str:
 
 @pytest.fixture(autouse=True)
 def namespace(catalog: Catalog, namespace_name: str) -> str:
-    catalog.create_namespace(namespace_name)
+    from sqlalchemy.exc import IntegrityError
+
+    with contextlib.suppress(IntegrityError):
+        catalog.create_namespace(namespace_name)
     return namespace_name
 
 

--- a/libraries/dagster-iceberg/tests/conftest.py
+++ b/libraries/dagster-iceberg/tests/conftest.py
@@ -119,10 +119,7 @@ def namespace_name() -> str:
 
 @pytest.fixture(autouse=True)
 def namespace(catalog: Catalog, namespace_name: str) -> str:
-    from sqlalchemy.exc import IntegrityError
-
-    with contextlib.suppress(IntegrityError):
-        catalog.create_namespace(namespace_name)
+    catalog.create_namespace_if_not_exists(namespace_name)
     return namespace_name
 
 

--- a/libraries/dagster-iceberg/tests/conftest.py
+++ b/libraries/dagster-iceberg/tests/conftest.py
@@ -1,4 +1,3 @@
-import contextlib
 import datetime as dt
 import random
 import shutil

--- a/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
@@ -56,6 +56,21 @@ def asset_multi_partitioned_table_identifier(namespace: str) -> str:
     return f"{namespace}.multi_partitioned"
 
 
+@pytest.fixture
+def asset_daily_partitioned_append_mode_table_identifier(namespace: str) -> str:
+    return f"{namespace}.daily_partitioned_append_mode"
+
+
+@pytest.fixture
+def asset_multi_partitioned_append_mode_table_identifier(namespace: str) -> str:
+    return f"{namespace}.multi_partitioned_append_mode"
+
+
+@pytest.fixture
+def asset_multi_partitioned_overwrite_mode_table_identifier(namespace: str) -> str:
+    return f"{namespace}.multi_partitioned_overwrite_mode"
+
+
 @asset(
     key_prefix=["my_schema"],
     metadata={"partition_spec_update_mode": "update", "schema_update_mode": "update"},
@@ -78,6 +93,37 @@ def b_plus_one(b_df: pl.LazyFrame) -> pl.LazyFrame:
 )
 def daily_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
     partition = datetime.datetime.strptime(context.partition_key, "%Y-%m-%d").date()
+    value = context.op_execution_context.op_config["value"]
+
+    return pl.from_dict({"partition": [partition], "value": [value], "b": [1]})
+
+
+@asset(
+    key_prefix=["my_schema"],
+    partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
+    config_schema={"value": str},
+    metadata={"partition_expr": "partition"},
+)
+def daily_partitioned_append_mode(context: AssetExecutionContext) -> pl.DataFrame:
+    partition = datetime.datetime.strptime(context.partition_key, "%Y-%m-%d").date()
+    value = context.op_execution_context.op_config["value"]
+
+    context.add_output_metadata({"write_mode": "append"})
+    return pl.from_dict({"partition": [partition], "value": [value], "b": [1]})
+
+
+@asset(
+    key_prefix=["my_schema"],
+    partitions_def=HourlyPartitionsDefinition(
+        start_date=datetime.datetime(2022, 1, 1, 0)
+    ),
+    config_schema={"value": str},
+    metadata={"partition_expr": "partition", "write_mode": "append"},
+)
+def hourly_partitioned_append_mode(
+    context: AssetExecutionContext,
+) -> pl.DataFrame:
+    partition = datetime.datetime.strptime(context.partition_key, "%Y-%m-%d-%H:%M")
     value = context.op_execution_context.op_config["value"]
 
     return pl.from_dict({"partition": [partition], "value": [value], "b": [1]})
@@ -131,124 +177,344 @@ def multi_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
         },
     )
 
+@asset(
+    key_prefix=["my_schema"],
+    partitions_def=MultiPartitionsDefinition(
+        partitions_defs={
+            "date": DailyPartitionsDefinition(
+                start_date="2022-01-01",
+                end_date="2022-01-10",
+            ),
+            "category": StaticPartitionsDefinition(["a", "b", "c"]),
+        },
+    ),
+    config_schema={"value": str},
+    metadata={
+        "partition_expr": {
+            "date": "date_this",
+            "category": "category_this",
+        },
+        "write_mode": "append",
+    },
+)
+def multi_partitioned_append_mode(context: AssetExecutionContext) -> pl.DataFrame:
+    category, date = context.partition_key.split("|")
+    date_parsed = datetime.datetime.strptime(date, "%Y-%m-%d").date()
+    value = context.op_execution_context.op_config["value"]
 
-def test_iceberg_io_manager_with_assets(
-    asset_b_df_table_identifier: str,
-    asset_b_plus_one_table_identifier: str,
-    catalog: Catalog,
-    io_manager: PolarsIcebergIOManager,
-):
-    resource_defs = {"io_manager": io_manager}
+    return pl.from_dict(
+        {
+            "date_this": [date_parsed],
+            "value": [value],
+            "b": [1],
+            "category_this": [category],
+        },
+    )
 
-    for _ in range(2):
-        res = materialize([b_df, b_plus_one], resources=resource_defs)
-        assert res.success
+@asset(
+    key_prefix=["my_schema"],
+    partitions_def=MultiPartitionsDefinition(
+        partitions_defs={
+            "date": DailyPartitionsDefinition(
+                start_date="2022-01-01",
+                end_date="2022-01-10",
+            ),
+            "category": StaticPartitionsDefinition(["a", "b", "c"]),
+        },
+    ),
+    config_schema={"value": str},
+    metadata={
+        "partition_expr": {
+            "date": "date_this",
+            "category": "category_this",
+        },
+        "write_mode": "overwrite",
+    },
+)
+def multi_partitioned_overwrite_mode(context: AssetExecutionContext) -> pl.DataFrame:
+    category, date = context.partition_key.split("|")
+    date_parsed = datetime.datetime.strptime(date, "%Y-%m-%d").date()
+    value = context.op_execution_context.op_config["value"]
 
-        table = catalog.load_table(asset_b_df_table_identifier)
+    return pl.from_dict(
+        {
+            "date_this": [date_parsed],
+            "value": [value],
+            "b": [1],
+            "category_this": [category],
+        },
+    )
+
+
+class TestIcebergIOManager:
+
+    def test_output_input_loading_for_asset_dependencies_with_overwrite(
+        self,
+        asset_b_df_table_identifier: str,
+        asset_b_plus_one_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager,
+    ):
+        resource_defs = {"io_manager": io_manager}
+
+        for _ in range(2):
+            res = materialize([b_df, b_plus_one], resources=resource_defs)
+            assert res.success
+
+            table = catalog.load_table(asset_b_df_table_identifier)
+            out_df = table.scan().to_arrow()
+            assert out_df["a"].to_pylist() == [1, 2, 3]
+
+            dt = catalog.load_table(asset_b_plus_one_table_identifier)
+            out_dt = dt.scan().to_arrow()
+            assert out_dt["a"].to_pylist() == [2, 3, 4]
+
+    def test_daily_partitioned_assets(
+        self,
+        asset_daily_partitioned_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager,
+    ):
+        resource_defs = {"io_manager": io_manager}
+
+        for date in ["2022-01-01", "2022-01-02", "2022-01-03"]:
+            res = materialize(
+                [daily_partitioned],
+                partition_key=date,
+                resources=resource_defs,
+                run_config={
+                    "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}},
+                },
+            )
+            assert res.success
+
+        table = catalog.load_table(asset_daily_partitioned_table_identifier)
+        assert len(table.spec().fields) == 1
+        assert table.spec().fields[0].name == "partition"
+
         out_df = table.scan().to_arrow()
-        assert out_df["a"].to_pylist() == [1, 2, 3]
+        assert out_df["partition"].to_pylist() == [
+            datetime.date(2022, 1, 3),
+            datetime.date(2022, 1, 2),
+            datetime.date(2022, 1, 1),
+        ]
 
-        dt = catalog.load_table(asset_b_plus_one_table_identifier)
-        out_dt = dt.scan().to_arrow()
-        assert out_dt["a"].to_pylist() == [2, 3, 4]
+    def test_daily_partitioned_assets_overwrite_mode(
+        self,
+        asset_daily_partitioned_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager,
+    ):
+        resource_defs = {"io_manager": io_manager}
 
+        for date, value in [("2022-01-01", "1"), ("2022-01-01", "2"), ("2022-01-01", "3")]:
+            res = materialize(
+                [daily_partitioned],
+                partition_key=date,
+                resources=resource_defs,
+                run_config={
+                    "ops": {"my_schema__daily_partitioned": {"config": {"value": value}}},
+                },
+            )
+            assert res.success
 
-def test_iceberg_io_manager_with_daily_partitioned_assets(
-    asset_daily_partitioned_table_identifier: str,
-    catalog: Catalog,
-    io_manager: PolarsIcebergIOManager,
-):
-    resource_defs = {"io_manager": io_manager}
+        table = catalog.load_table(asset_daily_partitioned_table_identifier)
+        assert len(table.spec().fields) == 1
+        assert table.spec().fields[0].name == "partition"
 
-    for date in ["2022-01-01", "2022-01-02", "2022-01-03"]:
-        res = materialize(
-            [daily_partitioned],
-            partition_key=date,
-            resources=resource_defs,
-            run_config={
-                "ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}},
-            },
-        )
-        assert res.success
+        out_df = table.scan().to_arrow()
+        assert len(out_df) == 1
+        assert out_df["partition"].to_pylist() == [
+            datetime.date(2022, 1, 1),
+        ]
+        assert out_df["value"].to_pylist() == ["3"]
 
-    table = catalog.load_table(asset_daily_partitioned_table_identifier)
-    assert len(table.spec().fields) == 1
-    assert table.spec().fields[0].name == "partition"
+    def test_daily_partitioned_assets_append_mode(
+        self,
+        asset_daily_partitioned_append_mode_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager,
+    ):
+        resource_defs = {"io_manager": io_manager}
 
-    out_df = table.scan().to_arrow()
-    assert out_df["partition"].to_pylist() == [
-        datetime.date(2022, 1, 3),
-        datetime.date(2022, 1, 2),
-        datetime.date(2022, 1, 1),
-    ]
+        for date in ["2022-01-01", "2022-01-01", "2022-01-02"]:
+            res = materialize(
+                [daily_partitioned_append_mode],
+                partition_key=date,
+                resources=resource_defs,
+                run_config={
+                    "ops": {
+                        "my_schema__daily_partitioned_append_mode": {
+                            "config": {"value": "1"}
+                        }
+                    },
+                },
+            )
+            assert res.success
 
+        table = catalog.load_table(asset_daily_partitioned_append_mode_table_identifier)
+        assert len(table.spec().fields) == 1
+        assert table.spec().fields[0].name == "partition"
 
-def test_iceberg_io_manager_with_hourly_partitioned_assets(
-    asset_hourly_partitioned_table_identifier: str,
-    catalog: Catalog,
-    io_manager: PolarsIcebergIOManager,
-):
-    resource_defs = {"io_manager": io_manager}
+        out_df = table.scan().to_arrow()
+        assert sorted(out_df["partition"].to_pylist()) == [
+            datetime.date(2022, 1, 1),
+            datetime.date(2022, 1, 1),
+            datetime.date(2022, 1, 2),
+        ]
+        assert out_df["value"].to_pylist() == ["1", "1", "1"]
 
-    for date in ["2022-01-01-01:00", "2022-01-01-02:00", "2022-01-01-03:00"]:
-        res = materialize(
-            [hourly_partitioned],
-            partition_key=date,
-            resources=resource_defs,
-            run_config={
-                "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
-            },
-        )
-        assert res.success
+    def test_hourly_partitioned_assets(
+        self,
+        asset_hourly_partitioned_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager,
+    ):
+        resource_defs = {"io_manager": io_manager}
 
-    table = catalog.load_table(asset_hourly_partitioned_table_identifier)
-    assert len(table.spec().fields) == 1
-    assert table.spec().fields[0].name == "partition"
+        for date in ["2022-01-01-01:00", "2022-01-01-02:00", "2022-01-01-03:00"]:
+            res = materialize(
+                [hourly_partitioned],
+                partition_key=date,
+                resources=resource_defs,
+                run_config={
+                    "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
+                },
+            )
+            assert res.success
 
-    out_df = table.scan().to_arrow()
-    assert out_df["partition"].to_pylist() == [
-        datetime.datetime(2022, 1, 1, 3, 0),
-        datetime.datetime(2022, 1, 1, 2, 0),
-        datetime.datetime(2022, 1, 1, 1, 0),
-    ]
+        table = catalog.load_table(asset_hourly_partitioned_table_identifier)
+        assert len(table.spec().fields) == 1
+        assert table.spec().fields[0].name == "partition"
 
+        out_df = table.scan().to_arrow()
+        assert out_df["partition"].to_pylist() == [
+            datetime.datetime(2022, 1, 1, 3, 0),
+            datetime.datetime(2022, 1, 1, 2, 0),
+            datetime.datetime(2022, 1, 1, 1, 0),
+        ]
 
-def test_iceberg_io_manager_with_multipartitioned_assets(
-    asset_multi_partitioned_table_identifier: str,
-    catalog: Catalog,
-    io_manager: PolarsIcebergIOManager,
-):
-    resource_defs = {"io_manager": io_manager}
+    def test_multipartitioned_assets(
+        self,
+        asset_multi_partitioned_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager,
+    ):
+        resource_defs = {"io_manager": io_manager}
 
-    for key in [
-        "a|2022-01-01",
-        "b|2022-01-01",
-        "c|2022-01-01",
-        "a|2022-01-02",
-        "b|2022-01-02",
-        "c|2022-01-02",
-    ]:
-        res = materialize(
-            [multi_partitioned],
-            partition_key=key,
-            resources=resource_defs,
-            run_config={
-                "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}},
-            },
-        )
-        assert res.success
+        for key in [
+            "a|2022-01-01",
+            "b|2022-01-01",
+            "c|2022-01-01",
+            "a|2022-01-02",
+            "b|2022-01-02",
+            "c|2022-01-02",
+        ]:
+            res = materialize(
+                [multi_partitioned],
+                partition_key=key,
+                resources=resource_defs,
+                run_config={
+                    "ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}},
+                },
+            )
+            assert res.success
 
-    table = catalog.load_table(asset_multi_partitioned_table_identifier)
-    assert len(table.spec().fields) == 2
-    assert [f.name for f in table.spec().fields] == ["category_this", "date_this"]
+        table = catalog.load_table(asset_multi_partitioned_table_identifier)
+        assert len(table.spec().fields) == 2
+        assert [f.name for f in table.spec().fields] == ["category_this", "date_this"]
 
-    out_df = table.scan().to_arrow()
-    assert out_df["date_this"].to_pylist() == [
-        datetime.date(2022, 1, 2),
-        datetime.date(2022, 1, 2),
-        datetime.date(2022, 1, 2),
-        datetime.date(2022, 1, 1),
-        datetime.date(2022, 1, 1),
-        datetime.date(2022, 1, 1),
-    ]
-    assert out_df["category_this"].to_pylist() == ["c", "b", "a", "c", "b", "a"]
+        out_df = table.scan().to_arrow()
+        assert out_df["date_this"].to_pylist() == [
+            datetime.date(2022, 1, 2),
+            datetime.date(2022, 1, 2),
+            datetime.date(2022, 1, 2),
+            datetime.date(2022, 1, 1),
+            datetime.date(2022, 1, 1),
+            datetime.date(2022, 1, 1),
+        ]
+        assert out_df["category_this"].to_pylist() == ["c", "b", "a", "c", "b", "a"]
+
+    def test_multipartitioned_assets_append_mode(
+        self,
+        asset_multi_partitioned_append_mode_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager):
+        resource_defs = {"io_manager": io_manager}
+        keys = [
+                "a|2022-01-01",
+                "b|2022-01-01",
+                "c|2022-01-01",
+                "a|2022-01-01",
+                "b|2022-01-01",
+                "c|2022-01-01",
+            ]
+        for key in keys:
+            res = materialize(
+                [multi_partitioned_append_mode],
+                partition_key=key,
+                resources=resource_defs,
+                run_config={
+                    "ops": {"my_schema__multi_partitioned_append_mode": {"config": {"value": "1"}}},
+                },
+            )
+            assert res.success
+
+        table = catalog.load_table(asset_multi_partitioned_append_mode_table_identifier)
+        assert len(table.spec().fields) == 2
+        assert [f.name for f in table.spec().fields] == ["category_this", "date_this"]
+
+        out_df = table.scan().to_arrow()
+        assert len(out_df) == len(keys)
+
+        date_this_values = set(out_df["date_this"].to_pylist())
+        assert len(date_this_values) == 1
+        expected_date_this_values = {datetime.datetime.strptime(k.split("|")[1], "%Y-%m-%d").date() for k in keys}
+        assert date_this_values == expected_date_this_values
+
+        category_this_values = set(out_df["category_this"].to_pylist())
+        assert len(category_this_values) == 3
+        expected_category_this_values = {k.split("|")[0] for k in keys}
+        assert category_this_values == expected_category_this_values
+
+    def test_multipartitioned_assets_overwrite_mode(
+        self,
+        asset_multi_partitioned_overwrite_mode_table_identifier: str,
+        catalog: Catalog,
+        io_manager: PolarsIcebergIOManager):
+        resource_defs = {"io_manager": io_manager}
+        keys = [
+                "a|2022-01-01",
+                "b|2022-01-01",
+                "c|2022-01-01",
+                "a|2022-01-01",
+                "b|2022-01-01",
+                "c|2022-01-01",
+            ]
+        for key in keys:
+            res = materialize(
+                [multi_partitioned_overwrite_mode],
+                partition_key=key,
+                resources=resource_defs,
+                run_config={
+                    "ops": {"my_schema__multi_partitioned_overwrite_mode": {"config": {"value": "1"}}},
+                },
+            )
+            assert res.success
+
+        table = catalog.load_table(asset_multi_partitioned_overwrite_mode_table_identifier)
+        assert len(table.spec().fields) == 2
+        assert [f.name for f in table.spec().fields] == ["category_this", "date_this"]
+
+        out_df = table.scan().to_arrow()
+        assert len(out_df) == 3
+
+        date_this_values = set(out_df["date_this"].to_pylist())
+        assert len(date_this_values) == 1
+        expected_date_this_values = {datetime.datetime.strptime(k.split("|")[1], "%Y-%m-%d").date() for k in keys}
+        assert date_this_values == expected_date_this_values
+
+        category_this_values = set(out_df["category_this"].to_pylist())
+        assert len(category_this_values) == 3
+        expected_category_this_values = {k.split("|")[0] for k in keys}
+        assert category_this_values == expected_category_this_values

--- a/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
@@ -102,9 +102,7 @@ def daily_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
     key_prefix=["my_schema"],
     partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
     config_schema={"value": str},
-    metadata={"partition_expr": "partition",
-              "write_mode": "overwrite"
-              },
+    metadata={"partition_expr": "partition", "write_mode": "overwrite"},
 )
 def daily_partitioned_append_mode(context: AssetExecutionContext) -> pl.DataFrame:
     partition = datetime.datetime.strptime(context.partition_key, "%Y-%m-%d").date()

--- a/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
@@ -177,6 +177,7 @@ def multi_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
         },
     )
 
+
 @asset(
     key_prefix=["my_schema"],
     partitions_def=MultiPartitionsDefinition(
@@ -210,6 +211,7 @@ def multi_partitioned_append_mode(context: AssetExecutionContext) -> pl.DataFram
             "category_this": [category],
         },
     )
+
 
 @asset(
     key_prefix=["my_schema"],
@@ -247,7 +249,6 @@ def multi_partitioned_overwrite_mode(context: AssetExecutionContext) -> pl.DataF
 
 
 class TestIcebergIOManager:
-
     def test_output_input_loading_for_asset_dependencies_with_overwrite(
         self,
         asset_b_df_table_identifier: str,
@@ -307,13 +308,19 @@ class TestIcebergIOManager:
     ):
         resource_defs = {"io_manager": io_manager}
 
-        for date, value in [("2022-01-01", "1"), ("2022-01-01", "2"), ("2022-01-01", "3")]:
+        for date, value in [
+            ("2022-01-01", "1"),
+            ("2022-01-01", "2"),
+            ("2022-01-01", "3"),
+        ]:
             res = materialize(
                 [daily_partitioned],
                 partition_key=date,
                 resources=resource_defs,
                 run_config={
-                    "ops": {"my_schema__daily_partitioned": {"config": {"value": value}}},
+                    "ops": {
+                        "my_schema__daily_partitioned": {"config": {"value": value}}
+                    },
                 },
             )
             assert res.success
@@ -378,7 +385,9 @@ class TestIcebergIOManager:
                 partition_key=date,
                 resources=resource_defs,
                 run_config={
-                    "ops": {"my_schema__hourly_partitioned": {"config": {"value": "1"}}},
+                    "ops": {
+                        "my_schema__hourly_partitioned": {"config": {"value": "1"}}
+                    },
                 },
             )
             assert res.success
@@ -439,23 +448,28 @@ class TestIcebergIOManager:
         self,
         asset_multi_partitioned_append_mode_table_identifier: str,
         catalog: Catalog,
-        io_manager: PolarsIcebergIOManager):
+        io_manager: PolarsIcebergIOManager,
+    ):
         resource_defs = {"io_manager": io_manager}
         keys = [
-                "a|2022-01-01",
-                "b|2022-01-01",
-                "c|2022-01-01",
-                "a|2022-01-01",
-                "b|2022-01-01",
-                "c|2022-01-01",
-            ]
+            "a|2022-01-01",
+            "b|2022-01-01",
+            "c|2022-01-01",
+            "a|2022-01-01",
+            "b|2022-01-01",
+            "c|2022-01-01",
+        ]
         for key in keys:
             res = materialize(
                 [multi_partitioned_append_mode],
                 partition_key=key,
                 resources=resource_defs,
                 run_config={
-                    "ops": {"my_schema__multi_partitioned_append_mode": {"config": {"value": "1"}}},
+                    "ops": {
+                        "my_schema__multi_partitioned_append_mode": {
+                            "config": {"value": "1"}
+                        }
+                    },
                 },
             )
             assert res.success
@@ -469,7 +483,9 @@ class TestIcebergIOManager:
 
         date_this_values = set(out_df["date_this"].to_pylist())
         assert len(date_this_values) == 1
-        expected_date_this_values = {datetime.datetime.strptime(k.split("|")[1], "%Y-%m-%d").date() for k in keys}
+        expected_date_this_values = {
+            datetime.datetime.strptime(k.split("|")[1], "%Y-%m-%d").date() for k in keys
+        }
         assert date_this_values == expected_date_this_values
 
         category_this_values = set(out_df["category_this"].to_pylist())
@@ -481,28 +497,35 @@ class TestIcebergIOManager:
         self,
         asset_multi_partitioned_overwrite_mode_table_identifier: str,
         catalog: Catalog,
-        io_manager: PolarsIcebergIOManager):
+        io_manager: PolarsIcebergIOManager,
+    ):
         resource_defs = {"io_manager": io_manager}
         keys = [
-                "a|2022-01-01",
-                "b|2022-01-01",
-                "c|2022-01-01",
-                "a|2022-01-01",
-                "b|2022-01-01",
-                "c|2022-01-01",
-            ]
+            "a|2022-01-01",
+            "b|2022-01-01",
+            "c|2022-01-01",
+            "a|2022-01-01",
+            "b|2022-01-01",
+            "c|2022-01-01",
+        ]
         for key in keys:
             res = materialize(
                 [multi_partitioned_overwrite_mode],
                 partition_key=key,
                 resources=resource_defs,
                 run_config={
-                    "ops": {"my_schema__multi_partitioned_overwrite_mode": {"config": {"value": "1"}}},
+                    "ops": {
+                        "my_schema__multi_partitioned_overwrite_mode": {
+                            "config": {"value": "1"}
+                        }
+                    },
                 },
             )
             assert res.success
 
-        table = catalog.load_table(asset_multi_partitioned_overwrite_mode_table_identifier)
+        table = catalog.load_table(
+            asset_multi_partitioned_overwrite_mode_table_identifier
+        )
         assert len(table.spec().fields) == 2
         assert [f.name for f in table.spec().fields] == ["category_this", "date_this"]
 
@@ -511,7 +534,9 @@ class TestIcebergIOManager:
 
         date_this_values = set(out_df["date_this"].to_pylist())
         assert len(date_this_values) == 1
-        expected_date_this_values = {datetime.datetime.strptime(k.split("|")[1], "%Y-%m-%d").date() for k in keys}
+        expected_date_this_values = {
+            datetime.datetime.strptime(k.split("|")[1], "%Y-%m-%d").date() for k in keys
+        }
         assert date_this_values == expected_date_this_values
 
         category_this_values = set(out_df["category_this"].to_pylist())

--- a/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
+++ b/libraries/dagster-iceberg/tests/io_managers/test_polars_io_manager.py
@@ -102,7 +102,9 @@ def daily_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
     key_prefix=["my_schema"],
     partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
     config_schema={"value": str},
-    metadata={"partition_expr": "partition"},
+    metadata={"partition_expr": "partition",
+              "write_mode": "overwrite"
+              },
 )
 def daily_partitioned_append_mode(context: AssetExecutionContext) -> pl.DataFrame:
     partition = datetime.datetime.strptime(context.partition_key, "%Y-%m-%d").date()

--- a/libraries/dagster-iceberg/tests/test_handler.py
+++ b/libraries/dagster-iceberg/tests/test_handler.py
@@ -1,0 +1,311 @@
+from unittest.mock import Mock, patch
+
+import pyarrow as pa
+import pytest
+from dagster import build_output_context
+from dagster._core.storage.db_io_manager import TableSlice
+from pyiceberg.catalog import Catalog
+
+from dagster_iceberg.handler import IcebergBaseTypeHandler, WriteMode
+
+
+class MockTypeHandler(IcebergBaseTypeHandler[pa.Table]):
+    """Mock type handler for testing."""
+
+    def to_data_frame(self, table, table_slice, target_type):
+        return table.scan().to_arrow()
+
+    def to_arrow(self, obj):
+        return obj
+
+
+@pytest.fixture
+def mock_catalog():
+    """Mock catalog for testing."""
+    catalog = Mock(spec=Catalog)
+    mock_table = Mock()
+    mock_table.schema.return_value.model_dump.return_value = {
+        "fields": [
+            {"name": "col1", "type": "string"},
+            {"name": "col2", "type": "int32"},
+        ]
+    }
+    mock_snapshot = Mock()
+    mock_snapshot.model_dump.return_value = {"snapshot_id": "test_snapshot"}
+    mock_table.current_snapshot.return_value = mock_snapshot
+    catalog.load_table.return_value = mock_table
+    return catalog
+
+
+@pytest.fixture
+def table_slice():
+    """Mock table slice for testing."""
+    return TableSlice(
+        table="test_table",
+        schema="test_schema",
+        partition_dimensions=[],
+    )
+
+
+@pytest.fixture
+def mock_table_writer():
+    with patch("dagster_iceberg._utils.io.table_writer") as mock_table_writer:
+        mock_table_writer.return_value = None
+        yield mock_table_writer
+
+
+@pytest.fixture
+def sample_data():
+    """Sample PyArrow table for testing."""
+    return pa.table({"col1": ["a", "b"], "col2": [1, 2]})
+
+
+@pytest.mark.parametrize(
+    [
+        # Test case 1: Definition metadata only
+        (
+            {
+                "write_mode": "append",
+                "partition_spec_update_mode": "update",
+                "schema_update_mode": "update",
+                "table_properties": {"prop1": "value1"},
+            },
+            {},
+            WriteMode.append,
+            "update",
+            "update",
+            {"prop1": "value1"},
+        ),
+        # Test case 2: Output metadata overrides definition metadata
+        (
+            {
+                "write_mode": "overwrite",
+                "partition_spec_update_mode": "error",
+                "schema_update_mode": "error",
+                "table_properties": {"prop1": "value1"},
+            },
+            {"write_mode": "append"},
+            WriteMode.append,
+            "error",
+            "error",
+            {"prop1": "value1"},
+        ),
+    ],
+)
+def test_handle_output_metadata_passing(
+    definition_metadata,
+    output_metadata,
+    expected_write_mode,
+    expected_partition_spec_mode,
+    expected_schema_mode,
+    expected_table_properties,
+    mock_catalog,
+    table_slice,
+    sample_data,
+    mock_table_writer,
+):
+    """Test that metadata from definition and output contexts is passed correctly to table_writer."""
+
+    # Create output context with metadata
+    context = build_output_context(
+        metadata=output_metadata,
+        definition_metadata=definition_metadata,
+        run_id="test_run_id",
+    )
+
+    # Create mock type handler
+    handler = MockTypeHandler()
+
+    # Call handle_output
+    handler.handle_output(
+        context=context,
+        table_slice=table_slice,
+        obj=sample_data,
+        connection=mock_catalog,
+    )
+
+    # Verify table_writer was called
+    mock_table_writer.assert_called_once()
+
+    # Get the call arguments
+    call_args = mock_table_writer.call_args
+
+    # Verify all expected parameters were passed
+    assert call_args.kwargs["dagster_run_id"] == "test_run_id"
+    assert (
+        call_args.kwargs["dagster_partition_key"] is None
+    )  # No partitions in this test
+
+    # Verify metadata-derived parameters
+    assert call_args.kwargs["write_mode"] == expected_write_mode
+    assert (
+        call_args.kwargs["partition_spec_update_mode"] == expected_partition_spec_mode
+    )
+    assert call_args.kwargs["schema_update_mode"] == expected_schema_mode
+    assert call_args.kwargs["table_properties"] == expected_table_properties
+
+
+class TestHandleOutput:
+    def test_append_output_metadata_overrides_definition_metadata(
+        self, mock_catalog, table_slice, sample_data, mock_table_writer
+    ):
+        """Test that output metadata takes priority over definition metadata."""
+
+        definition_metadata = {
+            "write_mode": "overwrite",
+            "partition_spec_update_mode": "error",
+            "schema_update_mode": "error",
+            "table_properties": {"def_prop": "def_value"},
+        }
+
+        output_metadata = {
+            "write_mode": "append",
+            "partition_spec_update_mode": "update",
+            "schema_update_mode": "update",
+            "table_properties": {"output_prop": "output_value"},
+        }
+
+        context = build_output_context(
+            metadata=output_metadata,
+            definition_metadata=definition_metadata,
+            run_id="test_run_id",
+        )
+
+        handler = MockTypeHandler()
+
+        with patch("dagster_iceberg._utils.io.table_writer") as mock_table_writer:
+            mock_table_writer.return_value = None
+
+            handler.handle_output(
+                context=context,
+                table_slice=table_slice,
+                obj=sample_data,
+                connection=mock_catalog,
+            )
+
+            # Verify output metadata takes priority
+            call_args = mock_table_writer.call_args
+            assert call_args.kwargs["write_mode"] == WriteMode.append
+            assert call_args.kwargs["partition_spec_update_mode"] == "update"
+            assert call_args.kwargs["schema_update_mode"] == "update"
+            assert call_args.kwargs["table_properties"] == {
+                "output_prop": "output_value"
+            }
+
+
+
+def test_handle_output_with_partitions(
+    mock_catalog,
+    sample_data,
+):
+    """Test handle_output with partitioned assets."""
+
+    # Create table slice with partitions
+    table_slice = TableSlice(
+        table="test_table",
+        schema="test_schema",
+        partition_dimensions=[],
+    )
+
+    # Create context with partition key
+    context = build_output_context(
+        metadata={"write_mode": "append"},
+        definition_metadata={"partition_spec_update_mode": "update"},
+        run_id="test_run_id",
+        partition_key="2022-01-01",
+    )
+
+    # Mock has_asset_partitions to return True
+    context.has_asset_partitions = True
+
+    handler = MockTypeHandler()
+
+    with patch("dagster_iceberg._utils.io.table_writer") as mock_table_writer:
+        mock_table_writer.return_value = None
+
+        handler.handle_output(
+            context=context,
+            table_slice=table_slice,
+            obj=sample_data,
+            connection=mock_catalog,
+        )
+
+        # Verify partition key was passed
+        call_args = mock_table_writer.call_args
+        assert call_args.kwargs["dagster_partition_key"] == "2022-01-01"
+
+
+def test_handle_output_metadata_priority(
+    mock_catalog,
+    table_slice,
+    sample_data,
+):
+    """Test that output metadata takes priority over definition metadata."""
+
+    definition_metadata = {
+        "write_mode": "overwrite",
+        "partition_spec_update_mode": "error",
+        "schema_update_mode": "error",
+        "table_properties": {"def_prop": "def_value"},
+    }
+
+    output_metadata = {
+        "write_mode": "append",
+        "partition_spec_update_mode": "update",
+        "schema_update_mode": "update",
+        "table_properties": {"output_prop": "output_value"},
+    }
+
+    context = build_output_context(
+        metadata=output_metadata,
+        definition_metadata=definition_metadata,
+        run_id="test_run_id",
+    )
+
+    handler = MockTypeHandler()
+
+    with patch("dagster_iceberg._utils.io.table_writer") as mock_table_writer:
+        mock_table_writer.return_value = None
+
+        handler.handle_output(
+            context=context,
+            table_slice=table_slice,
+            obj=sample_data,
+            connection=mock_catalog,
+        )
+
+        # Verify output metadata takes priority
+        call_args = mock_table_writer.call_args
+        assert call_args.kwargs["write_mode"] == WriteMode.append
+        assert call_args.kwargs["partition_spec_update_mode"] == "update"
+        assert call_args.kwargs["schema_update_mode"] == "update"
+        assert call_args.kwargs["table_properties"] == {"output_prop": "output_value"}
+
+
+def test_handle_output_adds_metadata_to_context(
+    mock_catalog,
+    table_slice,
+    sample_data,
+):
+    """Test that handle_output adds metadata to the context."""
+
+    context = build_output_context(
+        metadata={},
+        definition_metadata={},
+        run_id="test_run_id",
+    )
+
+    handler = MockTypeHandler()
+
+    with patch("dagster_iceberg._utils.io.table_writer"):
+        handler.handle_output(
+            context=context,
+            table_slice=table_slice,
+            obj=sample_data,
+            connection=mock_catalog,
+        )
+
+        # Verify that metadata was added to context
+        # This tests the second part of handle_output that adds metadata
+        assert "table_columns" in context.output_metadata
+        assert "snapshot_id" in context.output_metadata

--- a/libraries/dagster-iceberg/tests/test_handler.py
+++ b/libraries/dagster-iceberg/tests/test_handler.py
@@ -140,4 +140,3 @@ def test_handle_output_metadata_passing(
     )
     assert "table_columns" in context.output_metadata
     assert "snapshot_id" in context.output_metadata
-

--- a/libraries/dagster-iceberg/tests/test_handler.py
+++ b/libraries/dagster-iceberg/tests/test_handler.py
@@ -61,59 +61,30 @@ def sample_data():
     return pa.table({"col1": ["a", "b"], "col2": [1, 2]})
 
 
-@pytest.mark.parametrize(
-    [
-        (
-            {
-                "write_mode": "append",
-                "partition_spec_update_mode": "update",
-                "schema_update_mode": "update",
-                "table_properties": {"prop1": "value1"},
-                "partition_key": "2022-01-01",
-            },
-            {},
-            WriteMode.append,
-            "update",
-            "update",
-            {"prop1": "value1"},
-            "2022-01-01",
-        ),
-        # Test that output metadata overrides definition metadata for write mode
-        (
-            {
-                "write_mode": "overwrite",
-                "partition_spec_update_mode": "error",
-                "schema_update_mode": "error",
-                "table_properties": {"prop1": "value1"},
-                "partition_key": None,
-            },
-            {"write_mode": "append"},
-            WriteMode.append,
-            "error",
-            "error",
-            {"prop1": "value1"},
-            None,
-        ),
-    ],
-)
 def test_handle_output_metadata_passing(
-    definition_metadata,
-    output_metadata,
-    expected_write_mode,
-    expected_partition_spec_mode,
-    expected_schema_mode,
-    expected_table_properties,
     mock_catalog,
     table_slice,
     sample_data,
-    expected_partition_key,
     mock_table_writer,
 ):
     """Test that metadata from definition and output contexts is passed correctly to table_writer. Useful for testing overrides or calculated values"""
 
+    # Test that output metadata overrides definition metadata for write mode
+    definition_metadata = {
+        "write_mode": "overwrite",
+        "partition_spec_update_mode": "error",
+        "schema_update_mode": "error",
+        "table_properties": {"prop1": "value1"},
+        "partition_key": None,
+    }
+    expected_write_mode = WriteMode.append
+    expected_partition_spec_mode = "error"
+    expected_schema_mode = "error"
+    expected_table_properties = {"prop1": "value1"}
+    expected_partition_key = None
+
     run_id = str(uuid4())
     context = build_output_context(
-        metadata=output_metadata,
         definition_metadata=definition_metadata,
         run_id=run_id,
     )


### PR DESCRIPTION
## Summary & Motivation
Fixes #231 

This PR adds support for append mode to the Iceberg IO manager. The write mode can be set in asset definition metadata or at runtime via output metadata, using the key `write_mode`. Valid options are `append` or `overwrite`. 

## How I Tested These Changes

Added a number of unit tests to show append mode adds new values on top of existing values. Added unit tests for overwrite mode as well to highlight the difference in functionality.

Adding a write mode kind of led to a proliferation of tests... I initially implemented them with `@pytest.parametrize`, but found it to be pretty hard to read, so I switched to just having a test utility method. There's a lot of repetition in the tests already, if folks are open to it I'd be willing to try to bootstrap some testing infrastructure in a future PR.

I initially added tests in the polars-specific test module, but later decided it was probably better to validate the append / overwrite behavior in `test_io.py` instead so it wouldn't be as necessary to test append / overwrite for every IO manager type. With this in mind I could revert or simplify my changes to `test_polars_io_manager.py` if desired. The main reason to still have an asset-level test would be to verify that `write_mode` set on runtime output metadata overrides asset definition metadata... I wasn't able to do this in `test_handler.py` because it appears `build_output_context` doesn't expose an `output_metadata` parameter (something I'll look into making a PR for in the core Dagster repo).
