### PR TITLE
ducklake optional DATA_PATH for local storage directories

### DIFF
--- a/libraries/dagster-ducklake/CHANGELOG.md
+++ b/libraries/dagster-ducklake/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Allowed `path` to be unspecified when instantiating `DuckLakeLocalDirectory`, because [the data storage location only has to be specified when creating a new DuckLake](https://ducklake.select/docs/stable/duckdb/usage/connecting).
+- Changed the `get_ducklake_sql_parts` functions in `DuckLakeLocalDirectory` and `S3Config` output formatting to include leading commas, so that they are simple to exclude in `_setup_ducklake_connection`.

--- a/libraries/dagster-ducklake/dagster_ducklake/ducklake.py
+++ b/libraries/dagster-ducklake/dagster_ducklake/ducklake.py
@@ -111,18 +111,20 @@ class S3Config(BaseStorageBackend):
                 SCOPE 's3://{self.bucket}'
             );
         """
-        data_path_sql = f"DATA_PATH '{self.full_data_path}'"
+        data_path_sql = f", DATA_PATH '{self.full_data_path}'"
         return secret_sql, data_path_sql
 
 
 class DuckLakeLocalDirectory(BaseStorageBackend):
     """Configuration for a local filesystem storage directory."""
 
-    path: str = Field(description="Path to the local storage directory.")
+    path: str | None = Field(
+        default=None, description="Path to the local storage directory."
+    )
 
     def get_ducklake_sql_parts(self, alias: str) -> tuple[str, str]:
         """For local storage, no credential secret is needed."""
-        return "", f"DATA_PATH '{self.path}'"
+        return "", f", DATA_PATH '{self.path}'" if self.path else ""
 
 
 class DuckLakeResource(DuckDBConnectionProvider):
@@ -232,13 +234,15 @@ class DuckLakeResource(DuckDBConnectionProvider):
             cursor.execute(storage_secret_sql)
 
         ducklake_secret_name = f"secret_{self.alias}"
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
             CREATE OR REPLACE SECRET {ducklake_secret_name} (
                 TYPE DUCKLAKE,
-                {metadata_params_sql},
+                {metadata_params_sql}
                 {storage_data_path_sql}
             );
-        """)
+        """
+        )
 
         options_clause = self._build_attach_options_clause()
         cursor.execute(

--- a/libraries/dagster-ducklake/dagster_ducklake_tests/test_ducklake.py
+++ b/libraries/dagster-ducklake/dagster_ducklake_tests/test_ducklake.py
@@ -165,7 +165,7 @@ class TestS3Config:
         assert "USE_SSL true" in secret_sql
         assert "SCOPE 's3://test-bucket'" in secret_sql
 
-        assert data_path_sql == "DATA_PATH 's3://test-bucket/data/'"
+        assert data_path_sql == ", DATA_PATH 's3://test-bucket/data/'"
 
 
 class TestDuckLakeLocalDirectory:
@@ -182,7 +182,7 @@ class TestDuckLakeLocalDirectory:
         secret_sql, data_path_sql = config.get_ducklake_sql_parts("test_alias")
 
         assert secret_sql == ""
-        assert data_path_sql == "DATA_PATH '/tmp/data'"
+        assert data_path_sql == ", DATA_PATH '/tmp/data'"
 
 
 class TestDuckLakeResource:


### PR DESCRIPTION
## Summary & Motivation

-The `DATA_PATH` parameter is only required when creating a new ducklake, it's read from the metadata catalog for existing ducklakes, see https://ducklake.select/docs/stable/duckdb/usage/connecting. Specifying the path in code too means that the pipeline breaks if you ever change the data path in the catalog. Changing it to an optional parameter to allow dagster to just use the data path from the catalog.

## How I Tested These Changes

- `uv run pytest` -> 25 passed. Imported the updated package into my dagster project and ran it without any errors.

## Changelog

Ensure that an entry has been created in `CHANGELOG.md` outlining additions, deletions, and/or modifications.

See: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)
