### PR TITLE
Standardize shared ty configuration

### DIFF
--- a/.github/workflows/template-quality-check.yml
+++ b/.github/workflows/template-quality-check.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Type check
         working-directory: ${{ inputs.working_directory }}
-        run: uv run ty check
+        run: uv run ty check .
 
       - name: Test
         working-directory: ${{ inputs.working_directory }}

--- a/libraries/_template/Makefile
+++ b/libraries/_template/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/_template/pyproject.toml
+++ b/libraries/_template/pyproject.toml
@@ -8,12 +8,14 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
 ]
+
+# ty configuration is inherited from the repository root pyproject.toml.
 
 [build-system]
 requires = ["setuptools>=42"]
@@ -24,26 +26,3 @@ packages = ["example_integration"]
 
 [tool.setuptools.dynamic]
 version = {attr = "example_integration.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-adbc/Makefile
+++ b/libraries/dagster-adbc/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-adbc/pyproject.toml
+++ b/libraries/dagster-adbc/pyproject.toml
@@ -33,26 +33,3 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["ANN", "E", "F", "I"]
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-anthropic/Makefile
+++ b/libraries/dagster-anthropic/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-anthropic/pyproject.toml
+++ b/libraries/dagster-anthropic/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -25,26 +25,3 @@ packages = ["dagster_anthropic"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_anthropic.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-apprise/Makefile
+++ b/libraries/dagster-apprise/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-apprise/pyproject.toml
+++ b/libraries/dagster-apprise/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -29,26 +29,3 @@ version = {attr = "dagster_apprise.__version__"}
 
 [project.entry-points."dagster_dg_cli.registry_modules"]
 dagster_apprise = "dagster_apprise.components"
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-async-executor/Makefile
+++ b/libraries/dagster-async-executor/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-async-executor/pyproject.toml
+++ b/libraries/dagster-async-executor/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -31,26 +31,3 @@ version = {attr = "dagster_async_executor.__version__"}
 
 [tool.ruff]
 target-version = "py310"
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-chroma/Makefile
+++ b/libraries/dagster-chroma/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-chroma/pyproject.toml
+++ b/libraries/dagster-chroma/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -26,26 +26,3 @@ packages = ["dagster_chroma"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_chroma.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-contrib-gcp/Makefile
+++ b/libraries/dagster-contrib-gcp/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-contrib-gcp/pyproject.toml
+++ b/libraries/dagster-contrib-gcp/pyproject.toml
@@ -11,8 +11,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -27,26 +27,3 @@ find = {exclude= ['dagster_contrib_gcp_tests*']}
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_contrib_gcp.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-dataform/Makefile
+++ b/libraries/dagster-dataform/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-dataform/pyproject.toml
+++ b/libraries/dagster-dataform/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -27,26 +27,3 @@ packages = ["dagster_dataform"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_dataform.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-ducklake/Makefile
+++ b/libraries/dagster-ducklake/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-ducklake/dagster_ducklake/Makefile
+++ b/libraries/dagster-ducklake/dagster_ducklake/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-ducklake/pyproject.toml
+++ b/libraries/dagster-ducklake/pyproject.toml
@@ -27,26 +27,3 @@ packages = ["dagster_ducklake"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_ducklake.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-evidence/Makefile
+++ b/libraries/dagster-evidence/Makefile
@@ -12,10 +12,10 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .
 
 quality:
 	uv run ruff check
 	uv run ruff format --check
-	uv run ty check
+	uv run ty check .
 	uv run pytest

--- a/libraries/dagster-evidence/pyproject.toml
+++ b/libraries/dagster-evidence/pyproject.toml
@@ -21,8 +21,8 @@ test = [
     "pytest-mock",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "pytest-mock",
@@ -48,26 +48,3 @@ version = {attr = "dagster_evidence.__version__"}
 [project.entry-points]
 "dagster_dg.library" = { dagster_evidence = "dagster_evidence"}
 "dagster_dg.plugin" = { dagster_evidence = "dagster_evidence"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-gemini/Makefile
+++ b/libraries/dagster-gemini/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-gemini/pyproject.toml
+++ b/libraries/dagster-gemini/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -25,26 +25,3 @@ packages = ["dagster_gemini"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_gemini.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-hex/Makefile
+++ b/libraries/dagster-hex/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-hex/pyproject.toml
+++ b/libraries/dagster-hex/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest",
     "pytest-mock",
     "ty==0.0.37",
@@ -28,26 +28,3 @@ packages = ["dagster_hex"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_hex.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-iceberg/Makefile
+++ b/libraries/dagster-iceberg/Makefile
@@ -12,7 +12,7 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .
 
 docs:
 	uv run mkdocs serve

--- a/libraries/dagster-modal/Makefile
+++ b/libraries/dagster-modal/Makefile
@@ -11,4 +11,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-modal/pyproject.toml
+++ b/libraries/dagster-modal/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff>=0.6.8",
     "pytest",
     "ty==0.0.37",
@@ -26,26 +26,3 @@ packages = ["dagster_modal"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_modal.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-notdiamond/Makefile
+++ b/libraries/dagster-notdiamond/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-notdiamond/pyproject.toml
+++ b/libraries/dagster-notdiamond/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "dagster-openai",
     "ruff",
     "pytest",
@@ -27,26 +27,3 @@ packages = ["dagster_notdiamond"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_notdiamond.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-obstore/Makefile
+++ b/libraries/dagster-obstore/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-obstore/pyproject.toml
+++ b/libraries/dagster-obstore/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",

--- a/libraries/dagster-openlineage/Makefile
+++ b/libraries/dagster-openlineage/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-openlineage/pyproject.toml
+++ b/libraries/dagster-openlineage/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
 
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -33,26 +33,3 @@ version = { attr = "dagster_openlineage.version.__version__" }
 [project.entry-points]
 "dagster_dg.library" = { dagster_openlineage = "dagster_openlineage" }
 "dagster_dg.plugin" = { dagster_openlineage = "dagster_openlineage" }
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-polars/Makefile
+++ b/libraries/dagster-polars/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-polars/pyproject.toml
+++ b/libraries/dagster-polars/pyproject.toml
@@ -32,8 +32,8 @@ patito = [
 [project.urls]
 Repository = "https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-polars"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "deepdiff>=6.3.0",
     "hypothesis[zoneinfo]>=6.89.0",
     "moto[server]>=5.0.0",

--- a/libraries/dagster-qdrant/Makefile
+++ b/libraries/dagster-qdrant/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-qdrant/pyproject.toml
+++ b/libraries/dagster-qdrant/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -27,26 +27,3 @@ packages = ["dagster_qdrant"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_qdrant.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-salesforce/Makefile
+++ b/libraries/dagster-salesforce/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-salesforce/pyproject.toml
+++ b/libraries/dagster-salesforce/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -28,26 +28,3 @@ packages = ["dagster_salesforce"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_salesforce.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-sftp/Makefile
+++ b/libraries/dagster-sftp/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-sftp/pyproject.toml
+++ b/libraries/dagster-sftp/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -30,26 +30,3 @@ packages = ["dagster_sftp"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_sftp.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-sharepoint/Makefile
+++ b/libraries/dagster-sharepoint/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-sharepoint/pyproject.toml
+++ b/libraries/dagster-sharepoint/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -27,26 +27,3 @@ packages = ["dagster_sharepoint"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_sharepoint.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-teradata/Makefile
+++ b/libraries/dagster-teradata/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-teradata/pyproject.toml
+++ b/libraries/dagster-teradata/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -40,26 +40,3 @@ version = {attr = "dagster_teradata.__version__"}
 
 [tool.pytest.ini_options]
 addopts = "--ignore=dagster_teradata_tests/functional/"
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-call-non-callable = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-vertexai/Makefile
+++ b/libraries/dagster-vertexai/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-vertexai/pyproject.toml
+++ b/libraries/dagster-vertexai/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -26,26 +26,3 @@ packages = ["dagster_vertexai"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_vertexai.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-weaviate/Makefile
+++ b/libraries/dagster-weaviate/Makefile
@@ -6,4 +6,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/dagster-weaviate/pyproject.toml
+++ b/libraries/dagster-weaviate/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
     "ty==0.0.37",
@@ -25,26 +25,3 @@ packages = ["dagster_weaviate"]
 
 [tool.setuptools.dynamic]
 version = {attr = "dagster_weaviate.__version__"}
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/dagster-xquik/Makefile
+++ b/libraries/dagster-xquik/Makefile
@@ -12,4 +12,4 @@ ruff:
 	uv run ruff format
 
 check:
-	uv run ty check
+	uv run ty check .

--- a/libraries/pipes/implementations/java/pyproject.toml
+++ b/libraries/pipes/implementations/java/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
     "dagster>=1.8.9",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "dagster-webserver>=1.8.9",
     "ty==0.0.37",
     "pytest>=8.3.3",
@@ -25,26 +25,3 @@ dagster-pipes-tests = { path = "../../tests/dagster-pipes-tests", editable = tru
 addopts = "-s "
 color = "yes"
 testpaths = ["tests"]
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/libraries/pipes/implementations/rust/pyproject.toml
+++ b/libraries/pipes/implementations/rust/pyproject.toml
@@ -8,8 +8,8 @@ dependencies = [
     "dagster>=1.8.9",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "dagster-webserver>=1.8.9",
     "ty==0.0.37",
     "pytest>=8.3.3",
@@ -24,26 +24,3 @@ dagster-pipes-tests = { path = "../../tests/dagster-pipes-tests", editable = tru
 addopts = "-s "
 color = "yes"
 testpaths = ["tests"]
-
-[tool.ty.rules]
-unresolved-import = "ignore"
-unresolved-attribute = "ignore"
-invalid-attribute-access = "ignore"
-invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
-invalid-raise = "ignore"
-invalid-type-form = "ignore"
-invalid-method-override = "ignore"
-missing-argument = "ignore"
-unknown-argument = "ignore"
-too-many-positional-arguments = "ignore"
-no-matching-overload = "ignore"
-unsupported-operator = "ignore"
-empty-body = "ignore"
-call-non-callable = "ignore"
-unused-ignore-comment = "ignore"
-unused-type-ignore-comment = "ignore"
-invalid-parameter-default = "ignore"
-deprecated = "ignore"
-redundant-cast = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+# Shared tooling configuration for integrations in this repository.
+# Individual integration pyproject.toml files inherit this ty configuration
+# as long as they do not define their own [tool.ty] table.
+
+[tool.ty.rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+invalid-attribute-access = "ignore"
+invalid-argument-type = "ignore"
+invalid-return-type = "ignore"
+invalid-assignment = "ignore"
+invalid-raise = "ignore"
+invalid-type-form = "ignore"
+invalid-method-override = "ignore"
+missing-argument = "ignore"
+unknown-argument = "ignore"
+too-many-positional-arguments = "ignore"
+no-matching-overload = "ignore"
+unsupported-operator = "ignore"
+empty-body = "ignore"
+call-non-callable = "ignore"
+unused-ignore-comment = "ignore"
+unused-type-ignore-comment = "ignore"
+invalid-parameter-default = "ignore"
+deprecated = "ignore"
+redundant-cast = "ignore"


### PR DESCRIPTION
## Summary
- add a root pyproject.toml with shared ty rule configuration
- standardize dev dependencies on [dependency-groups] dev
- scope Makefile ty checks to the current integration with `ty check .`
- remove duplicated ty rule blocks where packages can inherit the root config

## Validation
- `git diff --check`
- `cd libraries/dagster-modal && make check`