### PR TITLE
fix(dagster-iceberg): add reader_override option to PolarsIcebergIOManager

### DIFF
--- a/libraries/dagster-iceberg/CHANGELOG.md
+++ b/libraries/dagster-iceberg/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `PolarsIcebergIOManager.reader_override` — configurable option (`'native'` | `'pyiceberg'` | `None`) that maps directly to the `reader_override` parameter of `polars.scan_iceberg`. Setting this to `'pyiceberg'` delegates all reads to the PyIceberg library instead of the Polars native Rust reader. This fixes a bug where the native reader leaves a deadlocked background thread open after reading from S3, preventing Kubernetes Dagster runs from finalising and reporting success.
 - `S3TablesCatalogConfig` — typed `IcebergCatalogConfig` subclass for AWS S3 Tables. Derives the Glue REST endpoint URL, SigV4 properties, and warehouse string from a `region` plus `table_bucket_arn` so users don't have to remember the format. User-supplied `properties` keys override the derived defaults.
 - Spark I/O manager.
 - Support for append mode in Iceberg I/O manager. Write mode options can be set via asset definition metadata using the `write_mode` key, or at runtime via output metadata with the same key. Runtime output metadata setting overrides asset definition metadata setting.

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 from dagster import InputContext
 from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
-from pydantic import Field
+from pydantic import Field, field_validator
 from pyiceberg import table as ibt
 from pyiceberg.catalog import Catalog
 
@@ -18,6 +18,8 @@ from dagster_iceberg import io_manager as _io_manager
 from dagster_iceberg._utils import DagsterPartitionToPolarsSqlPredicateMapper, preview
 
 PolarsTypes = Union[pl.LazyFrame, pl.DataFrame]  # noqa: UP007, avoid `autodoc` failure
+
+_VALID_READER_OVERRIDES = frozenset({"native", "pyiceberg"})
 
 
 def _get_polars_storage_options(table: ibt.Table) -> dict[str, str] | None:
@@ -177,7 +179,7 @@ class PolarsIcebergIOManager(_io_manager.IcebergIOManager):
 
     """
 
-    reader_override: Literal["native", "pyiceberg"] | None = Field(
+    reader_override: str | None = Field(
         default=None,
         description=(
             "Override the Polars Iceberg reader implementation used by "
@@ -186,9 +188,19 @@ class PolarsIcebergIOManager(_io_manager.IcebergIOManager):
             "Use this on deployments (e.g. Kubernetes) where the native reader "
             "leaves a deadlocked thread open after reading from S3, which prevents "
             "the Dagster run from finalising. When ``None`` (the default), Polars "
-            "selects the best reader automatically."
+            "selects the best reader automatically. "
+            f"Valid values: {sorted(_VALID_READER_OVERRIDES)}."
         ),
     )
+
+    @field_validator("reader_override")
+    @classmethod
+    def _validate_reader_override(cls, v: str | None) -> str | None:
+        if v is not None and v not in _VALID_READER_OVERRIDES:
+            raise ValueError(
+                f"reader_override must be one of {sorted(_VALID_READER_OVERRIDES)} or None, got {v!r}"
+            )
+        return v
 
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:

--- a/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/io_manager/polars.py
@@ -1,14 +1,17 @@
 from collections.abc import Sequence
-from typing import Union
+from typing import Literal, Union
 
 try:
     import polars as pl
 except ImportError as e:
     raise ImportError("Please install dagster-iceberg with the 'polars' extra.") from e
 import pyarrow as pa
+from dagster import InputContext
 from dagster._annotations import public
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
+from pydantic import Field
 from pyiceberg import table as ibt
+from pyiceberg.catalog import Catalog
 
 from dagster_iceberg import handler as _handler
 from dagster_iceberg import io_manager as _io_manager
@@ -48,6 +51,7 @@ class _PolarsIcebergTypeHandler(_handler.IcebergBaseTypeHandler[PolarsTypes]):
         table: ibt.Table,
         table_slice: TableSlice,
         target_type: type[PolarsTypes],
+        reader_override: Literal["native", "pyiceberg"] | None = None,
     ) -> PolarsTypes:
         selected_fields: str = (
             ",".join(table_slice.columns) if table_slice.columns is not None else "*"
@@ -64,12 +68,30 @@ class _PolarsIcebergTypeHandler(_handler.IcebergBaseTypeHandler[PolarsTypes]):
         pdf = pl.scan_iceberg(
             source=table,
             storage_options=_get_polars_storage_options(table),
+            reader_override=reader_override,
         )
 
         stmt = f"SELECT {selected_fields} FROM self"
         if row_filter is not None:
             stmt += f"\nWHERE {row_filter}"
         return pdf.sql(stmt) if target_type == pl.LazyFrame else pdf.sql(stmt).collect()
+
+    def load_input(
+        self,
+        context: InputContext,
+        table_slice: TableSlice,
+        connection: Catalog,
+    ) -> PolarsTypes:
+        """Loads the input as a Polars frame, respecting the configured ``reader_override``."""
+        reader_override: Literal["native", "pyiceberg"] | None = None
+        if context.resource_config:
+            reader_override = context.resource_config.get("reader_override")
+        return self.to_data_frame(
+            table=connection.load_table(f"{table_slice.schema}.{table_slice.table}"),
+            table_slice=table_slice,
+            target_type=context.dagster_type.typing_type,
+            reader_override=reader_override,
+        )
 
     def to_arrow(self, obj: PolarsTypes) -> pa.Table:
         if isinstance(obj, pl.LazyFrame):
@@ -154,6 +176,19 @@ class PolarsIcebergIOManager(_io_manager.IcebergIOManager):
                 ...
 
     """
