### PR TITLE
[dagster-polars] fix typo in docs

### DIFF
--- a/libraries/dagster-polars/dagster_polars/io_managers/delta.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/delta.py
@@ -96,7 +96,7 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
             defs = Definitions(
                 assets=[my_table],
                 resources={
-                    "polars_parquet_io_manager": PolarsDeltaIOManager(base_dir="s3://my-bucket/my-dir")
+                    "polars_delta_io_manager": PolarsDeltaIOManager(base_dir="s3://my-bucket/my-dir")
                 }
             )
 


### PR DESCRIPTION
Fixing a typo in the delta IOManager that accidentally referred parquet