### PR TITLE
handle DST days in transforming tz-aware asset partitions

### DIFF
--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
@@ -16,7 +16,7 @@ def diff_to_transformation(
     end: dt.datetime
 ) -> transforms.Transform:
     """Based on the interval between two dates, return a transformation"""
-    
+
     start_ = pendulum.instance(start)
     end_ = pendulum.instance(end)
 

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
@@ -13,20 +13,23 @@ def date_diff(start: dt.datetime, end: dt.datetime) -> pendulum.Interval:
 
 def diff_to_transformation(
     start: dt.datetime,
-    end: dt.datetime,
+    end: dt.datetime
 ) -> transforms.Transform:
-    """Based on the interval between two dates, return a transformation"""
-    delta = date_diff(start, end)
-    match delta.in_hours():
-        case 1:
-            return transforms.HourTransform()
-        case 24:
-            return transforms.DayTransform()
-        case 168:
-            return transforms.DayTransform()  # No week transform available
-        case _:
-            if delta.in_months() == 1:
-                return transforms.MonthTransform()
-            raise NotImplementedError(
-                f"Unsupported time window: {delta.in_words()}",
-            )
+    start_ = pendulum.instance(start)
+    end_ = pendulum.instance(end)
+
+    # calendar-aware checks (respect local time / DST)
+    if start_.add(hours=1) == end_:
+        return transforms.HourTransform()
+    if start_.add(days=1) == end_:
+        return transforms.DayTransform()
+    if start_.add(weeks=1) == end_:
+        return transforms.DayTransform()  # No week transform available
+    if start_.add(months=1) == end_:
+        return transforms.MonthTransform()
+
+    # fallback: still check month-ish differences via in_months()
+    if (end_ - start_).in_months() == 1:
+        return transforms.MonthTransform()
+
+    raise NotImplementedError(f"Unsupported time window: {(end_ - start_).in_words()}")

--- a/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
+++ b/libraries/dagster-iceberg/src/dagster_iceberg/_utils/transforms.py
@@ -15,6 +15,8 @@ def diff_to_transformation(
     start: dt.datetime,
     end: dt.datetime
 ) -> transforms.Transform:
+    """Based on the interval between two dates, return a transformation"""
+    
     start_ = pendulum.instance(start)
     end_ = pendulum.instance(end)
 


### PR DESCRIPTION
Handles tz-aware daily partitioned assets by performing a calendar-aware relative timedelta, permitting "1 day" to match 23-25 hours. Closes #336 