### PR TITLE
[dagster-polars] silence pydantic shadow warning on extension override

### DIFF
--- a/libraries/dagster-polars/CHANGELOG.md
+++ b/libraries/dagster-polars/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- The `extension` overrides on `PolarsParquetIOManager` and `PolarsDeltaIOManager` are now declared as `ClassVar[Optional[str]]`, which stops pydantic from treating them as model fields. Previously every import surfaced a `UserWarning: Field name "extension" in "PolarsParquetIOManager" shadows an attribute in parent "BasePolarsUPathIOManager"` (and the same for the delta manager) — that warning is now gone. Includes a regression test asserting no shadow warning is emitted on import.
 - Partitioned assets/outputs now log `dagster/partition_row_count` metadata instead of `dagster/row_count`. See https://docs.dagster.io/guides/build/assets/metadata-and-tags for more details. 
 
 ## Added

--- a/libraries/dagster-polars/dagster_polars/io_managers/delta.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/delta.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from enum import Enum
 from pprint import pformat
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import polars as pl
 from dagster import InputContext, MetadataValue, MultiPartitionKey, OutputContext
@@ -190,7 +190,11 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
 
     """
 
-    extension: str = ".delta"  # ty: ignore
+    # ``ClassVar`` so pydantic stops treating ``extension`` as a model field
+    # and the parent's annotation (``Optional[str]`` on ``UPathIOManager``) is
+    # not reported as shadowed on every import. The parent declares
+    # ``extension`` as an instance var, hence the pyright override silencer.
+    extension: ClassVar[Optional[str]] = ".delta"  # pyright: ignore[reportIncompatibleVariableOverride]
     mode: DeltaWriteMode = DeltaWriteMode.overwrite.value  # type: ignore
     schema_mode: DeltaSchemaMode | None = None
     version: int | None = None

--- a/libraries/dagster-polars/dagster_polars/io_managers/delta.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/delta.py
@@ -193,8 +193,8 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
     # ``ClassVar`` so pydantic stops treating ``extension`` as a model field
     # and the parent's annotation (``Optional[str]`` on ``UPathIOManager``) is
     # not reported as shadowed on every import. The parent declares
-    # ``extension`` as an instance var, hence the pyright override silencer.
-    extension: ClassVar[Optional[str]] = ".delta"  # pyright: ignore[reportIncompatibleVariableOverride]
+    # ``extension`` as an instance var, hence the ty override silencer.
+    extension: ClassVar[Optional[str]] = ".delta"  # ty: ignore[invalid-attribute-override]
     mode: DeltaWriteMode = DeltaWriteMode.overwrite.value  # type: ignore
     schema_mode: DeltaSchemaMode | None = None
     version: int | None = None

--- a/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
@@ -130,8 +130,8 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
     # ``ClassVar`` so pydantic stops treating ``extension`` as a model field
     # and the parent's annotation (``Optional[str]`` on ``UPathIOManager``) is
     # not reported as shadowed on every import. The parent declares
-    # ``extension`` as an instance var, hence the pyright override silencer.
-    extension: ClassVar[Optional[str]] = ".parquet"  # pyright: ignore[reportIncompatibleVariableOverride]
+    # ``extension`` as an instance var, hence the ty override silencer.
+    extension: ClassVar[Optional[str]] = ".parquet"  # ty: ignore[invalid-attribute-override]
 
     def sink_df_to_path(
         self,

--- a/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
+++ b/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 import polars as pl
 import pyarrow.dataset as ds
@@ -127,7 +127,11 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
 
     """
 
-    extension: str = ".parquet"  # ty: ignore
+    # ``ClassVar`` so pydantic stops treating ``extension`` as a model field
+    # and the parent's annotation (``Optional[str]`` on ``UPathIOManager``) is
+    # not reported as shadowed on every import. The parent declares
+    # ``extension`` as an instance var, hence the pyright override silencer.
+    extension: ClassVar[Optional[str]] = ".parquet"  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def sink_df_to_path(
         self,

--- a/libraries/dagster-polars/dagster_polars_tests/test_no_shadow_warning.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_no_shadow_warning.py
@@ -29,8 +29,6 @@ def test_no_extension_shadow_warning_on_import() -> None:
         _reload_io_managers()
 
     shadow = [
-        str(w.message)
-        for w in caught
-        if "shadows an attribute" in str(w.message)
+        str(w.message) for w in caught if "shadows an attribute" in str(w.message)
     ]
     assert not shadow, f"Pydantic shadow warning(s) leaked: {shadow}"

--- a/libraries/dagster-polars/dagster_polars_tests/test_no_shadow_warning.py
+++ b/libraries/dagster-polars/dagster_polars_tests/test_no_shadow_warning.py
@@ -1,0 +1,36 @@
+"""Regression test for the pydantic ``extension`` shadow warning.
+
+Pydantic 2 emits a ``UserWarning`` when a subclass redeclares a field
+that already exists on the parent model. ``UPathIOManager`` (Dagster
+core) declares ``extension: Optional[str] = None``; subclasses that
+overrode it as a plain ``extension: str = ".parquet"`` triggered the
+warning on every import. Declaring the override as ``ClassVar`` stops
+pydantic from treating it as a model field, silencing the warning.
+
+This test reloads both IO manager modules and asserts no shadow
+``UserWarning`` is emitted.
+"""
+
+import importlib
+import warnings
+
+
+def _reload_io_managers() -> None:
+    import dagster_polars.io_managers.delta as delta_module
+    import dagster_polars.io_managers.parquet as parquet_module
+
+    importlib.reload(parquet_module)
+    importlib.reload(delta_module)
+
+
+def test_no_extension_shadow_warning_on_import() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _reload_io_managers()
+
+    shadow = [
+        str(w.message)
+        for w in caught
+        if "shadows an attribute" in str(w.message)
+    ]
+    assert not shadow, f"Pydantic shadow warning(s) leaked: {shadow}"


### PR DESCRIPTION
`PolarsParquetIOManager` and `PolarsDeltaIOManager` both override the `extension` attribute that `UPathIOManager` declares as `Optional[str] = None`. Declaring it as a plain `extension: str = ".parquet"` makes pydantic 2 emit:

```
UserWarning: Field name "extension" in "PolarsParquetIOManager" shadows an attribute in parent "BasePolarsUPathIOManager"
```

…on **every `Definitions` import**. So every `dg` / `dagster` invocation. Downstream projects have been swallowing it with `warnings.filterwarnings("ignore", category=UserWarning, ...)` to keep their stop-hooks and CLIs quiet.

## The fix

Declare the override as `ClassVar[Optional[str]]`. The attribute is still readable at runtime (Dagster's `UPathIOManager` reads `self.extension`) but pydantic no longer registers it as a model field, so the shadow warning goes away:

```python
extension: ClassVar[Optional[str]] = ".parquet"  # pyright: ignore[reportIncompatibleVariableOverride]
```

The pyright `reportIncompatibleVariableOverride` ignore was already there before this PR (because `UPathIOManager` declares `extension` as an instance attribute, not a `ClassVar`), so net change to the `# pyright: ignore` count is zero.

## How I tested it

- Added `dagster_polars_tests/test_no_shadow_warning.py`. It reloads both IO manager modules with `warnings.catch_warnings(record=True)` and asserts no shadow `UserWarning` is emitted.
- Stash-checked: the test fails on the previous code and passes on this branch.
- Manual smoke test: `python -W error::UserWarning -c "from dagster_polars import PolarsParquetIOManager, PolarsDeltaIOManager"` succeeds (would crash before).
- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` all clean.
