### PR TITLE
feat(dagster-openlineage): decouple job namespace from dataset namespace

### DIFF
--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- **Independent job namespace.** `OpenLineageAdapter` and `OpenLineageEventLogStorage` accept a `job_namespace` argument — also read from the `OPENLINEAGE_JOB_NAMESPACE` environment variable and configurable in `instance.yaml` — that names the run/job independently of the dataset namespace. Datasets stay namespaced by where the data lives (so a backend can match them to catalogued tables); the job can be namespaced by the orchestrator. Falls back to the dataset namespace when unset, so existing callers are unaffected. `namespace_template` does not apply to it.
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-openlineage/README.md
+++ b/libraries/dagster-openlineage/README.md
@@ -57,6 +57,7 @@ event_log_storage:
           env: DAGSTER_PG_URL
     namespace: my-company
     # Optional:
+    # job_namespace: dagster
     # namespace_template: "{namespace}/{tag:tenant}"
     # timeout: 2.0
     # strict_assertion_mapping: false
@@ -83,6 +84,7 @@ Environment variables go on the process that runs the Dagster daemon:
 - `OPENLINEAGE_URL` (required)
 - `OPENLINEAGE_API_KEY` (optional)
 - `OPENLINEAGE_NAMESPACE` (optional, default `dagster`)
+- `OPENLINEAGE_JOB_NAMESPACE` (optional; falls back to the dataset namespace)
 
 ## Namespace templates
 
@@ -92,6 +94,8 @@ Provide `namespace_template` (wrapper) or let the adapter/sensor derive the defa
 - `{tag:KEY}` — the run tag named `KEY`, empty if unset
 
 Adjacent slashes collapse; trailing slashes strip. Unknown tokens raise `NamespaceTemplateError` at construction. `{code_location}` and `{repository}` are deferred to v0.3 — they do not reliably reach `store_event` time.
+
+Templates apply to **dataset** namespaces only; `namespace_template` does not apply to `job_namespace`.
 
 Example:
 

--- a/libraries/dagster-openlineage/dagster_openlineage/adapter.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/adapter.py
@@ -63,21 +63,39 @@ log = logging.getLogger(__name__)
 class OpenLineageAdapter:
     """Adapter translating Dagster events to OpenLineage emissions.
 
-    Construction accepts optional namespace/template and strictness knobs; the
-    v0.1 pipeline/step surface keeps its default arguments unchanged so
+    The v0.1 pipeline/step surface keeps its default arguments unchanged so
     existing callers work without modification.
+
+    Args:
+        namespace: Namespace for emitted datasets, and for jobs when
+            ``job_namespace`` is unset. Defaults to the ``OPENLINEAGE_NAMESPACE``
+            environment variable, then to ``"default"``.
+        job_namespace: Namespace for the run/job, independent of the dataset
+            namespace. Defaults to the ``OPENLINEAGE_JOB_NAMESPACE`` environment
+            variable, then falls back to the dataset namespace.
+            ``namespace_template`` does not apply to it.
+        namespace_template: Optional template resolved per run from run tags,
+            e.g. ``"{namespace}/{tag:tenant}"``.
+        timeout: Emit timeout in seconds for the default emitter; ignored when
+            ``emitter`` is supplied.
+        strict_assertion_mapping: When True, a WARN-severity asset check maps to
+            a failed OpenLineage assertion instead of a passing one.
+        emitter: Pre-built emitter to use; one is created from ``timeout`` when
+            omitted.
     """
 
     def __init__(
         self,
         *,
         namespace: Optional[str] = None,
+        job_namespace: Optional[str] = None,
         namespace_template: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         strict_assertion_mapping: bool = False,
         emitter: Optional[OpenLineageEmitter] = None,
     ) -> None:
         self._namespace = namespace or _DEFAULT_NAMESPACE_NAME
+        self._job_namespace = job_namespace or os.getenv("OPENLINEAGE_JOB_NAMESPACE")
         self._parsed_template: Optional[ParsedTemplate] = (
             parse_namespace_template(namespace_template) if namespace_template else None
         )
@@ -147,7 +165,13 @@ class OpenLineageAdapter:
         timestamp: float,
         repository_name: Optional[str],
     ):
