### PR TITLE
Mock Vertex AI SDK calls in tests

### DIFF
--- a/libraries/dagster-vertexai/dagster_vertexai_tests/test_resource.py
+++ b/libraries/dagster-vertexai/dagster_vertexai_tests/test_resource.py
@@ -64,8 +64,12 @@ class FakeGenerativeModel:
 def mock_vertexai(monkeypatch):
     """Avoid live Vertex AI calls and ADC requirements in unit tests."""
 
-    monkeypatch.setattr("dagster_vertexai.resource.vertexai.init", lambda **kwargs: None)
-    monkeypatch.setattr("dagster_vertexai.resource.GenerativeModel", FakeGenerativeModel)
+    monkeypatch.setattr(
+        "dagster_vertexai.resource.vertexai.init", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        "dagster_vertexai.resource.GenerativeModel", FakeGenerativeModel
+    )
 
 
 def test_resource_initialization():

--- a/libraries/dagster-vertexai/dagster_vertexai_tests/test_resource.py
+++ b/libraries/dagster-vertexai/dagster_vertexai_tests/test_resource.py
@@ -34,6 +34,40 @@ VERTEX_AI_RESOURCE_CONFIG = {
 # --- Tests ---
 
 
+class FakeCountTokensResponse:
+    total_tokens = 1
+
+
+class FakeUsageMetadata:
+    candidates_token_count = 2
+    prompt_token_count = 3
+    total_token_count = 5
+
+
+class FakeGenerationResponse:
+    text = "mocked Vertex AI response"
+    usage_metadata = FakeUsageMetadata()
+
+
+class FakeGenerativeModel:
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+
+    def generate_content(self, *args, **kwargs):
+        return FakeGenerationResponse()
+
+    def count_tokens(self, *args, **kwargs):
+        return FakeCountTokensResponse()
+
+
+@pytest.fixture(autouse=True)
+def mock_vertexai(monkeypatch):
+    """Avoid live Vertex AI calls and ADC requirements in unit tests."""
+
+    monkeypatch.setattr("dagster_vertexai.resource.vertexai.init", lambda **kwargs: None)
+    monkeypatch.setattr("dagster_vertexai.resource.GenerativeModel", FakeGenerativeModel)
+
+
 def test_resource_initialization():
     """Tests that the resource can be initialized without errors."""
     try:


### PR DESCRIPTION
## Summary
- Mock Vertex AI SDK initialization and generative model calls in dagster-vertexai tests
- Avoid requiring Google Application Default Credentials in CI
- Preserve token usage metadata assertions with fake responses

## Testing
- cd libraries/dagster-vertexai && uv run pytest -q
- cd libraries/dagster-vertexai && uv run ruff check dagster_vertexai dagster_vertexai_tests
- cd libraries/dagster-vertexai && uv run ty check