### PR TITLE
Skip Teradata functional tests by default

### DIFF
--- a/libraries/dagster-teradata/pyproject.toml
+++ b/libraries/dagster-teradata/pyproject.toml
@@ -38,6 +38,9 @@ packages = [
 [tool.setuptools.dynamic]
 version = {attr = "dagster_teradata.__version__"}
 
+[tool.pytest.ini_options]
+addopts = "--ignore=dagster_teradata_tests/functional/"
+
 [tool.ty.rules]
 unresolved-import = "ignore"
 invalid-argument-type = "ignore"


### PR DESCRIPTION
## Summary
- configure pytest for dagster-teradata to ignore functional tests by default
- matches the existing Makefile test target behavior

## Testing
- cd libraries/dagster-teradata && uv run --python 3.12 pytest