### PR TITLE
feat(dagster-openlineage): emit jobType and per-asset ownership facets

### DIFF
--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- **Job type + ownership facets.** Every emitted job carries a `jobType` facet (`integration=DAGSTER`, `processingType=BATCH`), so lineage backends can attribute the pipeline to Dagster rather than a generic fallback. Jobs also carry an optional `ownership` facet: **asset jobs use the asset's own Dagster `owners`** (`team:<team>` / email, passed through per asset), and any job with no per-asset owners — pipeline/step events, or assets that declare none — falls back to a **default team** configured via the `OPENLINEAGE_TEAM` env var or the `team=` adapter argument. No per-asset owners and no default team means no ownership facet.
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-openlineage/README.md
+++ b/libraries/dagster-openlineage/README.md
@@ -9,6 +9,7 @@ Asset-centric OpenLineage emission for Dagster. Emits schema, column-lineage, da
 - **Data quality assertions** placed on `InputDataset` (spec-conformant)
 - **Partition → nominal time** heuristic (ISO date or date-hour)
 - **Multi-tenant namespaces** via string templates (`{namespace}`, `{tag:KEY}`)
+- **Job type + ownership facets** — `jobType` (integration `DAGSTER`) on every job; `ownership` from each asset's native Dagster `owners`, with a configurable default team fallback
 - **Bounded emit** — synchronous, 2s default timeout, retries disabled, failures swallowed
 - **Pipeline / step events** preserved (v0.1 surface unchanged)
 
@@ -102,6 +103,23 @@ Example:
 # Run tags            -> resolved namespace
 {"tenant": "acme"}    -> "dagster/acme"
 {}                    -> "dagster"          # tag unresolved, trailing slash stripped
