### PR TITLE
feat(dagster-openlineage): add exclude_asset_keys to the storage wrapper

### DIFF
--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- **`exclude_asset_keys` on the storage wrapper.** Exclude specific assets out of OpenLineage emitting lineage events via fnmatch glob patterns matched against `AssetKey.to_user_string()`, set in code or `instance.yaml`. Useful when a dedicated connector is the better source of an asset's lineage.
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-openlineage/README.md
+++ b/libraries/dagster-openlineage/README.md
@@ -60,6 +60,7 @@ event_log_storage:
     # namespace_template: "{namespace}/{tag:tenant}"
     # timeout: 2.0
     # strict_assertion_mapping: false
+    # exclude_asset_keys: ["*dbt*"]
 ```
 
 Set `OPENLINEAGE_URL` (and optionally `OPENLINEAGE_API_KEY`) in the environment of any process that writes Dagster events — typically the run worker and the daemon.

--- a/libraries/dagster-openlineage/dagster_openlineage/storage.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/storage.py
@@ -29,6 +29,7 @@ import inspect
 import logging
 import threading
 from collections import OrderedDict
+from fnmatch import fnmatch
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
 
 import yaml
@@ -93,11 +94,15 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
         namespace_template: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         strict_assertion_mapping: bool = False,
+        exclude_asset_keys: Optional[Iterable[str]] = None,
         adapter: Optional[OpenLineageAdapter] = None,
         inst_data: Optional[ConfigurableClassData] = None,
     ) -> None:
         self._wrapped = wrapped
         self._inst_data = inst_data
+        # Assets whose materializations/checks are not emitted as OpenLineage,
+        # matched against AssetKey.to_user_string(). See _is_excluded.
+        self._excluded_keys: Set[str] = set(exclude_asset_keys or [])
         self._adapter = adapter or OpenLineageAdapter(
             namespace=namespace,
             namespace_template=namespace_template,
@@ -140,6 +145,10 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
             "strict_assertion_mapping": Field(
                 bool, is_required=False, default_value=False
             ),
+            # Glob patterns (fnmatch: *, ?, [seq]) matched against
+            # AssetKey.to_user_string(); a plain string is an exact match. Assets
+            # matching any pattern are not emitted as OpenLineage. See _is_excluded.
+            "exclude_asset_keys": Field([str], is_required=False, default_value=[]),
         }
 
     @classmethod
@@ -163,6 +172,7 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
             strict_assertion_mapping=config_value.get(
                 "strict_assertion_mapping", False
             ),
+            exclude_asset_keys=config_value.get("exclude_asset_keys", []),
             inst_data=inst_data,
         )
 
@@ -203,6 +213,12 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
         run_id = event.run_id
         ts = event.timestamp
         run_tags = _run_tags_for(self._wrapped, run_id)
+
+        # Skip opted-out assets before any handling (including failure-synthesis
+        # tracking), so an excluded asset is entirely invisible to OpenLineage.
+        excluded_key = _asset_key_of(de, etype)
+        if excluded_key is not None and self._is_excluded(excluded_key):
+            return
 
         if etype == DagsterEventType.ASSET_MATERIALIZATION_PLANNED:
             data = de.event_specific_data
@@ -345,6 +361,35 @@ class OpenLineageEventLogStorage(EventLogStorage, ConfigurableClass):
                 run_tags=run_tags,
             )
 
+    def _is_excluded(self, asset_key: AssetKey) -> bool:
+        """Whether an asset's events should be suppressed from OpenLineage.
+
+        Each configured entry is a glob pattern (fnmatch: ``*``, ``?``,
+        ``[seq]``) matched against ``AssetKey.to_user_string()``; a plain string
+        with no wildcards is an exact match. Use this when another connector is
+        the better source of an asset's lineage.
+        """
+        key = asset_key.to_user_string()
+        return any(fnmatch(key, pattern) for pattern in self._excluded_keys)
+
+
+def _asset_key_of(de: Any, etype: "DagsterEventType") -> Optional[AssetKey]:
+    # Resolve the AssetKey for asset-scoped event types (None for run-level
+    # events). Extraction differs per event type, mirroring _dispatch.
+    data = de.event_specific_data
+    if etype == DagsterEventType.ASSET_MATERIALIZATION:
+        return data.materialization.asset_key
+    if etype == DagsterEventType.ASSET_OBSERVATION:
+        return data.asset_observation.asset_key
+    if etype in (
+        DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+        DagsterEventType.ASSET_FAILED_TO_MATERIALIZE,
+        DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
+        DagsterEventType.ASSET_CHECK_EVALUATION,
+    ):
+        return getattr(data, "asset_key", None)
+    return None
+
 
 def _format_error_message(error: Any) -> Optional[str]:
     if error is None:
@@ -406,4 +451,4 @@ OpenLineageEventLogStorage.__abstractmethods__ = frozenset()
 __all__ = ["OpenLineageEventLogStorage"]
 
 # Quiet unused-import noise for static checkers.
-_ = (Iterable, List)
+_ = (List,)

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_storage_wrapper.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_storage_wrapper.py
@@ -403,3 +403,61 @@ def test_check_evaluation_planned_embedded_when_materialization_planned():
         and c.args[0].job.name.endswith("__checks")
     ]
     assert start_events == []
+
+
+# ---------------------------------------------------------------------------
+# exclude_asset_keys
+# ---------------------------------------------------------------------------
+
+
+def _make_wrapper_with_exclusions(
+    patterns: list[str],
+) -> tuple[OpenLineageEventLogStorage, MagicMock]:
+    client = MagicMock()
+    adapter = OpenLineageAdapter(emitter=OpenLineageEmitter(client=client))
+    wrapper = OpenLineageEventLogStorage(
+        wrapped=InMemoryEventLogStorage(),
+        exclude_asset_keys=patterns,
+        adapter=adapter,
+    )
+    return wrapper, client
+
+
+def test_excluded_asset_exact_match_is_not_emitted():
+    wrapper, client = _make_wrapper_with_exclusions(["orders"])
+    wrapper.store_event(_materialization_event(_rid(), AssetKey(["orders"])))
+    # Storage still wrote the event; only OL emission is suppressed.
+    client.emit.assert_not_called()
+
+
+def test_excluded_asset_glob_is_not_emitted_but_others_are():
+    wrapper, client = _make_wrapper_with_exclusions(["*dbt*"])
+    wrapper.store_event(_materialization_event(_rid(), AssetKey(["stg_orders_dbt"])))
+    client.emit.assert_not_called()
+    wrapper.store_event(_materialization_event(_rid(), AssetKey(["orders"])))
+    assert client.emit.call_count == 1
+
+
+def test_excluded_asset_is_not_tracked_for_failure_synthesis():
+    wrapper, client = _make_wrapper_with_exclusions(["orders"])
+    run_id = _rid()
+    wrapper.store_event(_planned_event(run_id, AssetKey(["orders"])))
+    wrapper.store_event(_step_failure_event(run_id))
+    # The excluded asset was gated before tracking, so no FAIL is synthesized.
+    client.emit.assert_not_called()
+    assert run_id not in wrapper._planned_assets
+
+
+def test_exclude_asset_keys_passed_through_from_config_value():
+    wrapper = OpenLineageEventLogStorage.from_config_value(
+        inst_data=None,
+        config_value={
+            "wrapped": {
+                "module": "dagster._core.storage.event_log.in_memory",
+                "class": "InMemoryEventLogStorage",
+                "config": {},
+            },
+            "exclude_asset_keys": ["*dbt*", "orders"],
+        },
+    )
+    assert wrapper._excluded_keys == {"*dbt*", "orders"}


### PR DESCRIPTION
Add `exclude_asset_keys` to `OpenLineageEventLogStorage` — fnmatch glob patterns that opt specific assets out of OpenLineage emission.

## Summary & Motivation

When a Dagster job runs dbt, every dbt model materializes as an asset and would emit OpenLineage — but a dedicated dbt integration (e.g. OpenMetadata's DBT connector) can be a better source for those models (column lineage, tests, model SQL from the dbt artifacts). Emitting them over OpenLineage as well produces duplicate, thinner edges. This adds a way to opt specific assets out.

`exclude_asset_keys` is a list of `fnmatch` glob patterns matched against `AssetKey.to_user_string()`, set in code or `instance.yaml`. Matching assets are skipped before any handling (including failure-synthesis tracking), so they are entirely invisible to OpenLineage.

## How I Tested These Changes

- Unit tests: exact-match and glob exclusion (with a non-matching asset still emitting), exclusion skips failure synthesis, and config passthrough from `instance.yaml`.
- `uv run pytest` green; `ruff check`, `ruff format --check`, and `ty check .` clean.
- Tested locally end to end: ingested the emitted OpenLineage events into OpenMetadata and used it to visualise the resulting lineage.

## Changelog

Added a `### Features` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Related changes

Part of a set of small improvements to Dagster → OpenLineage. The lineage-fidelity changes are each independent and mergeable on their own; the ownership pair is stacked (#354 builds on #353).

**Lineage fidelity:**
- #344 — decouple job namespace from dataset namespace
- #345 — emit asset run-start without a placeholder output
- #346 — derive asset inputs from column lineage
- #347 — add `exclude_asset_keys` to the storage wrapper

**Ownership:**
- #353 — emit jobType and per-asset ownership facets
- #354 — read native asset owners in the sensor (builds on #353; until #353 merges its diff includes #353's commit)