-        namespace = repository_name if repository_name else self._namespace
+        # An explicit repository_name (v0.1) still takes precedence; otherwise
+        # use the job namespace, which itself falls back to the default namespace.
+        namespace = (
+            repository_name
+            if repository_name
+            else self._job_namespace_for(self._namespace)
+        )
         self._emit(
             RunEvent(
                 eventType=event_type,
@@ -229,7 +253,13 @@ class OpenLineageAdapter:
         step_key: str,
         repository_name: Optional[str],
     ):
-        namespace = repository_name if repository_name else self._namespace
+        # An explicit repository_name (v0.1) still takes precedence; otherwise
+        # use the job namespace, which itself falls back to the default namespace.
+        namespace = (
+            repository_name
+            if repository_name
+            else self._job_namespace_for(self._namespace)
+        )
         self._emit(
             RunEvent(
                 eventType=event_type,
@@ -261,13 +291,14 @@ class OpenLineageAdapter:
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
+        job_namespace = self._job_namespace_for(namespace)
         self._emit(
             RunEvent(
                 eventType=RunState.START,
                 eventTime=to_utc_iso_8601(timestamp),
-                run=self._build_run(namespace=namespace, run_id=run_id),
+                run=self._build_run(namespace=job_namespace, run_id=run_id),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=job_namespace, job_name=asset_key.to_user_string()
                 ),
                 producer=_PRODUCER,
                 outputs=[
@@ -290,6 +321,7 @@ class OpenLineageAdapter:
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
+        job_namespace = self._job_namespace_for(namespace)
         output_facets = self._build_asset_output_facets(metadata, namespace)
         run_facets = self._build_asset_run_facets(partition_key)
 
@@ -303,10 +335,10 @@ class OpenLineageAdapter:
                 eventType=RunState.COMPLETE,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=self._build_run(
-                    namespace=namespace, run_id=run_id, run_facets=run_facets
+                    namespace=job_namespace, run_id=run_id, run_facets=run_facets
                 ),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=job_namespace, job_name=asset_key.to_user_string()
                 ),
                 producer=_PRODUCER,
                 inputs=inputs,
@@ -332,6 +364,7 @@ class OpenLineageAdapter:
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
+        job_namespace = self._job_namespace_for(namespace)
         run_facets = self._build_asset_run_facets(partition_key)
         if error_message:
             run_facets["errorMessage"] = build_error_message_facet(
@@ -342,10 +375,10 @@ class OpenLineageAdapter:
                 eventType=RunState.FAIL,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=self._build_run(
-                    namespace=namespace, run_id=run_id, run_facets=run_facets
+                    namespace=job_namespace, run_id=run_id, run_facets=run_facets
                 ),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=job_namespace, job_name=asset_key.to_user_string()
                 ),
                 producer=_PRODUCER,
                 outputs=[
@@ -413,13 +446,14 @@ class OpenLineageAdapter:
             return
         del check_name  # surfaced via Assertion entries on completion
         namespace = self._resolve_namespace(run_tags)
+        job_namespace = self._job_namespace_for(namespace)
         job_name = f"{asset_key.to_user_string()}__checks"
         self._emit(
             RunEvent(
                 eventType=RunState.START,
                 eventTime=to_utc_iso_8601(timestamp),
-                run=self._build_run(namespace=namespace, run_id=run_id),
-                job=self._build_job(namespace=namespace, job_name=job_name),
+                run=self._build_run(namespace=job_namespace, run_id=run_id),
+                job=self._build_job(namespace=job_namespace, job_name=job_name),
                 producer=_PRODUCER,
                 inputs=[
                     InputDataset(namespace=namespace, name="/".join(asset_key.path))
@@ -437,6 +471,7 @@ class OpenLineageAdapter:
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
+        job_namespace = self._job_namespace_for(namespace)
         job_name = f"{asset_key.to_user_string()}__checks"
         quality_facet = build_data_quality_assertions_facet(
             evaluations, strict_assertion_mapping=self._strict_assertion_mapping
@@ -449,7 +484,7 @@ class OpenLineageAdapter:
             inputFacets={"dataQualityAssertions": quality_facet},
         )
         run = self._build_run(
-            namespace=namespace,
+            namespace=job_namespace,
             run_id=run_id,
             run_facets={**custom_run_facet},
         )
@@ -458,7 +493,7 @@ class OpenLineageAdapter:
                 eventType=RunState.COMPLETE,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=run,
-                job=self._build_job(namespace=namespace, job_name=job_name),
+                job=self._build_job(namespace=job_namespace, job_name=job_name),
                 producer=_PRODUCER,
                 inputs=[input_ds],
             )
@@ -475,6 +510,11 @@ class OpenLineageAdapter:
             self._parsed_template, self._namespace, run_tags or {}
         )
         return resolved or self._namespace
+
+    def _job_namespace_for(self, dataset_namespace: str) -> str:
+        # Fall back to the dataset namespace when no job namespace is configured,
+        # so callers that never set one keep the original single-namespace behavior.
+        return self._job_namespace or dataset_namespace
 
     def _build_asset_output_facets(
         self, metadata: Optional[Mapping[str, Any]], namespace: str

--- a/libraries/dagster-openlineage/dagster_openlineage/storage.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/storage.py
@@ -90,6 +90,7 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
         wrapped: EventLogStorage,
         *,
         namespace: Optional[str] = None,
+        job_namespace: Optional[str] = None,
         namespace_template: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         strict_assertion_mapping: bool = False,
@@ -100,6 +101,7 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
         self._inst_data = inst_data
         self._adapter = adapter or OpenLineageAdapter(
             namespace=namespace,
+            job_namespace=job_namespace,
             namespace_template=namespace_template,
             timeout=timeout,
             strict_assertion_mapping=strict_assertion_mapping,
@@ -128,6 +130,7 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
                 "config": Field(dict, is_required=False, default_value={}),
             },
             "namespace": Field(str, is_required=False),
+            "job_namespace": Field(str, is_required=False),
             # Supports {namespace} token only in Mechanism A. The {tag:KEY}
             # token is parsed and accepted but always resolves to an empty
             # string here because EventLogStorage has no access to RunStorage
@@ -158,6 +161,7 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
         return cls(
             wrapped=inner,
             namespace=config_value.get("namespace"),
+            job_namespace=config_value.get("job_namespace"),
             namespace_template=config_value.get("namespace_template"),
             timeout=config_value.get("timeout", DEFAULT_TIMEOUT_SECONDS),
             strict_assertion_mapping=config_value.get(

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_asset.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_asset.py
@@ -254,3 +254,41 @@ def test_check_job_name_does_not_collide_with_asset_named_checks():
     # Output job name is {asset}__checks. Collision is structural (suffix) but
     # the job name still differs from the bare asset.
     assert event.job.name == "__checks__checks"
+
+
+def test_job_namespace_decouples_job_from_dataset_namespace():
+    adapter, client = _make_adapter(
+        namespace="postgres://db:5432", job_namespace="dagster://local"
+    )
+    adapter.asset_materialization(
+        AssetKey(["db.orders"]),
+        run_id=_rid(),
+        timestamp=time.time(),
+        upstream_asset_keys=[AssetKey(["db.raw"])],
+    )
+    event: RunEvent = client.emit.call_args.args[0]
+    assert event.job.namespace == "dagster://local"
+    assert event.outputs[0].namespace == "postgres://db:5432"
+    assert event.inputs[0].namespace == "postgres://db:5432"
+
+
+def test_job_namespace_reads_openlineage_job_namespace_env(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_JOB_NAMESPACE", "dagster://local")
+    adapter, client = _make_adapter(namespace="postgres://db:5432")
+    adapter.asset_materialization(
+        AssetKey(["orders"]), run_id=_rid(), timestamp=time.time()
+    )
+    event: RunEvent = client.emit.call_args.args[0]
+    assert event.job.namespace == "dagster://local"
+    assert event.outputs[0].namespace == "postgres://db:5432"
+
+
+def test_job_namespace_falls_back_to_dataset_namespace_when_unset(monkeypatch):
+    monkeypatch.delenv("OPENLINEAGE_JOB_NAMESPACE", raising=False)
+    adapter, client = _make_adapter(namespace="prod")
+    adapter.asset_materialization(
+        AssetKey(["orders"]), run_id=_rid(), timestamp=time.time()
+    )
+    event: RunEvent = client.emit.call_args.args[0]
+    assert event.job.namespace == "prod"
+    assert event.outputs[0].namespace == "prod"

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_pipeline.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_pipeline.py
@@ -119,3 +119,29 @@ def test_cancel_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             outputs=[],
         )
     )
+
+
+@patch("dagster_openlineage.adapter.to_utc_iso_8601")
+@patch("dagster_openlineage.adapter.OpenLineageClient.emit")
+def test_pipeline_run_uses_job_namespace(mock_client_emit, mock_to_utc_iso_8601):
+    mock_to_utc_iso_8601.return_value = "2022-01-01T00:00:00.000000Z"
+    adapter = OpenLineageAdapter(
+        namespace="postgres://db:5432", job_namespace="dagster://local"
+    )
+    adapter.start_pipeline("a_pipeline", str(generate_new_uuid()), time.time())
+    event = mock_client_emit.call_args.args[0]
+    assert event.job.namespace == "dagster://local"
+
+
+@patch("dagster_openlineage.adapter.to_utc_iso_8601")
+@patch("dagster_openlineage.adapter.OpenLineageClient.emit")
+def test_pipeline_run_repository_name_overrides_job_namespace(
+    mock_client_emit, mock_to_utc_iso_8601
+):
+    mock_to_utc_iso_8601.return_value = "2022-01-01T00:00:00.000000Z"
+    adapter = OpenLineageAdapter(job_namespace="dagster://local")
+    adapter.start_pipeline(
+        "a_pipeline", str(generate_new_uuid()), time.time(), repository_name="my_repo"
+    )
+    event = mock_client_emit.call_args.args[0]
+    assert event.job.namespace == "my_repo"

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_storage_wrapper.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_storage_wrapper.py
@@ -126,6 +126,23 @@ def test_from_config_value_rehydrates_inner_storage():
     assert wrapper._adapter._namespace == "multi_tenant"
 
 
+def test_from_config_value_passes_job_namespace_to_adapter():
+    wrapper = OpenLineageEventLogStorage.from_config_value(
+        inst_data=None,
+        config_value={
+            "wrapped": {
+                "module": "dagster._core.storage.event_log.in_memory",
+                "class": "InMemoryEventLogStorage",
+                "config": {},
+            },
+            "namespace": "postgres://db:5432",
+            "job_namespace": "dagster://local",
+        },
+    )
+    assert wrapper._adapter._job_namespace == "dagster://local"
+    assert wrapper._adapter._namespace == "postgres://db:5432"
+
+
 def test_inst_data_preserved_through_round_trip():
     from dagster._serdes import ConfigurableClassData
 


### PR DESCRIPTION
Add a `job_namespace` argument (and `OPENLINEAGE_JOB_NAMESPACE` env var / `instance.yaml` key) so the run/job can be namespaced independently of the datasets: datasets are named where the data lives, the job where the orchestrator runs. Unset, it falls back to the dataset namespace, so existing callers are unaffected.

## Summary & Motivation

The adapter previously used a single `namespace` for both the datasets and the job/run.

Adding this change allows the dataset namespace to be named e.g. `postgres://host:5432` and then allow the job namespace to be named `dagster`. One shared value can't satisfy both — namespacing datasets for catalog matching drags the Dagster job into that data-system namespace, and vice versa.

This adds an independent `job_namespace`, settable three consistent ways — constructor argument, `OPENLINEAGE_JOB_NAMESPACE` environment variable, or `instance.yaml` config key (parity with `namespace` / `namespace_template` / `strict_assertion_mapping`). It applies to every job/run-bearing event (pipeline, step, asset materialization / planned / failed, and asset checks).

Backward compatible: keyword-only, optional, and falls back to the dataset namespace when unset, so existing callers and `instance.yaml` files behave exactly as before. `namespace_template` does not apply to `job_namespace`.

## How I Tested These Changes

- Unit tests: `job_namespace` via constructor arg, via `OPENLINEAGE_JOB_NAMESPACE`, and the fallback-when-unset; the dataset-vs-job namespace split on a materialization; `instance.yaml` config passthrough on the storage wrapper; and the pipeline surface (job namespace applied, `repository_name` still taking precedence).
- `uv run pytest` green; `ruff check`, `ruff format --check`, and `ty check .` clean.
- Tested locally end to end: ingested the emitted OpenLineage events into OpenMetadata and used it to visualise the resulting lineage.

## Changelog

Added a `### Features` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Related changes

Part of a set of small improvements to Dagster → OpenLineage. The lineage-fidelity changes are each independent and mergeable on their own; the ownership pair is stacked (#354 builds on #353).

**Lineage fidelity:**
- #344 — decouple job namespace from dataset namespace
- #345 — emit asset run-start without a placeholder output
- #346 — derive asset inputs from column lineage
- #347 — add `exclude_asset_keys` to the storage wrapper

**Ownership:**
- #353 — emit jobType and per-asset ownership facets
- #354 — read native asset owners in the sensor (builds on #353; until #353 merges its diff includes #353's commit)