+```
+
+## Job facets
+
+Every job the adapter emits carries a `jobType` facet with `integration=DAGSTER` and
+`processingType=BATCH` (a Dagster asset run is bounded). Lineage backends use the integration to
+attribute the pipeline to Dagster rather than a generic fallback.
+
+Jobs also carry an `ownership` facet. **Asset jobs use the asset's own Dagster `owners`** —
+`@asset(owners=["team:analytics", "you@example.com"])` — passed through per asset, so different
+assets can be owned by different teams. Any job with no per-asset owners (pipeline/step events, or
+assets that declare none) falls back to a **default team**, set via the `OPENLINEAGE_TEAM`
+environment variable or the `team=` adapter argument. No per-asset owners and no default team → no
+ownership facet.
+
+```bash
+export OPENLINEAGE_TEAM=my-default-team   # fallback for jobs without per-asset owners
 ```
 
 ## Emit path

--- a/libraries/dagster-openlineage/dagster_openlineage/adapter.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/adapter.py
@@ -19,7 +19,11 @@ from openlineage.client.event_v2 import (
     RunState,
     StaticDataset,
 )
-from openlineage.client.facet_v2 import parent_run as parent_run_facet
+from openlineage.client.facet_v2 import (
+    job_type_job,
+    ownership_job,
+    parent_run as parent_run_facet,
+)
 
 from dagster import (
     AssetCheckEvaluation,
@@ -57,6 +61,10 @@ _PRODUCER = (
 
 set_producer(_PRODUCER)
 
+# Constant jobType facet fields. BATCH because an asset run is bounded, not streaming.
+_INTEGRATION = "DAGSTER"
+_PROCESSING_TYPE = "BATCH"
+
 log = logging.getLogger(__name__)
 
 
@@ -73,6 +81,7 @@ class OpenLineageAdapter:
         *,
         namespace: Optional[str] = None,
         namespace_template: Optional[str] = None,
+        team: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         strict_assertion_mapping: bool = False,
         emitter: Optional[OpenLineageEmitter] = None,
@@ -82,6 +91,13 @@ class OpenLineageAdapter:
             parse_namespace_template(namespace_template) if namespace_template else None
         )
         self._strict_assertion_mapping = strict_assertion_mapping
+        # default team (from arg or OPENLINEAGE_TEAM env) for any job with no per-asset owners
+        self._team = team or os.getenv("OPENLINEAGE_TEAM")
+        # jobType is the same for every job; build it once
+        self._job_type_facet = job_type_job.JobTypeJobFacet(
+            processingType=_PROCESSING_TYPE, integration=_INTEGRATION, jobType="JOB"
+        )
+        self._default_owners: List[str] = [f"team:{self._team}"] if self._team else []
         self._client = OpenLineageClient()
         self._emitter = emitter or OpenLineageEmitter(
             timeout=timeout, client=self._client
@@ -258,6 +274,7 @@ class OpenLineageAdapter:
         run_id: str,
         timestamp: float,
         *,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -267,7 +284,9 @@ class OpenLineageAdapter:
                 eventTime=to_utc_iso_8601(timestamp),
                 run=self._build_run(namespace=namespace, run_id=run_id),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=namespace,
+                    job_name=asset_key.to_user_string(),
+                    owners=owners,
                 ),
                 producer=_PRODUCER,
                 outputs=[
@@ -287,6 +306,7 @@ class OpenLineageAdapter:
         metadata: Optional[Mapping[str, Any]] = None,
         upstream_asset_keys: Optional[Sequence[AssetKey]] = None,
         partition_key: Optional[str] = None,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -306,7 +326,9 @@ class OpenLineageAdapter:
                     namespace=namespace, run_id=run_id, run_facets=run_facets
                 ),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=namespace,
+                    job_name=asset_key.to_user_string(),
+                    owners=owners,
                 ),
                 producer=_PRODUCER,
                 inputs=inputs,
@@ -329,6 +351,7 @@ class OpenLineageAdapter:
         error_message: Optional[str] = None,
         stack_trace: Optional[str] = None,
         partition_key: Optional[str] = None,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -345,7 +368,9 @@ class OpenLineageAdapter:
                     namespace=namespace, run_id=run_id, run_facets=run_facets
                 ),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=namespace,
+                    job_name=asset_key.to_user_string(),
+                    owners=owners,
                 ),
                 producer=_PRODUCER,
                 outputs=[
@@ -404,6 +429,7 @@ class OpenLineageAdapter:
         timestamp: float,
         *,
         standalone: bool,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         # Only emit when a check runs in its own job (standalone). When the
@@ -419,7 +445,9 @@ class OpenLineageAdapter:
                 eventType=RunState.START,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=self._build_run(namespace=namespace, run_id=run_id),
-                job=self._build_job(namespace=namespace, job_name=job_name),
+                job=self._build_job(
+                    namespace=namespace, job_name=job_name, owners=owners
+                ),
                 producer=_PRODUCER,
                 inputs=[
                     InputDataset(namespace=namespace, name="/".join(asset_key.path))
@@ -434,6 +462,7 @@ class OpenLineageAdapter:
         run_id: str,
         timestamp: float,
         *,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -458,7 +487,9 @@ class OpenLineageAdapter:
                 eventType=RunState.COMPLETE,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=run,
-                job=self._build_job(namespace=namespace, job_name=job_name),
+                job=self._build_job(
+                    namespace=namespace, job_name=job_name, owners=owners
+                ),
                 producer=_PRODUCER,
                 inputs=[input_ds],
             )
@@ -522,9 +553,22 @@ class OpenLineageAdapter:
             )
         return Run(runId=run_id, facets=facets)
 
-    @staticmethod
-    def _build_job(namespace: str, job_name: str) -> Job:
-        return Job(namespace=namespace, name=job_name, facets={})
+    def _job_facets(self, owners: Optional[Sequence[str]] = None) -> Dict[str, Any]:
+        """Job facets: the constant jobType facet plus an ownership facet. Ownership
+        prefers the passed per-asset ``owners`` and falls back to the default team; an
+        empty result emits no ownership facet."""
+        facets: Dict[str, Any] = {"jobType": self._job_type_facet}
+        effective_owners = list(owners) if owners else self._default_owners
+        if effective_owners:
+            facets["ownership"] = ownership_job.OwnershipJobFacet(
+                owners=[ownership_job.Owner(name=o) for o in effective_owners]
+            )
+        return facets
+
+    def _build_job(
+        self, namespace: str, job_name: str, owners: Optional[Sequence[str]] = None
+    ) -> Job:
+        return Job(namespace=namespace, name=job_name, facets=self._job_facets(owners))
 
 
 def _extract_schema(metadata: Mapping[str, Any]) -> Optional[TableSchema]:

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/conftest.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/conftest.py
@@ -4,6 +4,7 @@
 import time
 from typing import Optional
 
+from openlineage.client.facet_v2 import job_type_job
 from openlineage.client.uuid import generate_new_uuid
 
 from dagster import (
@@ -22,6 +23,14 @@ PRODUCER = (
     f"https://github.com/OpenLineage/OpenLineage/tree/"
     f"{OPENLINEAGE_DAGSTER_VERSION}/integration/dagster"
 )
+
+# every job the adapter emits carries a jobType facet (integration=DAGSTER, BATCH); with no
+# team configured there is no ownership facet.
+DEFAULT_JOB_FACETS = {
+    "jobType": job_type_job.JobTypeJobFacet(
+        processingType="BATCH", integration="DAGSTER", jobType="JOB"
+    )
+}
 
 
 def make_pipeline_run_with_external_pipeline_origin(

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_job_facets.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_job_facets.py
@@ -1,0 +1,90 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+from unittest.mock import patch
+
+from openlineage.client.facet_v2 import job_type_job, ownership_job
+from openlineage.client.uuid import generate_new_uuid
+
+from dagster import AssetKey
+
+from dagster_openlineage.adapter import OpenLineageAdapter
+
+
+def test_jobtype_facet_always_present():
+    facets = OpenLineageAdapter()._job_facets()
+
+    assert facets["jobType"] == job_type_job.JobTypeJobFacet(
+        processingType="BATCH", integration="DAGSTER", jobType="JOB"
+    )
+
+
+def test_no_ownership_without_team_or_owners():
+    assert "ownership" not in OpenLineageAdapter()._job_facets()
+
+
+def test_default_team_ownership_when_no_per_asset_owners():
+    facets = OpenLineageAdapter(team="lakehouse")._job_facets()
+
+    assert facets["ownership"] == ownership_job.OwnershipJobFacet(
+        owners=[ownership_job.Owner(name="team:lakehouse")]
+    )
+
+
+def test_per_asset_owners_override_the_default_team():
+    facets = OpenLineageAdapter(team="lakehouse")._job_facets(
+        owners=["team:calculator", "dan@example.com"]
+    )
+
+    assert facets["ownership"] == ownership_job.OwnershipJobFacet(
+        owners=[
+            ownership_job.Owner(name="team:calculator"),
+            ownership_job.Owner(name="dan@example.com"),
+        ]
+    )
+
+
+def test_per_asset_owners_without_a_default_team():
+    facets = OpenLineageAdapter()._job_facets(owners=["team:calculator"])
+
+    assert facets["ownership"] == ownership_job.OwnershipJobFacet(
+        owners=[ownership_job.Owner(name="team:calculator")]
+    )
+
+
+def test_empty_owners_falls_back_to_default_team():
+    facets = OpenLineageAdapter(team="lakehouse")._job_facets(owners=[])
+
+    assert facets["ownership"].owners[0].name == "team:lakehouse"
+
+
+def test_team_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_TEAM", "calculator")
+
+    facets = OpenLineageAdapter()._job_facets()
+
+    assert facets["ownership"].owners[0].name == "team:calculator"
+
+
+def test_team_argument_takes_precedence_over_env(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_TEAM", "from-env")
+
+    facets = OpenLineageAdapter(team="from-arg")._job_facets()
+
+    assert facets["ownership"].owners[0].name == "team:from-arg"
+
+
+@patch("dagster_openlineage.adapter.OpenLineageClient.emit")
+def test_asset_materialization_threads_owners_onto_the_job(mock_emit):
+    # the owners argument on an asset method reaches the emitted job's ownership facet
+    adapter = OpenLineageAdapter()
+    adapter.asset_materialization(
+        AssetKey(["db.table"]),
+        str(generate_new_uuid()),
+        time.time(),
+        owners=["team:lakehouse"],
+    )
+
+    emitted = mock_emit.call_args[0][0]
+    assert emitted.job.facets == adapter._job_facets(["team:lakehouse"])

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_pipeline.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_pipeline.py
@@ -10,7 +10,7 @@ from openlineage.client.uuid import generate_new_uuid
 
 from dagster_openlineage.adapter import OpenLineageAdapter
 
-from .conftest import PRODUCER
+from .conftest import DEFAULT_JOB_FACETS, PRODUCER
 
 
 @patch("dagster_openlineage.adapter.to_utc_iso_8601")
@@ -32,7 +32,11 @@ def test_start_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.START,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],
@@ -59,7 +63,11 @@ def test_complete_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.COMPLETE,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],
@@ -86,7 +94,11 @@ def test_fail_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.FAIL,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],
@@ -113,7 +125,11 @@ def test_cancel_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.ABORT,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_step.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_step.py
@@ -11,7 +11,7 @@ from openlineage.client.uuid import generate_new_uuid
 
 from dagster_openlineage.adapter import OpenLineageAdapter
 
-from .conftest import PRODUCER
+from .conftest import DEFAULT_JOB_FACETS, PRODUCER
 
 
 def _expected_parent_facet(pipeline_run_id: str, pipeline_name: str):
@@ -50,7 +50,7 @@ def test_start_pipeline(mock_client, mock_to_utc_iso_8601):
             job=Job(
                 namespace=DEFAULT_NAMESPACE_NAME,
                 name=f"{pipeline_name}.{step_key}",
-                facets={},
+                facets=DEFAULT_JOB_FACETS,
             ),
             producer=PRODUCER,
             inputs=[],
@@ -90,7 +90,7 @@ def test_complete_step(mock_client, mock_to_utc_iso_8601):
             job=Job(
                 namespace=DEFAULT_NAMESPACE_NAME,
                 name=f"{pipeline_name}.{step_key}",
-                facets={},
+                facets=DEFAULT_JOB_FACETS,
             ),
             producer=PRODUCER,
             inputs=[],
@@ -128,7 +128,7 @@ def test_fail_step(mock_client, mock_to_utc_iso_8601):
             job=Job(
                 namespace=DEFAULT_NAMESPACE_NAME,
                 name=f"{pipeline_name}.{step_key}",
-                facets={},
+                facets=DEFAULT_JOB_FACETS,
             ),
             producer=PRODUCER,
             inputs=[],


### PR DESCRIPTION
Attach a `jobType` facet and an `ownership` facet to every emitted job.

## Summary & Motivation

Emitted jobs carried neither a `jobType` nor an `ownership` facet, so a lineage backend could not tell that a pipeline was a Dagster job, nor who owned it.

This adds:

- a `jobType` facet (`integration=DAGSTER`, `processingType=BATCH`) on every job, so backends attribute the pipeline to Dagster rather than a generic fallback; and
- an `ownership` facet. The asset-emitting methods take an `owners` argument (the asset's own Dagster `owners` — `team:<team>` / email), so different assets can be owned by different teams. Jobs with no per-asset owners fall back to a default team from `OPENLINEAGE_TEAM` or the `team=` argument; with neither, no ownership facet is emitted.

This lets a backend such as OpenMetadata route the pipeline to its Dagster service and set the pipeline owner from the team. The sensor wires each asset's native `owners` into the `owners` argument in a follow-up (see Related changes). Backward compatible: no owners and no default team reproduces the previous output.

## How I Tested These Changes

- Unit tests: jobType present on every job; per-asset owners override the default team; default-team fallback via `team=` and `OPENLINEAGE_TEAM`; arg-over-env precedence; no owners → no facet; owners threaded onto a real materialization's job.
- `uv run pytest` green; `ruff check`, `ruff format --check`, and `ty check .` clean.
- Tested locally end to end: ingested the emitted OpenLineage events into OpenMetadata and used it to visualise the resulting lineage.

## Changelog

Added a `### Features` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Related changes

Part of a set of small improvements to Dagster → OpenLineage. The lineage-fidelity changes are each independent and mergeable on their own; the ownership pair is stacked (#354 builds on #353).

**Lineage fidelity:**
- #344 — decouple job namespace from dataset namespace
- #345 — emit asset run-start without a placeholder output
- #346 — derive asset inputs from column lineage
- #347 — add `exclude_asset_keys` to the storage wrapper

**Ownership:**
- #353 — emit jobType and per-asset ownership facets
- #354 — read native asset owners in the sensor (builds on #353; until #353 merges its diff includes #353's commit)
