### PR TITLE
Fix kitchen sink fixture scope

### DIFF
--- a/libraries/dagster-iceberg/kitchen-sink/Dockerfile
+++ b/libraries/dagster-iceberg/kitchen-sink/Dockerfile
@@ -15,8 +15,21 @@
 
 FROM python:3.9-bullseye
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
+# Debian bullseye is end-of-life and mid-archival. Its .deb files have been
+# withdrawn from deb.debian.org, and bullseye-security has not appeared on
+# archive.debian.org yet. Both suites have to stay in play. Security ships
+# newer builds than main (libcurl4 u16 vs u13, openjdk-11 11.0.32 vs 11.0.24),
+# and this base image already has the security ones installed, so main alone
+# leaves apt unable to satisfy them. snapshot.debian.org still serves both at
+# a fixed date, which pins the image to one consistent set. Snapshot Release
+# files are expired by definition, hence Check-Valid-Until.
+RUN printf '%s\n' \
+      'deb http://snapshot.debian.org/archive/debian/20260901T000000Z bullseye main' \
+      'deb http://snapshot.debian.org/archive/debian-security/20260901T000000Z bullseye-security main' \
+      > /etc/apt/sources.list && \
+    rm -f /etc/apt/sources.list.d/*.list && \
+    apt-get -o Acquire::Check-Valid-Until=false -qq update && \
+    apt-get -q install -y --no-install-recommends \
       sudo \
       curl \
       vim \

--- a/libraries/dagster-iceberg/kitchen-sink/compose.yaml
+++ b/libraries/dagster-iceberg/kitchen-sink/compose.yaml
@@ -17,8 +17,8 @@
 
 services:
   spark-iceberg:
-    image: python-integration
-    container_name: pyiceberg-spark
+    image: kitchen-sink-spark
+    container_name: kitchen-sink-spark
     build: .
     networks:
       iceberg_net:

--- a/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
+++ b/libraries/dagster-iceberg/kitchen-sink/tests/test_e2e.py
@@ -10,7 +10,7 @@ from dagster._utils import file_relative_path
 MAKEFILE_DIR = file_relative_path(__file__, "../")
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def _catalog():
     subprocess.run(["make", "catalog"], cwd=MAKEFILE_DIR, check=True)
     subprocess.run(["sleep", "10"])

--- a/libraries/dagster-iceberg/tests/docker/Dockerfile
+++ b/libraries/dagster-iceberg/tests/docker/Dockerfile
@@ -15,8 +15,21 @@
 
 FROM python:3.9-bullseye
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
+# Debian bullseye is end-of-life and mid-archival. Its .deb files have been
+# withdrawn from deb.debian.org, and bullseye-security has not appeared on
+# archive.debian.org yet. Both suites have to stay in play. Security ships
+# newer builds than main (libcurl4 u16 vs u13, openjdk-11 11.0.32 vs 11.0.24),
+# and this base image already has the security ones installed, so main alone
+# leaves apt unable to satisfy them. snapshot.debian.org still serves both at
+# a fixed date, which pins the image to one consistent set. Snapshot Release
+# files are expired by definition, hence Check-Valid-Until.
+RUN printf '%s\n' \
+      'deb http://snapshot.debian.org/archive/debian/20260901T000000Z bullseye main' \
+      'deb http://snapshot.debian.org/archive/debian-security/20260901T000000Z bullseye-security main' \
+      > /etc/apt/sources.list && \
+    rm -f /etc/apt/sources.list.d/*.list && \
+    apt-get -o Acquire::Check-Valid-Until=false -qq update && \
+    apt-get -q install -y --no-install-recommends \
       sudo \
       curl \
       vim \


### PR DESCRIPTION
## Summary & Motivation

The kitchen-sink end to end tests brought their whole Docker stack up and down for every single test. The `_catalog` fixture in `kitchen-sink/tests/test_e2e.py` had no scope set, so for each of the 8 tests it ran `make catalog`, waited a hard coded 10 seconds, then `make down`. Spark, Hive, MinIO and the REST catalog were torn down and rebuilt 8 times, with 80 seconds of sleeping on top. That was most of the `dagster-iceberg` check.

All 8 tests live in one file, so module scope brings the stack up once instead of 8 times.

```python
@pytest.fixture(scope="module", autouse=True)
def _catalog():
```

`module` rather than `session`, because the two stacks cannot be up at the same time. Both this one and the one under `tests/docker` publish 8080, 8888 and 15002, and both suites reach Spark Connect at `sc://localhost`, so each needs port 15002 to itself. `session` scope keeps the kitchen-sink stack up for the whole run and the main suite then cannot start. `module` scope tears it down when the file finishes, which is what the per test teardown was quietly doing before.

This also gives the kitchen-sink stack its own container and image names. Both compose files declared `container_name: pyiceberg-spark` and `image: python-integration`. Container names are global to the Docker daemon, and two different Dockerfiles building to one tag means whichever built last wins. The main suite keeps the old name, since `tests/io_managers/test_spark_io_manager.py` looks its container up by name.

Closes #350.

Stacked on #349, so the diff includes that PR's two Dockerfile changes. Without them the image build fails on withdrawn Debian bullseye packages and the suite never runs. They drop out once #349 merges and this is rebased. #349 stands alone and does not need this PR.

## How I Tested These Changes

CI on this PR is the test.

The check now passes in 8m39s. Previous green run was 13 to 15 minutes, so this is roughly 35% quicker

Sharing one catalog across the 8 tests turned out to be fine. They pass together, and nothing depended on getting a clean catalog each time.

## Changelog

N/A. This changes test setup only, with no effect on the published package.