+
+    reader_override: Literal["native", "pyiceberg"] | None = Field(
+        default=None,
+        description=(
+            "Override the Polars Iceberg reader implementation used by "
+            "``polars.scan_iceberg``. When set to ``'pyiceberg'``, Polars delegates "
+            "all I/O to the PyIceberg library instead of its native Rust reader. "
+            "Use this on deployments (e.g. Kubernetes) where the native reader "
+            "leaves a deadlocked thread open after reading from S3, which prevents "
+            "the Dagster run from finalising. When ``None`` (the default), Polars "
+            "selects the best reader automatically."
+        ),
+    )
 
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:

--- a/libraries/dagster-iceberg/tests/unit/test_polars_reader_override.py
+++ b/libraries/dagster-iceberg/tests/unit/test_polars_reader_override.py
@@ -62,14 +62,14 @@ def test_reader_override_rejects_invalid_value() -> None:
 
     from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="reader_override must be one of"):
         PolarsIcebergIOManager(
             name="test",
             config=IcebergCatalogConfig(
                 properties={"uri": "sqlite:///test.db", "warehouse": "file:///tmp/wh"}
             ),
             namespace="default",
-            reader_override="rust",  # type: ignore[arg-type]
+            reader_override="rust",
         )
 
 

--- a/libraries/dagster-iceberg/tests/unit/test_polars_reader_override.py
+++ b/libraries/dagster-iceberg/tests/unit/test_polars_reader_override.py
@@ -1,0 +1,235 @@
+"""Unit tests for PolarsIcebergIOManager.reader_override configuration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dagster_iceberg.config import IcebergCatalogConfig
+
+# ---------------------------------------------------------------------------
+# PolarsIcebergIOManager field validation
+# ---------------------------------------------------------------------------
+
+
+def test_reader_override_defaults_to_none() -> None:
+    """reader_override should be None when not set."""
+    pytest.importorskip("polars")
+    from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
+
+    mgr = PolarsIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": "sqlite:///test.db", "warehouse": "file:///tmp/wh"}
+        ),
+        namespace="default",
+    )
+    assert mgr.reader_override is None
+
+
+def test_reader_override_accepts_pyiceberg() -> None:
+    pytest.importorskip("polars")
+    from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
+
+    mgr = PolarsIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": "sqlite:///test.db", "warehouse": "file:///tmp/wh"}
+        ),
+        namespace="default",
+        reader_override="pyiceberg",
+    )
+    assert mgr.reader_override == "pyiceberg"
+
+
+def test_reader_override_accepts_native() -> None:
+    pytest.importorskip("polars")
+    from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
+
+    mgr = PolarsIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": "sqlite:///test.db", "warehouse": "file:///tmp/wh"}
+        ),
+        namespace="default",
+        reader_override="native",
+    )
+    assert mgr.reader_override == "native"
+
+
+def test_reader_override_rejects_invalid_value() -> None:
+    pytest.importorskip("polars")
+    from pydantic import ValidationError
+
+    from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
+
+    with pytest.raises(ValidationError):
+        PolarsIcebergIOManager(
+            name="test",
+            config=IcebergCatalogConfig(
+                properties={"uri": "sqlite:///test.db", "warehouse": "file:///tmp/wh"}
+            ),
+            namespace="default",
+            reader_override="rust",  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# _PolarsIcebergTypeHandler.to_data_frame passes reader_override through
+# ---------------------------------------------------------------------------
+
+
+def test_to_data_frame_passes_reader_override_to_scan_iceberg() -> None:
+    """reader_override kwarg must be forwarded to pl.scan_iceberg."""
+    pl = pytest.importorskip("polars")
+    from dagster._core.storage.db_io_manager import TableSlice
+
+    from dagster_iceberg.io_manager.polars import _PolarsIcebergTypeHandler
+
+    handler = _PolarsIcebergTypeHandler()
+
+    mock_table = MagicMock()
+    mock_table.schema.return_value = MagicMock()
+    mock_table.spec.return_value = MagicMock(fields=[])
+
+    mock_lazy = MagicMock(spec=pl.LazyFrame)
+    mock_lazy.sql.return_value = mock_lazy  # sql() returns LazyFrame
+
+    table_slice = TableSlice(
+        schema="ns",
+        table="tbl",
+        columns=None,
+        partition_dimensions=None,
+        database="cat",
+    )
+
+    with patch("polars.scan_iceberg", return_value=mock_lazy) as mock_scan:
+        handler.to_data_frame(
+            table=mock_table,
+            table_slice=table_slice,
+            target_type=pl.LazyFrame,
+            reader_override="pyiceberg",
+        )
+
+    mock_scan.assert_called_once()
+    _, kwargs = mock_scan.call_args
+    assert kwargs.get("reader_override") == "pyiceberg"
+
+
+def test_to_data_frame_passes_none_reader_override_by_default() -> None:
+    """When reader_override is not supplied it should still be passed as None."""
+    pl = pytest.importorskip("polars")
+    from dagster._core.storage.db_io_manager import TableSlice
+
+    from dagster_iceberg.io_manager.polars import _PolarsIcebergTypeHandler
+
+    handler = _PolarsIcebergTypeHandler()
+
+    mock_table = MagicMock()
+    mock_table.schema.return_value = MagicMock()
+    mock_table.spec.return_value = MagicMock(fields=[])
+
+    mock_lazy = MagicMock(spec=pl.LazyFrame)
+    mock_lazy.sql.return_value = mock_lazy
+
+    table_slice = TableSlice(
+        schema="ns",
+        table="tbl",
+        columns=None,
+        partition_dimensions=None,
+        database="cat",
+    )
+
+    with patch("polars.scan_iceberg", return_value=mock_lazy) as mock_scan:
+        handler.to_data_frame(
+            table=mock_table,
+            table_slice=table_slice,
+            target_type=pl.LazyFrame,
+        )
+
+    _, kwargs = mock_scan.call_args
+    assert kwargs.get("reader_override") is None
+
+
+# ---------------------------------------------------------------------------
+# load_input reads reader_override from resource_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_input_reads_reader_override_from_resource_config() -> None:
+    """load_input must pull reader_override from context.resource_config."""
+    pl = pytest.importorskip("polars")
+    from dagster._core.storage.db_io_manager import TableSlice
+
+    from dagster_iceberg.io_manager.polars import _PolarsIcebergTypeHandler
+
+    handler = _PolarsIcebergTypeHandler()
+
+    mock_table = MagicMock()
+    mock_table.schema.return_value = MagicMock()
+    mock_table.spec.return_value = MagicMock(fields=[])
+
+    mock_catalog = MagicMock()
+    mock_catalog.load_table.return_value = mock_table
+
+    mock_lazy = MagicMock(spec=pl.LazyFrame)
+    mock_lazy.sql.return_value = mock_lazy
+
+    context = MagicMock()
+    context.resource_config = {"reader_override": "pyiceberg"}
+    context.dagster_type.typing_type = pl.LazyFrame
+
+    table_slice = TableSlice(
+        schema="ns",
+        table="tbl",
+        columns=None,
+        partition_dimensions=None,
+        database="cat",
+    )
+
+    with patch("polars.scan_iceberg", return_value=mock_lazy) as mock_scan:
+        handler.load_input(
+            context=context, table_slice=table_slice, connection=mock_catalog
+        )
+
+    _, kwargs = mock_scan.call_args
+    assert kwargs.get("reader_override") == "pyiceberg"
+
+
+def test_load_input_uses_none_when_resource_config_absent() -> None:
+    """When resource_config is None, reader_override must default to None."""
+    pl = pytest.importorskip("polars")
+    from dagster._core.storage.db_io_manager import TableSlice
+
+    from dagster_iceberg.io_manager.polars import _PolarsIcebergTypeHandler
+
+    handler = _PolarsIcebergTypeHandler()
+
+    mock_table = MagicMock()
+    mock_table.schema.return_value = MagicMock()
+    mock_table.spec.return_value = MagicMock(fields=[])
+
+    mock_catalog = MagicMock()
+    mock_catalog.load_table.return_value = mock_table
+
+    mock_lazy = MagicMock(spec=pl.LazyFrame)
+    mock_lazy.sql.return_value = mock_lazy
+
+    context = MagicMock()
+    context.resource_config = None
+    context.dagster_type.typing_type = pl.LazyFrame
+
+    table_slice = TableSlice(
+        schema="ns",
+        table="tbl",
+        columns=None,
+        partition_dimensions=None,
+        database="cat",
+    )
+
+    with patch("polars.scan_iceberg", return_value=mock_lazy) as mock_scan:
+        handler.load_input(
+            context=context, table_slice=table_slice, connection=mock_catalog
+        )
+
+    _, kwargs = mock_scan.call_args
+    assert kwargs.get("reader_override") is None


### PR DESCRIPTION
## Summary

Exposes the `reader_override` parameter of `polars.scan_iceberg` as a configurable field on `PolarsIcebergIOManager`.

### Problem

When reading from S3, Polars' native Rust Iceberg reader leaves a deadlocked background thread open after the read completes. This prevents the Dagster run process from exiting cleanly in Kubernetes, so the pod never terminates and the run never reports success.

### Solution

`polars.scan_iceberg` accepts a `reader_override: Literal['native', 'pyiceberg'] | None` parameter (added in recent Polars releases) that forces it to delegate all I/O to the PyIceberg library instead of its native reader. This PR surfaces that option as a first-class field on `PolarsIcebergIOManager` so operators can opt in to the PyIceberg reader at the resource level.

```python
resources = {
    "io_manager": PolarsIcebergIOManager(
        name="my_catalog",
        config=IcebergCatalogConfig(properties={...}),
        namespace="analytics",
        reader_override="pyiceberg",  # bypasses the native reader
    )
}
```

The default is `None`, which preserves the existing behaviour (Polars picks the reader automatically).

## Changes

- `PolarsIcebergIOManager` — new `reader_override: Literal['native', 'pyiceberg'] | None = None` Pydantic field with descriptive docstring.
- `_PolarsIcebergTypeHandler.to_data_frame` — accepts optional `reader_override` kwarg and forwards it to `pl.scan_iceberg`.
- `_PolarsIcebergTypeHandler.load_input` — new override that reads `reader_override` from `context.resource_config` and passes it through to `to_data_frame`.
- `CHANGELOG.md` — entry under `[Unreleased]`.
- `tests/unit/test_polars_reader_override.py` — 7 unit tests covering field validation, `scan_iceberg` kwarg forwarding, and `resource_config` propagation.