### PR TITLE
Fix dagster-iceberg image build against end-of-life Debian bullseye

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/Dockerfile
+++ b/libraries/dagster-iceberg/kitchen-sink/Dockerfile
@@ -15,8 +15,21 @@
 
 FROM python:3.9-bullseye
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
+# Debian bullseye is end-of-life and mid-archival. Its .deb files have been
+# withdrawn from deb.debian.org, and bullseye-security has not appeared on
+# archive.debian.org yet. Both suites have to stay in play. Security ships
+# newer builds than main (libcurl4 u16 vs u13, openjdk-11 11.0.32 vs 11.0.24),
+# and this base image already has the security ones installed, so main alone
+# leaves apt unable to satisfy them. snapshot.debian.org still serves both at
+# a fixed date, which pins the image to one consistent set. Snapshot Release
+# files are expired by definition, hence Check-Valid-Until.
+RUN printf '%s\n' \
+      'deb http://snapshot.debian.org/archive/debian/20260901T000000Z bullseye main' \
+      'deb http://snapshot.debian.org/archive/debian-security/20260901T000000Z bullseye-security main' \
+      > /etc/apt/sources.list && \
+    rm -f /etc/apt/sources.list.d/*.list && \
+    apt-get -o Acquire::Check-Valid-Until=false -qq update && \
+    apt-get -q install -y --no-install-recommends \
       sudo \
       curl \
       vim \

--- a/libraries/dagster-iceberg/tests/docker/Dockerfile
+++ b/libraries/dagster-iceberg/tests/docker/Dockerfile
@@ -15,8 +15,21 @@
 
 FROM python:3.9-bullseye
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
+# Debian bullseye is end-of-life and mid-archival. Its .deb files have been
+# withdrawn from deb.debian.org, and bullseye-security has not appeared on
+# archive.debian.org yet. Both suites have to stay in play. Security ships
+# newer builds than main (libcurl4 u16 vs u13, openjdk-11 11.0.32 vs 11.0.24),
+# and this base image already has the security ones installed, so main alone
+# leaves apt unable to satisfy them. snapshot.debian.org still serves both at
+# a fixed date, which pins the image to one consistent set. Snapshot Release
+# files are expired by definition, hence Check-Valid-Until.
+RUN printf '%s\n' \
+      'deb http://snapshot.debian.org/archive/debian/20260901T000000Z bullseye main' \
+      'deb http://snapshot.debian.org/archive/debian-security/20260901T000000Z bullseye-security main' \
+      > /etc/apt/sources.list && \
+    rm -f /etc/apt/sources.list.d/*.list && \
+    apt-get -o Acquire::Check-Valid-Until=false -qq update && \
+    apt-get -q install -y --no-install-recommends \
       sudo \
       curl \
       vim \


### PR DESCRIPTION
Contributes to #340. 
This PR needs to land in order for #348 iceberg check to pass.
PR #351 improve the dagster-iceberg test run time which is being fixed here

## Summary & Motivation

The `dagster-iceberg` checks are failing. The `spark-iceberg` test image is built from `python:3.9-bullseye`. Debian bullseye has reached end of life and its packages are mid-archival. The `.deb` files have been pulled from `deb.debian.org`, but `bullseye-security` isn't published on `archive.debian.org` yet either. The index is still served, so apt resolves package versions and then can't download them:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/o/openjdk-11/openjdk-11-jdk_11.0.32.1+1-1~deb11u1_amd64.deb  404  Not Found
```

That fails the image build, so `docker compose up --wait` fails and every test errors at setup. On a recent run all 136 tests errored without a single one executing.

This PR pins both suites to a fixed date on `snapshot.debian.org`, which still serves the withdrawn files. Both suites are needed.  Security ships newer builds than main, so main on its own leaves apt unable to satisfy the security versions already installed in the image.

| package | main | bullseye-security |
|---|---|---|
| `libcurl4` | 7.74.0-1.3+deb11u13 | 7.74.0-1.3+deb11u16 |
| `openjdk-11-jdk` | 11.0.24+8-2~deb11u1 | 11.0.32.1+1-1~deb11u1 |

Moving off bullseye would be the better long term fix, but it isn't like for like. The image installs `openjdk-11-jdk`, which bookworm doesn't carry, so it would change the Spark runtime rather than repair CI.

`kitchen-sink/Dockerfile` has the same block and would break the same way next time it is built, so both are fixed together. `apt-get install` also drops from `-qq` to `-q`, since at `-qq` apt hid which package it couldn't satisfy and made this slow to diagnose.

## How I Tested These Changes

I'm using the CI itself as the test as I don't have Docker locally on this device.

## Changelog

N/A. This repairs the test container build; no integration behaviour changes.
