### PR TITLE
feat(dagster-openlineage): derive asset inputs from column lineage

### DIFF
--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- **Table-level inputs from column lineage.** Asset materialization events now derive input datasets from `dagster/column_lineage` metadata, so backends that build lineage from a `RunEvent`'s inputs/outputs form the upstream edge instead of seeing only the output side.
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-openlineage/dagster_openlineage/adapter.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/adapter.py
@@ -293,10 +293,21 @@ class OpenLineageAdapter:
         output_facets = self._build_asset_output_facets(metadata, namespace)
         run_facets = self._build_asset_run_facets(partition_key)
 
-        inputs: List[InputDataset] = [
-            InputDataset(namespace=namespace, name="/".join(key.path))
-            for key in (upstream_asset_keys or [])
-        ]
+        # Inputs are the explicit upstream keys plus any keys from
+        # `dagster/column_lineage` metadata, deduplicated by dataset name.
+        input_by_name: Dict[str, InputDataset] = {}
+        for key in upstream_asset_keys or []:
+            name = "/".join(key.path)
+            input_by_name.setdefault(name, InputDataset(namespace=namespace, name=name))
+        col_lineage = _extract_column_lineage(metadata) if metadata else None
+        if col_lineage is not None:
+            for deps in col_lineage.deps_by_column.values():
+                for dep in deps:
+                    name = "/".join(dep.asset_key.path)
+                    input_by_name.setdefault(
+                        name, InputDataset(namespace=namespace, name=name)
+                    )
+        inputs: List[InputDataset] = list(input_by_name.values())
 
         self._emit(
             RunEvent(

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_asset.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_asset.py
@@ -254,3 +254,45 @@ def test_check_job_name_does_not_collide_with_asset_named_checks():
     # Output job name is {asset}__checks. Collision is structural (suffix) but
     # the job name still differs from the bare asset.
     assert event.job.name == "__checks__checks"
+
+
+def test_asset_materialization_derives_input_datasets_from_column_lineage():
+    adapter, client = _make_adapter()
+    metadata = {
+        "dagster/column_lineage": TableColumnLineage(
+            deps_by_column={
+                "out_a": [TableColumnDep(asset_key=AssetKey("raw"), column_name="a")],
+                "out_b": [TableColumnDep(asset_key=AssetKey("ref"), column_name="b")],
+            }
+        )
+    }
+    adapter.asset_materialization(
+        AssetKey(["orders"]), run_id=_rid(), timestamp=time.time(), metadata=metadata
+    )
+    event: RunEvent = client.emit.call_args.args[0]
+    assert sorted(ds.name for ds in event.inputs) == ["raw", "ref"]
+
+
+def test_asset_materialization_unions_upstream_and_column_lineage_inputs():
+    adapter, client = _make_adapter()
+    metadata = {
+        "dagster/column_lineage": TableColumnLineage(
+            deps_by_column={
+                "out": [
+                    TableColumnDep(asset_key=AssetKey("raw"), column_name="a"),
+                    TableColumnDep(asset_key=AssetKey("raw"), column_name="b"),
+                ]
+            }
+        )
+    }
+    adapter.asset_materialization(
+        AssetKey(["orders"]),
+        run_id=_rid(),
+        timestamp=time.time(),
+        upstream_asset_keys=[AssetKey(["raw"]), AssetKey(["ref"])],
+        metadata=metadata,
+    )
+    event: RunEvent = client.emit.call_args.args[0]
+    # "raw" comes from the explicit upstream keys and from two lineage columns;
+    # it is deduplicated to a single input, explicit keys kept first.
+    assert [ds.name for ds in event.inputs] == ["raw", "ref"]


### PR DESCRIPTION
Asset materialization events now derive table-level input datasets from `dagster/column_lineage` metadata, so backends that build lineage from a `RunEvent`'s inputs/outputs form the upstream edge.

## Summary & Motivation

The adapter already turns `dagster/column_lineage` metadata into a `columnLineage` facet on the output dataset, but that facet does not put the upstream tables into the event's `inputs`. A backend that builds table lineage from `inputs`/`outputs` therefore sees the output with no upstream, and no edge forms — even though the column facet already references those upstreams.

This derives `InputDataset`s from the same metadata, unioned with any explicit `upstream_asset_keys` and deduplicated by dataset name, so the table edge and the column facet come from one source.

## How I Tested These Changes

- Unit tests: inputs derived from column lineage; union of explicit upstream keys and column-lineage-derived keys, deduplicated.
- `uv run pytest` green; `ruff check`, `ruff format --check`, and `ty check .` clean.
- Tested locally end to end: ingested the emitted OpenLineage events into OpenMetadata and used it to visualise the resulting lineage.

## Changelog

Added a `### Features` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Related changes

Part of a set of small improvements to Dagster → OpenLineage. The lineage-fidelity changes are each independent and mergeable on their own; the ownership pair is stacked (#354 builds on #353).

**Lineage fidelity:**
- #344 — decouple job namespace from dataset namespace
- #345 — emit asset run-start without a placeholder output
- #346 — derive asset inputs from column lineage
- #347 — add `exclude_asset_keys` to the storage wrapper

**Ownership:**
- #353 — emit jobType and per-asset ownership facets
- #354 — read native asset owners in the sensor (builds on #353; until #353 merges its diff includes #353's commit)
