### PR TITLE
Keep changelogs in step with releases and backfill missing entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ cython_debug/
 # NodeJS
 node_modules/
 /.idea
+
+# macOS
+.DS_Store

--- a/libraries/dagster-adbc/CHANGELOG.md
+++ b/libraries/dagster-adbc/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.2] - 2026-05-22
+
+- Update dagster-adbc lockfile (#298)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.1] - 2026-04-21
+
+- Add dagster-adbc integration (#272)

--- a/libraries/dagster-anthropic/CHANGELOG.md
+++ b/libraries/dagster-anthropic/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.6] - 2026-05-22
+
+- Update dagster-anthropic lockfile (#299)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.5] - 2025-11-12
+
+- See the git history for the changes in this release.
+
+## [0.0.4] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.3] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+
+## [0.0.2] - 2025-03-10
+
+- ignore pyright failures
+- inspect dagster version
+- amend experimental tag => preview
+- Clean up trailing whitespace, add missing newlines
+- Remove extraneous `.`s at the end of Ruff commands
+- Updates package name to skewer case in pip install command
+- dagster-contrib-anthropic -> dagster-anthropic (#99)
+
+## [0.0.1] - 2025-01-15
+
+- Add Anthropic Resource (#95)

--- a/libraries/dagster-apprise/CHANGELOG.md
+++ b/libraries/dagster-apprise/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-05-22
+
+- Update dagster-apprise lockfile (#300)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+- chore: prevent registry warnings for community integrations (#270)
+
+## [0.0.2] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
 ## [0.0.1]
 
 ### Added

--- a/libraries/dagster-async-executor/CHANGELOG.md
+++ b/libraries/dagster-async-executor/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.4] - 2026-06-29
+
+- fix(dagster-async-executor): bound event receive so delayed retries don't hang (#327)
+
+## [0.0.3] - 2026-05-22
+
+- Update dagster-async-executor lockfile (#301)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.2] - 2025-12-11
+
+- Update async executor packaging (#261)
+
 ## [0.0.1]
 
 - Initial Release, 2025-12-06

--- a/libraries/dagster-chroma/CHANGELOG.md
+++ b/libraries/dagster-chroma/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.5] - 2026-05-22
+
+- Update dagster-chroma lockfile (#302)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.4] - 2025-11-12
+
+- See the git history for the changes in this release.
+
+## [0.0.3] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.2] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- Clean up trailing whitespace, add missing newlines
+- Remove extraneous `.`s at the end of Ruff commands
+- Run Ruff formatter on libraries that would fail CI
+- Updates package name to skewer case in pip install command
+
+## [0.0.1] - 2025-01-15
+
+- dagster-contrib-chroma -> dagster-chroma (#102)
+- Add Chroma Resource (#91)

--- a/libraries/dagster-contrib-gcp/CHANGELOG.md
+++ b/libraries/dagster-contrib-gcp/CHANGELOG.md
@@ -1,10 +1,37 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.10] - 2026-05-22
+
+- Update dagster-contrib-gcp lockfile (#303)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+- Fix changelog for dagster-contrib-gcp
+
 ## 0.0.9
 
 ### Updated
 
 - (pull/259) Added the `container_name` field option to support multi-container job launching
+
+## [0.0.8] - 2025-11-12
+
+- See the git history for the changes in this release.
+
+## [0.0.7] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.6] - 2025-04-16
+
+- Bug: job dict mutation (#181)
+
+## [0.0.5] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
 
 ## 0.0.4
 
@@ -24,3 +51,11 @@
 ### Updated
 
 - (pull/88) Added job timeout as dagster.yaml instance config
+
+## [0.0.2] - 2024-11-21
+
+- fix build to detect sub-packages (#27)
+
+## [0.0.1] - 2024-11-21
+
+- add cloud runner (#26)

--- a/libraries/dagster-dataform/CHANGELOG.md
+++ b/libraries/dagster-dataform/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.7] - 2026-05-22
+
+- Update dagster-dataform lockfile (#304)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.6] - 2026-02-06
+
+- Add support to dagster-dataform for selective model execution (#268)
+
+## [0.0.5] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
+## [0.0.4] - 2025-09-02
+
+- Add support for SQL Assertion ingestion as Asset Checks (#230)
+
+## [0.0.3] - 2025-08-25
+
+- Fix __init__.py imports (#229)
+
+## [0.0.2] - 2025-08-21
+
+- Import module objects into __init__.py (#228)
+
+## [0.0.1] - 2025-08-19
+
+- New dagster-dataform Integration  (#227)

--- a/libraries/dagster-ducklake/CHANGELOG.md
+++ b/libraries/dagster-ducklake/CHANGELOG.md
@@ -6,3 +6,21 @@
 
 - Allowed `path` to be unspecified when instantiating `DuckLakeLocalDirectory`, because [the data storage location only has to be specified when creating a new DuckLake](https://ducklake.select/docs/stable/duckdb/usage/connecting).
 - Changed the `get_ducklake_sql_parts` functions in `DuckLakeLocalDirectory` and `S3Config` output formatting to include leading commas, so that they are simple to exclude in `_setup_ducklake_connection`.
+
+## [0.0.4] - 2026-05-22
+
+- Update dagster-ducklake lockfile (#305)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.3] - 2026-04-28
+
+- ducklake optional DATA_PATH for local storage directories (#275)
+
+## [0.0.2] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
+## [0.0.1] - 2025-10-06
+
+- feat: add ducklake integration (#238)

--- a/libraries/dagster-elasticsearch/CHANGELOG.md
+++ b/libraries/dagster-elasticsearch/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `BaseConnectionConfig.to_client_kwargs` is now a declared abstract method, so missing implementations show up under `mypy`.
 - Loosened the `elasticsearch` client pin to `>=8.10,<11`. The integration only uses bulk and alias APIs that haven't changed across Elasticsearch 8, 9, and 10. Pin a specific major in your own project to match your server (the client refuses cross-major). Test fixtures honour the `ES_TEST_IMAGE` env var so a single test run can target any supported major.
 
+## [0.0.2] - 2026-05-22
+
+- Update dagster-elasticsearch lockfile (#306)
+
 ## [0.0.1]
 
 ### Added

--- a/libraries/dagster-evidence/CHANGELOG.md
+++ b/libraries/dagster-evidence/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.2.1] - 2026-05-22
+
+- Update dagster-evidence lockfile (#307)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.2.0] - 2026-02-02
+
+- Feat/add new evidence component v2 (#265)
+
+## [0.1.7] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
+## [0.1.6] - 2025-05-29
+
+- Evidence resource (#199)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.1.5] - 2025-04-09
+
+- use multiple entrypoints
+
+## [0.1.4] - 2025-04-09
+
+- use project instead of plugin for current release
+
+## [0.1.3] - 2025-04-09
+
+- use plugin in entry-point
+
+## [0.1.2] - 2025-04-09
+
+- re-define project.entry-points
+
+## [0.1.1] - 2025-04-09
+
+- register EvidenceProject to __all__
+
+## [0.1.0] - 2025-04-09
+
+- RFC: dagster-evidence (#167)

--- a/libraries/dagster-gemini/CHANGELOG.md
+++ b/libraries/dagster-gemini/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.6] - 2026-05-22
+
+- Update dagster-gemini lockfile (#308)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.4] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.3] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- ignore pyright failures
+- inspect dagster version
+- amend experimental tag => preview
+- Clean up trailing whitespace, add missing newlines
+- Remove extraneous `.`s at the end of Ruff commands
+- Updates package name to skewer case in pip install command
+- dagster-contrib-gemini -> dagster-gemini (#98)
+
+## [0.0.2] - 2025-01-15
+
+- See the git history for the changes in this release.
+
+## [0.0.1] - 2025-01-15
+
+- user skewer-case for project name
+- Add Gemini Resource (#96)

--- a/libraries/dagster-hex/CHANGELOG.md
+++ b/libraries/dagster-hex/CHANGELOG.md
@@ -1,10 +1,31 @@
 # Changelog
 
+## [Unreleased]
+
 ---
 
-## 0.1.7 - UNRELEASED
+## [0.1.10] - 2026-05-22
 
--
+- Update dagster-hex lockfile (#309)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.1.9] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.1.8] - 2025-04-10
+
+- Get version from `__version__` instead of metadata (#175)
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+
+## [0.1.7] - 2025-03-10
+
+- ignore pyright failures
+- inspect dagster version
+- amend experimental tag => preview
 
 ## 0.1.6
 

--- a/libraries/dagster-hf-datasets/CHANGELOG.md
+++ b/libraries/dagster-hf-datasets/CHANGELOG.md
@@ -9,3 +9,12 @@
 - Added resources in readme.md with additional examples and release post.
 
 - Standardize project alias and add metadata to pyproject.toml
+
+## [0.0.2] - 2026-06-29
+
+- Update Image Path for README and fix nits in Docs (#326)
+
+## [0.0.1] - 2026-05-27
+
+- Prepare dagster-hf-datasets for release
+- Add `hf datasets` for Dagster (#288)

--- a/libraries/dagster-iceberg/CHANGELOG.md
+++ b/libraries/dagster-iceberg/CHANGELOG.md
@@ -13,4 +13,149 @@
 ### Changed
 
 - Rename I/O managers from `<Storage><Engine>IOManager` to `<Engine><Storage>IOManager`.
-- Support for pyiceberg 0.10.0 (#241). Change behavior for how partition field names are calculated to address validation introduced in [pyiceberg #2505](https://github.com/apache/iceberg-python/pull/2305). Partition field names calculated for Dagster asset partitions now include a configurable prefix before the column name they reference. **Migration note**: When updating partition specs on existing tables, new partition field names will be generated using the configured prefix (default: `part_`). For example, a partition field previously named `timestamp` will become `part_timestamp`. Existing data remains accessible, but queries referencing partition fields will need to be updated to use the new naming convention. To maintain backward compatibility, existing tables with unchanged partition specs will retain their original field names until their partition specs are updated. 
+- Support for pyiceberg 0.10.0 (#241). Change behavior for how partition field names are calculated to address validation introduced in [pyiceberg #2505](https://github.com/apache/iceberg-python/pull/2305). Partition field names calculated for Dagster asset partitions now include a configurable prefix before the column name they reference. **Migration note**: When updating partition specs on existing tables, new partition field names will be generated using the configured prefix (default: `part_`). For example, a partition field previously named `timestamp` will become `part_timestamp`. Existing data remains accessible, but queries referencing partition fields will need to be updated to use the new naming convention. To maintain backward compatibility, existing tables with unchanged partition specs will retain their original field names until their partition specs are updated.
+
+## [0.3.14] - 2026-05-27
+
+- fix(dagster-iceberg): add reader_override option to PolarsIcebergIOManager (#323)
+
+## [0.3.13] - 2026-05-22
+
+- Update dagster-iceberg lockfile (#310)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.3.12] - 2026-05-22
+
+- Fix Iceberg partition expression typing (#290)
+- chore(dagster-iceberg): loosen pyiceberg upper bound to <0.12 (#289)
+- Add S3TablesCatalogConfig to dagster-iceberg (#279)
+
+## [0.3.11] - 2026-02-11
+
+- include future annotations
+
+## [0.3.10] - 2026-02-10
+
+- set upper bound for compatibility (#269)
+
+## [0.3.9] - 2026-02-10
+
+- Include future annotations in dagster-iceberg
+
+## [0.3.8] - 2025-11-18
+
+- Adding upsert support  (#242)
+
+## [0.3.7] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
+## [0.3.6] - 2025-10-23
+
+- Assign configurable prefix to partition field names to prevent conflict with schema field names (#241)
+- colton/consolidate github workflows (#236)
+
+## [0.3.5] - 2025-10-03
+
+- Fix indentation of docstring
+
+## [0.3.4] - 2025-10-03
+
+- Add append mode support (#235)
+
+## [0.3.3] - 2025-06-30
+
+- less specific import (#212)
+
+## [0.3.2] - 2025-06-30
+
+- less specific import (#211)
+
+## [0.3.1] - 2025-06-09
+
+- Provide extensible load function (#203)
+- Upgrade Spark<4.0 and other deps (#204)
+- Remove pandas for Polars example (#194)
+- Ensure all APIs are in "preview" (#192)
+- Update `is_dagster_package=False` for each package (#193)
+- Make docs build for Dagster site (#189)
+- Test Spark with multi partitions
+- Test Spark with daily partitions
+- Test Spark with hourly partition
+- Stop aliasing `datetime` as `dt`
+- Add unit test coverage for Spark (#176)
+- Update dependencies in `uv.lock`
+- Remove usage of `testcontainers`
+- Use Compose env to test existing
+- Set up Spark Iceberg Compose env
+- Kill unused `CustomDbIOManager`s
+
+## [0.3.0] - 2025-04-16
+
+- Rename I/O managers engine-first (#169)
+- Standardize capitalization of IO (#168)
+- Use `COL` suffix in kitchen sink
+- Test daily partitions with Spark
+- Test time partitions with Polars
+- Add test for Spark 2D partitions
+- Reload 2D-partitioned Spark data
+- Check 2D partitioning with Spark
+- Add multi partitioning unit test
+- Test 2D partitioning with Polars
+- Rename `PARTITION_EXPR` variable
+- Import, use `dg` in kitchen sink
+- Add partition type to asset name
+- Drop an unnecessary length check
+- Ensure partitioned reads, writes
+- Group kitchen sink assets by lib
+- Upgrade Dagster for typing fixes
+- Add partitioned Spark asset test
+- Don't run Spark jobs in parallel
+- Support partitioned Spark assets
+- Add partitioned Polars data test
+- Restore `print` of reloaded data
+- Support configuring Spark remote
+- Provide URL using `spark.remote`
+- Don't use Pythonic configuration
+- Do not require `dagster-pyspark`
+- Ruff more and drop other configs
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- Remove duplicate kitchen_sink.py (#148)
+- Wait for Docker services to rise
+- Upgrade deps (including PySpark)
+- Use a faster, non-archive mirror
+- Test with `SPARK_REMOTE` env var
+- Reduce `NUM_PARTS` for faster CI
+- Test end-to-end Spark read/write
+- Only materialize Polars in tests
+- Ignore the bad typing in Dagster
+- Make `NUM_PARTS` a config option
+- Create a `SparkIcebergIOManager`
+
+## [0.2.2] - 2025-03-10
+
+- ignore pyright failures
+- inspect dagster version
+- amend experimental tag => preview
+- Use "rest" catalog with "nyc" db
+- Use "demo" catalog with "nyc" db
+- Update tests to use REST catalog
+- Don't format copied provision.py
+- Add Spark Connect to Compose env
+- Copy PyIceberg integration setup
+- Add `spark-iceberg` Compose file
+- Define the `spark` package extra
+- Materialize the downstream asset
+- Test reloading data from Iceberg
+- Set database to the catalog name (#137)
+- Update links in documentation (#131)
+- Clean up trailing whitespace, add missing newlines
+- Add end-to-end kitchen sink test (#122)
+- Add `Makefile` for local testing (#121)
+- Create minimal `kitchen_sink.py` (#120)
+
+## [0.2.1] - 2025-02-20
+
+- Feat: Add dagster-iceberg (#115)

--- a/libraries/dagster-modal/CHANGELOG.md
+++ b/libraries/dagster-modal/CHANGELOG.md
@@ -1,7 +1,45 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.5] - 2026-05-22
+
+- Update dagster-modal lockfile (#311)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.4] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.3] - 2025-04-09
+
+- Rename I/O managers engine-first (#169)
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- Remove extraneous `.`s at the end of Ruff commands
+- dagster-contrib-modal -> dagster-modal (#101)
+
 ## [0.0.2]
 
 ### Updated
 
 - Updated type of `modal.run` `context` parameter to `Union[AssetExecutionContext, OpExecutionContext]`
+
+## [0.0.1] - 2024-10-25
+
+- add docstring examples (#18)
+- ignore incompatible method overrides pyright check (#17)
+- rename dagster-modal to dagster-contrib-modal
+- maint: add pyright check directive for each makefile
+- maint: remove .python-version files from version control
+- add CI for quality checks: ruff and pytest (#12)
+- add github action for unit testing
+- fix: builds for dagster-hex and dagster-modal (#10)
+- add unit test (#7)
+- add make ruff directive; run ruff fix and format
+- simplify uv publish command
+- add publish url; add note about releases in README
+- add note about publisher
+- introduce dagster-modal integration (#1)

--- a/libraries/dagster-notdiamond/CHANGELOG.md
+++ b/libraries/dagster-notdiamond/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+> **Note on version ordering.** Releases below are listed newest first by
+> release date, which is not the same as descending version order. This
+> library shipped 0.1.2 and 0.1.3, then commit `ca78a07` moved the version
+> out of `pyproject.toml` and into `__init__.py` as 0.0.2, and releases have
+> continued from that lower base. PyPI serves the highest version, so
+> `pip install dagster-notdiamond` still resolves to 0.1.3; 0.0.3 onwards are
+> published but only reachable by pinning an exact version. See
+> [#340](https://github.com/dagster-io/community-integrations/issues/340).
+
+## [Unreleased]
+
+## [0.0.5] - 2026-05-22
+
+- Update NotDiamond SDK (#297)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.4] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.3] - 2025-04-09
+
+- Rename I/O managers engine-first (#169)
+- Fix Ruff violation in example
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+
+## [0.1.3] - 2025-03-10
+
+- ignore pyright failures
+- inspect dagster version
+- amend experimental tag => preview
+- Remove extraneous `.`s at the end of Ruff commands
+- Run Ruff formatter on libraries that would fail CI
+- adds example of using the model gateway (#110)
+- rename `dagster-contrib-notdiamond` to `dagster-notdiamond` (#108)
+- create example showcasing model routing usage with OAI (#94)
+
 ## [0.1.2]
 
 - Removing TOML config.
@@ -12,3 +52,15 @@
 ## [0.1.0]
 
 - Initial Release, 2024-10-30
+
+## [0.0.1] - 2024-11-07
+
+- add setuptools configuration
+- make ruff
+- fixing expected user_agent param
+- Docs and example job
+- test run
+- forgot to save pyproject
+- feedback from colton
+- rename to dagster-contrib-notdiamond
+- initial

--- a/libraries/dagster-obstore/CHANGELOG.md
+++ b/libraries/dagster-obstore/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.2.5] - 2026-05-22
+
+- Update dagster-obstore lockfile (#312)
+- Standardize shared ty configuration (#295)
+- Start obstore test services in pytest (#294)
+- Migrate type checking to ty (#291)
+
+## [0.2.4] - 2026-03-19
+
+- chore: prevent registry warnings for community integrations (#270)
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.2.3] - 2025-04-09
+
+- fix: update imports to use dagster_shared and bump dagster dependency to 1.10.7 (#159)
+
+## [0.2.2] - 2025-03-29
+
+- See the git history for the changes in this release.
+
+## [0.2.1] - 2025-03-26
+
+- chore: bump >= obstore-0.6 (#149)
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- Clean up trailing whitespace, add missing newlines
+- Remove extraneous `.`s at the end of Ruff commands
+
+## [0.2.0] - 2025-02-11
+
+- chore: bump obstore (#113)
+
+## [0.1.1] - 2025-02-07
+
+- fix: release, use hatchling build system (#109)
+
+## [0.1.0] - 2025-02-05
+
+- feat: dagster-obstore (#107)

--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.2.1] - 2026-05-22
+
+- Update dagster-openlineage lockfile (#313)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-polars/CHANGELOG.md
+++ b/libraries/dagster-polars/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - The `extension` overrides on `PolarsParquetIOManager` and `PolarsDeltaIOManager` are now declared as `ClassVar[Optional[str]]`, which stops pydantic from treating them as model fields. Previously every import surfaced a `UserWarning: Field name "extension" in "PolarsParquetIOManager" shadows an attribute in parent "BasePolarsUPathIOManager"` (and the same for the delta manager) — that warning is now gone. Includes a regression test asserting no shadow warning is emitted on import.
 - Fixed `PolarsParquetIOManager` reads and writes failing on S3 when fsspec-style `storage_options` (`key`, `secret`, `client_kwargs`) were passed to the IO manager. Polars uses `object_store` under the hood, which expects different key names (`aws_access_key_id`, `aws_secret_access_key`, etc.). The IO manager now translates fsspec keys to their `object_store` equivalents on every read and write, and drops unknown keys against an allowlist so typos surface as missing config rather than opaque Rust errors. Applies on `polars >= 1.17`; older versions keep the previous fsspec passthrough. Closes [#257](https://github.com/dagster-io/community-integrations/issues/257).
-- Partitioned assets/outputs now log `dagster/partition_row_count` metadata instead of `dagster/row_count`. See https://docs.dagster.io/guides/build/assets/metadata-and-tags for more details. 
+- Partitioned assets/outputs now log `dagster/partition_row_count` metadata instead of `dagster/row_count`. See https://docs.dagster.io/guides/build/assets/metadata-and-tags for more details.
 
 ## Added
 
@@ -21,6 +21,34 @@
 - `PolarsParquetIOManager.write_df_to_path` now passes `storage_options` to Polars `write_parquet` for cloud storage writes (requires Polars >= 1.17.0).
 - `PolarsParquetIOManager.sink_df_to_path` now uses Polars native `sink_parquet` with `storage_options` (requires Polars >= 1.17.0, falls back to collecting for older versions).
 
+## [0.27.12] - 2026-05-22
+
+- Update dagster-polars lockfile (#314)
+
+## [0.27.11] - 2026-05-22
+
+- remap fsspec storage_options for object_store reads (closes #257) (#280)
+
+## [0.27.10] - 2026-05-22
+
+- silence pydantic shadow warning on extension override (#281)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+- dagster-polars: parquet writes to cloud storage (#264)
+
+## [0.27.9] - 2026-02-03
+
+- log dagster/partition_row_count instead of dagster/row_count for partitioned outputs (#267)
+
+## [0.27.8] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- fix typo in docs (#239)
+
+## [0.27.7] - 2025-09-22
+
+- add top-level schema_mode PolarsDeltaIOManager parameter (#233)
+
 ## 0.27.6
 
 - Use new deltalake (>=1.0.0) syntax and arguments for delta io manager while retaining compatibility via version parsing and legacy syntax.
@@ -31,6 +59,22 @@
 - Bump polars dev dependency to support latest deltalake syntax
 - Fixed `ImportError` when `patito` is not installed
 - Fixed groupings of iomanager config allowing inclusion of s3fs and polars options.
+
+## [0.27.5] - 2025-08-15
+
+- fix: sanitize config passed to polars.scan_parquet (#220)
+- Removes setuptools-scm dep for dagster-polars
+
+## [0.27.4] - 2025-07-23
+
+- Fix/use new streaming collect (#215)
+
+## [0.27.3] - 2025-07-21
+
+- refactor/update delta write options (#217)
+- fix ImportError with patito and ensure optional deps are not top-level imports (#196)
+- Update `is_dagster_package=False` for each package (#193)
+- update changelog (#190)
 
 ## 0.27.2
 

--- a/libraries/dagster-qdrant/CHANGELOG.md
+++ b/libraries/dagster-qdrant/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.4] - 2026-05-22
+
+- Update dagster-qdrant lockfile (#315)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.3] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.2] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+
+## [0.0.1] - 2025-03-05
+
+- feat: Qdrant Resource (#140)

--- a/libraries/dagster-salesforce/CHANGELOG.md
+++ b/libraries/dagster-salesforce/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.3] - 2026-05-22
+
+- Update dagster-salesforce lockfile (#316)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.2] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
 ## [0.0.1]
 
 - Initial Release, 2025-11-09

--- a/libraries/dagster-sftp/CHANGELOG.md
+++ b/libraries/dagster-sftp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.3] - 2026-05-22
+
+- Update dagster-sftp lockfile (#317)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
 ## [0.0.2]
 
 - Correctly pass `follow_symlinks` into `get_file_info()`

--- a/libraries/dagster-sharepoint/CHANGELOG.md
+++ b/libraries/dagster-sharepoint/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+## [0.0.4] - 2026-05-22
+
+- Update dagster-sharepoint lockfile (#318)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.3] - 2026-04-29
+
+- support optional `site` parameter to SharePointResource (#277)
+
+## [0.0.2] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+
 ## [0.0.1]
 
 - Initial Release, 2025-11-09

--- a/libraries/dagster-teradata/CHANGELOG.md
+++ b/libraries/dagster-teradata/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.8] - 2026-05-22
+
+- Update dagster-teradata lockfile (#319)
+- Standardize shared ty configuration (#295)
+- Skip Teradata functional tests by default (#292)
+- Migrate type checking to ty (#291)
+- Drop support for Python 3.9 (#243)
+
+## [0.0.7] - 2025-10-06
+
+- See the git history for the changes in this release.
+
+## [0.0.6] - 2025-10-06
+
+- See the git history for the changes in this release.
+
+## [0.0.5] - 2025-07-03
+
+- Added missing packages (#213)
+
+## [0.0.4] - 2025-06-30
+
+- dagster-teradata : Added QueryBand and BTEQ Operator support (#210)
+- add publish section README (#198)
+
+## [0.0.3] - 2025-05-14
+
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.2] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- Clean up trailing whitespace, add missing newlines
+- Remove extraneous `.`s at the end of Ruff commands
+- Fix formatting, and check in CI (#126)
+
+## [0.0.1] - 2025-01-31
+
+- Add Teradata Resource (#104)

--- a/libraries/dagster-vertexai/CHANGELOG.md
+++ b/libraries/dagster-vertexai/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.2] - 2026-05-22
+
+- Update dagster-vertexai lockfile (#320)
+- Standardize shared ty configuration (#295)
+- Mock Vertex AI SDK calls in tests (#293)
+- Migrate type checking to ty (#291)
+- Drop support for Python 3.9 (#243)
+
+## [0.0.1] - 2025-09-09
+
+- Feat/enable vertexai (#232)

--- a/libraries/dagster-weaviate/CHANGELOG.md
+++ b/libraries/dagster-weaviate/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.4] - 2026-05-22
+
+- Update dagster-weaviate lockfile (#321)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.3] - 2025-11-12
+
+- Drop support for Python 3.9 (#243)
+- Update `is_dagster_package=False` for each package (#193)
+
+## [0.0.2] - 2025-04-09
+
+- Enable telemetry across all community integrations
+- Set package version dynamically, ensure it matches
+- Clean up trailing whitespace, add missing newlines
+- Remove extraneous `.`s at the end of Ruff commands
+- Updates package name to skewer case in pip install command
+- dagster-contrib-weaviate -> dagster-weaviate (#97)
+
+## [0.0.1] - 2025-01-15
+
+- skewer-case for project name
+- Add Weaviate Resource (#87)

--- a/libraries/dagster-xquik/CHANGELOG.md
+++ b/libraries/dagster-xquik/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.0.2] - 2026-05-22
+
+- Update dagster-xquik lockfile (#322)
+- Standardize shared ty configuration (#295)
+- Migrate type checking to ty (#291)
+
+## [0.0.1] - 2026-05-14
+
+- Add Dagster Xquik integration (#282)

--- a/release.sh
+++ b/release.sh
@@ -74,7 +74,81 @@ fi
 
 sed -i '' 's/__version__ = "[^"]*"/__version__ = "'"$VERSION"'"/' "${version_file}"
 
-git add "${version_file}"
+# The sed above changes nothing if the file has no `__version__` assignment
+# to rewrite, which would otherwise release a version the package never
+# declares.
+if ! grep -q "__version__ = \"${VERSION}\"" "${version_file}"; then
+  echo "ERROR: ${version_file} does not declare __version__ = \"${VERSION}\" after the version bump"
+  echo "Check that the file contains a literal '__version__ = \"X.X.X\"' assignment."
+  exit 1
+fi
+
+# Keep the library's CHANGELOG in step with the release, so the two can't drift
+# apart. Handles three cases:
+#   - "## [Unreleased]" exists: promote it to this version, dated today, and
+#     start a fresh empty [Unreleased] section above it.
+#   - No CHANGELOG at all: create one, and warn.
+#   - CHANGELOG without an [Unreleased] section: add a dated heading for this
+#     version, and warn.
+# If the changelog already has an entry for this version, the file is left
+# untouched, so running the same release twice changes nothing.
+changelog_file="libraries/${PACKAGE}/CHANGELOG.md"
+release_date=$(date +%Y-%m-%d)
+
+if [ ! -f "$changelog_file" ]; then
+  cat > "$changelog_file" <<EOF
+# Changelog
+
+All notable changes to this integration will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [${VERSION}] - ${release_date}
+
+- See the git history for the changes in this release.
+EOF
+  echo "WARNING: ${PACKAGE} had no CHANGELOG.md; created one with an entry for ${VERSION}"
+elif grep -q "^## \[\{0,1\}${VERSION}\]\{0,1\}\( \|$\)" "$changelog_file"; then
+  echo "CHANGELOG already documents ${VERSION}; leaving it unchanged"
+elif grep -q '^## \[Unreleased\]' "$changelog_file"; then
+  awk -v ver="$VERSION" -v date="$release_date" '
+    !promoted && /^## \[Unreleased\]/ {
+      print "## [Unreleased]"
+      print ""
+      print "## [" ver "] - " date
+      promoted = 1
+      next
+    }
+    { print }
+  ' "$changelog_file" > "${changelog_file}.tmp" && mv "${changelog_file}.tmp" "$changelog_file"
+  echo "Promoted [Unreleased] to [${VERSION}] in ${changelog_file}"
+else
+  # No [Unreleased] to promote. Insert a dated heading above the newest existing
+  # version section, or at the end of the file if there are none.
+  awk -v ver="$VERSION" -v date="$release_date" '
+    !inserted && /^## / {
+      print "## [" ver "] - " date
+      print ""
+      print "- See the git history for the changes in this release."
+      print ""
+      inserted = 1
+    }
+    { print }
+    END {
+      if (!inserted) {
+        print ""
+        print "## [" ver "] - " date
+        print ""
+        print "- See the git history for the changes in this release."
+      }
+    }
+  ' "$changelog_file" > "${changelog_file}.tmp" && mv "${changelog_file}.tmp" "$changelog_file"
+  echo "WARNING: ${changelog_file} has no [Unreleased] section; added a bare entry for ${VERSION}"
+fi
+
+git add "${version_file}" "${changelog_file}"
 if git diff --staged --quiet; then
   echo "Version is already ${VERSION}; skipping release commit"
 else

--- a/release.sh
+++ b/release.sh
@@ -84,12 +84,12 @@ if ! grep -q "__version__ = \"${VERSION}\"" "${version_file}"; then
 fi
 
 # Keep the library's CHANGELOG in step with the release, so the two can't drift
-# apart. Handles three cases:
-#   - "## [Unreleased]" exists: promote it to this version, dated today, and
-#     start a fresh empty [Unreleased] section above it.
-#   - No CHANGELOG at all: create one, and warn.
-#   - CHANGELOG without an [Unreleased] section: add a dated heading for this
-#     version, and warn.
+# apart. It handles three cases.
+#   - When "## [Unreleased]" exists, promote it to this version, dated today,
+#     and start a fresh empty [Unreleased] section above it.
+#   - When there is no CHANGELOG at all, create one and warn.
+#   - When the CHANGELOG has no [Unreleased] section, add a dated heading for
+#     this version and warn.
 # If the changelog already has an entry for this version, the file is left
 # untouched, so running the same release twice changes nothing.
 changelog_file="libraries/${PACKAGE}/CHANGELOG.md"

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -8,7 +8,7 @@
 # out, and `[dagster-foo] ` subject prefixes are stripped since the library is
 # implied by the file the entry lives in.
 #
-# Release tags live on GitHub, so fetch them first:
+# Release tags live on GitHub, so fetch them first.
 #
 #     git fetch origin --tags
 #
@@ -40,8 +40,8 @@ fi
 # lives. Their early releases are tagged under the old prefix and their early
 # commits touched the old directory, so both have to be searched or those
 # releases come back empty. The map is deliberately hardcoded rather than
-# derived from `git log --diff-filter=R`: dagster-qdrant is also a rename (of
-# `_template`), and following that would pull unrelated template history in.
+# derived from `git log --diff-filter=R`. dagster-qdrant is also a rename of
+# `_template`, and following that would pull unrelated template history in.
 case "$PACKAGE" in
   dagster-anthropic)  legacy="dagster-contrib-anthropic" ;;
   dagster-chroma)     legacy="dagster-contrib-chroma" ;;
@@ -60,7 +60,7 @@ if [ -n "$legacy" ]; then
   tag_globs+=("refs/tags/${legacy//-/_}-*")
 fi
 
-# Releases ordered by tag date, not by version number: dagster-notdiamond went
+# Releases ordered by tag date, not by version number. dagster-notdiamond went
 # 0.1.2 -> 0.1.3 -> 0.0.3 -> 0.0.4 -> 0.0.5 (see issue #340), so sorting by
 # version would compute every commit range against the wrong predecessor.
 # Where the same version appears under both the old and new prefix it is the

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Generates CHANGELOG sections for a library from its git release tags.
+#
+# For each release of <library>, prints a dated version heading followed by one
+# bullet per commit that touched that library between the previous release and
+# this one. Release chores (version bumps, "Release <pkg> X.X.X") are filtered
+# out, and `[dagster-foo] ` subject prefixes are stripped since the library is
+# implied by the file the entry lives in.
+#
+# Release tags live on GitHub, so fetch them first:
+#
+#     git fetch origin --tags
+#
+# USAGE
+#
+#     ./scripts/generate_changelog.sh dagster-polars            # print to stdout
+#     ./scripts/generate_changelog.sh dagster-polars > out.md   # save for review
+#
+# The output is a starting point for a maintainer to review and reword, not a
+# finished changelog.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <library>" >&2
+  echo "Example: $0 dagster-polars" >&2
+  exit 1
+fi
+
+PACKAGE="$1"
+PACKAGE_DIR="libraries/${PACKAGE}"
+
+if [ ! -d "$PACKAGE_DIR" ]; then
+  echo "ERROR: ${PACKAGE_DIR} does not exist" >&2
+  exit 1
+fi
+
+# Six libraries were renamed out of `dagster-contrib-*` partway through their
+# lives. Their early releases are tagged under the old prefix and their early
+# commits touched the old directory, so both have to be searched or those
+# releases come back empty. The map is deliberately hardcoded rather than
+# derived from `git log --diff-filter=R`: dagster-qdrant is also a rename (of
+# `_template`), and following that would pull unrelated template history in.
+case "$PACKAGE" in
+  dagster-anthropic)  legacy="dagster-contrib-anthropic" ;;
+  dagster-chroma)     legacy="dagster-contrib-chroma" ;;
+  dagster-gemini)     legacy="dagster-contrib-gemini" ;;
+  dagster-modal)      legacy="dagster-contrib-modal" ;;
+  dagster-notdiamond) legacy="dagster-contrib-notdiamond" ;;
+  dagster-weaviate)   legacy="dagster-contrib-weaviate" ;;
+  *)                  legacy="" ;;
+esac
+
+# Paths to search for commits, and tag globs to search for releases.
+paths=("$PACKAGE_DIR")
+tag_globs=("refs/tags/${PACKAGE//-/_}-*")
+if [ -n "$legacy" ]; then
+  paths+=("libraries/${legacy}")
+  tag_globs+=("refs/tags/${legacy//-/_}-*")
+fi
+
+# Releases ordered by tag date, not by version number: dagster-notdiamond went
+# 0.1.2 -> 0.1.3 -> 0.0.3 -> 0.0.4 -> 0.0.5 (see issue #340), so sorting by
+# version would compute every commit range against the wrong predecessor.
+# Where the same version appears under both the old and new prefix it is the
+# same release re-tagged, so the first one seen wins.
+tags=()
+versions=()
+seen=""
+while IFS=' ' read -r _ tag; do
+  version="${tag##*-}"
+  case "$version" in
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *) continue ;;
+  esac
+  case " $seen " in
+    *" $version "*) continue ;;
+  esac
+  seen="$seen $version"
+  tags+=("$tag")
+  versions+=("$version")
+done < <(git for-each-ref --sort=creatordate --format='%(creatordate:unix) %(refname:short)' "${tag_globs[@]}")
+
+if [ "${#versions[@]}" -eq 0 ]; then
+  echo "ERROR: No release tags found for ${PACKAGE}" >&2
+  echo "Did you fetch tags?  git fetch origin --tags" >&2
+  exit 1
+fi
+
+echo "# Changelog"
+echo ""
+echo "All notable changes to this integration will be documented in this file."
+echo ""
+echo "The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)."
+echo ""
+echo "## [Unreleased]"
+
+# Walk newest -> oldest so the changelog reads newest first, while comparing
+# each release against the one that preceded it chronologically.
+for (( i = ${#versions[@]} - 1; i >= 0; i-- )); do
+  version="${versions[$i]}"
+  tag="${tags[$i]}"
+  date=$(git log -1 --format=%ad --date=short "$tag")
+
+  if [ "$i" -gt 0 ]; then
+    range="${tags[$((i - 1))]}..${tag}"
+  else
+    range="$tag"   # first release: everything up to that tag
+  fi
+
+  echo ""
+  echo "## [${version}] - ${date}"
+  echo ""
+
+  entries=$(git log "$range" --no-merges --format='- %s' -- "${paths[@]}" \
+    | grep -viE '^- (\[[^]]*\] *)?(bump |release |prep(are)? release|version bump)' \
+    | sed -E 's/^- \[[^]]*\] */- /' || true)
+
+  if [ -n "$entries" ]; then
+    echo "$entries"
+  else
+    echo "- See the git history for the changes in this release."
+  fi
+done


### PR DESCRIPTION
Closes #340.
Compliments PR #341 and the very old issue #20 
Relies upon #349 which repairs the `dagster-iceberg` test image build

## Summary & Motivation

#### Problem

`release.sh` bumped `__version__` and pushed a tag, but never touched `CHANGELOG.md`. Changelogs only stayed current if a maintainer remembered to edit one by hand. Twelve libraries had no changelog at all, and fifteen more were missing releases.

#### Fix

`release.sh` now updates the library's changelog in the same release commit. It...

- promotes `[Unreleased]` to a dated version heading, and starts a fresh `[Unreleased]` above it
- creates a changelog, with a warning, when the library hasn't got one
- adds a bare dated heading, also with a warning, when there's no `[Unreleased]` to promote

If the changelog already lists the version, the file is left alone, so running the same release twice changes nothing. It also stops with an error when the version file has no `__version__` to rewrite, instead of quietly shipping a version the package never declares.

New `scripts/generate_changelog.sh` rebuilds a library's changelog from its release tags. One dated heading per release, one bullet per commit that touched the library between tags. It picks up the six libraries renamed out of `dagster-contrib-*`, whose early releases are tagged under the old name, and orders releases by tag date rather than version number, since `dagster-notdiamond` shipped 0.1.2 and 0.1.3 before dropping back to 0.0.3.

#### Updates

Every library that had released without recording it now has an entry per release:

- The twelve libraries with no`CHANGELOG.md` now have one
- The fifteen stale ones get only their missing sections slotted in, leaving hand-written entries alone

The generated bullets are just commit subjects. Ideally these should be be checked by the library maintainers and re-written as appropriate.

Two entries are corrections rather than additions:

- `dagster-hex` 0.1.7 was marked "UNRELEASED" with an empty bullet despite shipping on 2025-03-10. It now carries its real date and commits.

- ⚠️ `dagster-notdiamond` now has a note explaining why its releases are listed by date rather than by descending version. The version regressed from 0.1.3 to 0.0.2 in `ca78a07`, and PyPI still serves 0.1.3.  In effect, **dagster-notdiamond's version has gone backwards**


#### Note
This PR ignores `.DS_Store`, which kept turning up as untracked noise across the library directories.

## How I Tested These Changes

`release.sh` only runs at release time, and the rest is documentation. I ran the real script in a throwaway repo pointed at a local remote, so commits, pushes and tags all genuinely ran:

- each of the three changelog states:
    - `[Unreleased]` present: promoted to the new dated heading, with hand-written entries carried across
    - no changelog: one created, with a warning
    - `[Unreleased]` missing: dated heading added with a warning, and the rest of the file untouched
- running a release twice leaves the changelog byte-identical with a clean tree
- the new error case of no `__version__` means no changelog, no commit, no tag, and gives exit 1
- bad version, unknown package, no arguments and too many arguments are all rejected

For the backfill: every release tag now has a matching heading, the generator recovers pre-rename history (`dagster-anthropic` 0.0.1 shows "Add Anthropic Resource (#95)"), and diffing against `main` confirms the fifteen stale files only gained sections. `uvx pre-commit run` passes.

## Changelog

N/A. This is release tooling and the changelog files themselves.