### PR TITLE
Fix Iceberg partition expression typing

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/Dockerfile
+++ b/libraries/dagster-iceberg/kitchen-sink/Dockerfile
@@ -37,12 +37,12 @@ RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME} && mkdir -p /home/iceberg/
 WORKDIR ${SPARK_HOME}
 
 # Remember to also update `tests/conftest`'s spark setting
-ENV SPARK_VERSION=3.5.7
+ENV SPARK_VERSION=3.5.8
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.9.1
 ENV PYICEBERG_VERSION=0.9.1
 
-RUN curl --retry 5 -fSL https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+RUN curl --retry 5 -fSL https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 

--- a/libraries/dagster-iceberg/kitchen-sink/Dockerfile
+++ b/libraries/dagster-iceberg/kitchen-sink/Dockerfile
@@ -42,7 +42,7 @@ ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.9.1
 ENV PYICEBERG_VERSION=0.9.1
 
-RUN curl --retry 5 -s -C - https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+RUN curl --retry 5 -fSL https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/partitions.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/partitions.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar, cast
 from dagster._core.definitions import TimeWindow
 from pyiceberg import expressions as E
 from pyiceberg import types as T
+from pyiceberg.expressions.literals import literal
 from pyiceberg.transforms import IdentityTransform
 
 from dagster_iceberg._utils.retries import IcebergOperationWithRetry
@@ -191,7 +192,10 @@ class DagsterPartitionToIcebergExpressionMapper(
         partition_expr: str,
         partition_filters: Sequence[str],
     ) -> E.BooleanExpression | E.LiteralPredicate[str]:
-        predicates = [E.EqualTo(partition_expr, p) for p in partition_filters]
+        predicates = [
+            E.EqualTo(term=E.Reference(name=partition_expr), value=literal(p))
+            for p in partition_filters
+        ]
         if len(predicates) > 1:
             return E.Or(*predicates)
         return predicates[0]
@@ -204,8 +208,14 @@ class DagsterPartitionToIcebergExpressionMapper(
     ) -> E.BooleanExpression:
         return E.And(
             *[
-                E.GreaterThanOrEqual(partition_expr, start_dt.isoformat()),
-                E.LessThan(partition_expr, end_dt.isoformat()),
+                E.GreaterThanOrEqual(
+                    term=E.Reference(name=partition_expr),
+                    value=literal(start_dt.isoformat()),
+                ),
+                E.LessThan(
+                    term=E.Reference(name=partition_expr),
+                    value=literal(end_dt.isoformat()),
+                ),
             ],
         )
 

--- a/libraries/dagster-iceberg/tests/docker/Dockerfile
+++ b/libraries/dagster-iceberg/tests/docker/Dockerfile
@@ -37,12 +37,12 @@ RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME} && mkdir -p /home/iceberg/
 WORKDIR ${SPARK_HOME}
 
 # Remember to also update `tests/conftest`'s spark setting
-ENV SPARK_VERSION=3.5.7
+ENV SPARK_VERSION=3.5.8
 ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.8.0
 ENV PYICEBERG_VERSION=0.8.1
 
-RUN curl --retry 5 -fSL https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+RUN curl --retry 5 -fSL https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 

--- a/libraries/dagster-iceberg/tests/docker/Dockerfile
+++ b/libraries/dagster-iceberg/tests/docker/Dockerfile
@@ -42,7 +42,7 @@ ENV ICEBERG_SPARK_RUNTIME_VERSION=3.5_2.12
 ENV ICEBERG_VERSION=1.8.0
 ENV PYICEBERG_VERSION=0.8.1
 
-RUN curl --retry 5 -s -C - https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+RUN curl --retry 5 -fSL https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 


### PR DESCRIPTION
Fast follow to PR #289 to address type checking failures in the Iceberg partition expression mapper.

## Summary
- Construct PyIceberg predicates with typed keyword arguments
- Wrap expression terms with `E.Reference`
- Wrap predicate values with PyIceberg `literal`

## Validation
- `uv run ruff format src/dagster_iceberg/_utils/partitions.py`
- `uv run ruff check src/dagster_iceberg/_utils/partitions.py`
- `uv run pyright`