### PR TITLE
fix(dagster-openlineage): emit asset run-start without a placeholder output

### DIFF
--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Asset run-start no longer emits a placeholder output.** `ASSET_MATERIALIZATION_PLANNED` now emits a pure run-start with no inputs or outputs; the `COMPLETE` event still carries the inputs, outputs, and facets. This avoids a spurious output-only edge (an output with no input side) in backends that build lineage from every event.
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-openlineage/dagster_openlineage/adapter.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/adapter.py
@@ -261,6 +261,10 @@ class OpenLineageAdapter:
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
+        # START (planned) has no inputs and no schema/column facets yet. Emitting a
+        # bare output here makes backends that build edges from every event create a
+        # spurious output edge with no input side, so emit START as a pure run-start
+        # signal; the COMPLETE event carries the inputs, outputs, and facets.
         self._emit(
             RunEvent(
                 eventType=RunState.START,
@@ -270,11 +274,6 @@ class OpenLineageAdapter:
                     namespace=namespace, job_name=asset_key.to_user_string()
                 ),
                 producer=_PRODUCER,
-                outputs=[
-                    OutputDataset(
-                        namespace=namespace, name="/".join(asset_key.path), facets={}
-                    )
-                ],
             )
         )
 

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_asset.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_asset.py
@@ -35,7 +35,7 @@ def _make_adapter(**kwargs) -> tuple[OpenLineageAdapter, MagicMock]:
     return adapter, client
 
 
-def test_asset_materialization_planned_emits_run_start():
+def test_asset_materialization_planned_emits_run_start_without_datasets():
     adapter, client = _make_adapter()
     adapter.asset_materialization_planned(
         AssetKey(["orders"]), run_id=_rid(), timestamp=time.time()
@@ -45,8 +45,9 @@ def test_asset_materialization_planned_emits_run_start():
     assert isinstance(event, RunEvent)
     assert event.eventType == RunState.START
     assert event.job.name == "orders"
-    assert len(event.outputs) == 1
-    assert event.outputs[0].name == "orders"
+    # START is a pure run-start signal; inputs and outputs arrive on COMPLETE.
+    assert not event.inputs
+    assert not event.outputs
 
 
 def test_asset_materialization_emits_schema_facet():

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_e2e_asset_emission.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_e2e_asset_emission.py
@@ -180,9 +180,10 @@ def test_planned_then_complete_emits_start_complete_pair():
     run_events = [e for e in transport.events if isinstance(e, RunEvent)]
     assert [e.eventType for e in run_events] == [RunState.START, RunState.COMPLETE]
     assert all(e.job.name == "orders" for e in run_events)
-    assert all(
-        e.outputs is not None and e.outputs[0].name == "orders" for e in run_events
-    )
+    start, complete = run_events
+    # START carries no datasets; COMPLETE carries the output.
+    assert not start.outputs
+    assert complete.outputs is not None and complete.outputs[0].name == "orders"
 
 
 def test_materialization_schema_facet_on_output():


### PR DESCRIPTION
`ASSET_MATERIALIZATION_PLANNED` emitted a placeholder output dataset with no inputs and no facets. This change emits it as a pure run-start; the `COMPLETE` event still carries the full inputs, outputs, and facets.

## Summary & Motivation

A planned/START event has no materialization metadata yet — no inputs, no schema, no column lineage. For lineage backends that build edges from every event this can produce an output-only edge with no input side. Emitting START as a pure run-start signal keeps the run-start semantics while deferring all dataset/facet information to `COMPLETE`, where it is actually known.

## How I Tested These Changes

- Updated the adapter and end-to-end tests: START now asserts no inputs/outputs; `COMPLETE` still carries the output.
- `uv run pytest` green; `ruff check`, `ruff format --check`, and `ty check .` clean.
- Tested locally end to end: ingested the emitted OpenLineage events into OpenMetadata and used it to visualise the resulting lineage.

## Changelog

Added a `### Changed` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Related changes

Part of a set of small improvements to Dagster → OpenLineage. The lineage-fidelity changes are each independent and mergeable on their own; the ownership pair is stacked (#354 builds on #353).

**Lineage fidelity:**
- #344 — decouple job namespace from dataset namespace
- #345 — emit asset run-start without a placeholder output
- #346 — derive asset inputs from column lineage
- #347 — add `exclude_asset_keys` to the storage wrapper

**Ownership:**
- #353 — emit jobType and per-asset ownership facets
- #354 — read native asset owners in the sensor (builds on #353; until #353 merges its diff includes #353's commit)
