### PR TITLE
feat(dagster-openlineage): read native asset owners in the sensor

### DIFF
--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - **Job type + ownership facets.** Every emitted job carries a `jobType` facet (`integration=DAGSTER`, `processingType=BATCH`), so lineage backends can attribute the pipeline to Dagster rather than a generic fallback. Jobs also carry an optional `ownership` facet: **asset jobs use the asset's own Dagster `owners`** (`team:<team>` / email, passed through per asset), and any job with no per-asset owners — pipeline/step events, or assets that declare none — falls back to a **default team** configured via the `OPENLINEAGE_TEAM` env var or the `team=` adapter argument. No per-asset owners and no default team means no ownership facet.
+- **Sensor: native asset ownership, exclusion, and emission scope.** `openlineage_sensor` now resolves each asset's Dagster `owners` from the code location's asset graph and emits them as the ownership facet — something the storage wrapper cannot do, because materialisation events carry no owners. New options: `exclude_asset_keys` (fnmatch globs, same semantics as the wrapper's) to keep specific assets out of OpenLineage; `emit_pipeline_step_events` (default `True`, preserving v0.1) which, when `False`, emits **asset events only** — mirroring the wrapper's footprint — while still driving failure-synthesis from run-termination events; and `default_status` to set the sensor's `DefaultSensorStatus`.
 
 ## 0.2.0
 

--- a/libraries/dagster-openlineage/CHANGELOG.md
+++ b/libraries/dagster-openlineage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- **Job type + ownership facets.** Every emitted job carries a `jobType` facet (`integration=DAGSTER`, `processingType=BATCH`), so lineage backends can attribute the pipeline to Dagster rather than a generic fallback. Jobs also carry an optional `ownership` facet: **asset jobs use the asset's own Dagster `owners`** (`team:<team>` / email, passed through per asset), and any job with no per-asset owners — pipeline/step events, or assets that declare none — falls back to a **default team** configured via the `OPENLINEAGE_TEAM` env var or the `team=` adapter argument. No per-asset owners and no default team means no ownership facet.
+
 ## 0.2.0
 
 ### Breaking

--- a/libraries/dagster-openlineage/README.md
+++ b/libraries/dagster-openlineage/README.md
@@ -9,6 +9,7 @@ Asset-centric OpenLineage emission for Dagster. Emits schema, column-lineage, da
 - **Data quality assertions** placed on `InputDataset` (spec-conformant)
 - **Partition → nominal time** heuristic (ISO date or date-hour)
 - **Multi-tenant namespaces** via string templates (`{namespace}`, `{tag:KEY}`)
+- **Job type + ownership facets** — `jobType` (integration `DAGSTER`) on every job; `ownership` from each asset's native Dagster `owners`, with a configurable default team fallback
 - **Bounded emit** — synchronous, 2s default timeout, retries disabled, failures swallowed
 - **Pipeline / step events** preserved (v0.1 surface unchanged)
 
@@ -102,6 +103,23 @@ Example:
 # Run tags            -> resolved namespace
 {"tenant": "acme"}    -> "dagster/acme"
 {}                    -> "dagster"          # tag unresolved, trailing slash stripped
+```
+
+## Job facets
+
+Every job the adapter emits carries a `jobType` facet with `integration=DAGSTER` and
+`processingType=BATCH` (a Dagster asset run is bounded). Lineage backends use the integration to
+attribute the pipeline to Dagster rather than a generic fallback.
+
+Jobs also carry an `ownership` facet. **Asset jobs use the asset's own Dagster `owners`** —
+`@asset(owners=["team:analytics", "you@example.com"])` — passed through per asset, so different
+assets can be owned by different teams. Any job with no per-asset owners (pipeline/step events, or
+assets that declare none) falls back to a **default team**, set via the `OPENLINEAGE_TEAM`
+environment variable or the `team=` adapter argument. No per-asset owners and no default team → no
+ownership facet.
+
+```bash
+export OPENLINEAGE_TEAM=my-default-team   # fallback for jobs without per-asset owners
 ```
 
 ## Emit path

--- a/libraries/dagster-openlineage/README.md
+++ b/libraries/dagster-openlineage/README.md
@@ -70,20 +70,34 @@ Set `OPENLINEAGE_URL` (and optionally `OPENLINEAGE_API_KEY`) in the environment 
 Add `openlineage_sensor(include_asset_events=True)` to your `Definitions`. v0.2 keeps `include_asset_events=False` as the default (v0.1 parity); v0.3 will flip it.
 
 ```python
-from dagster import Definitions
+from dagster import DefaultSensorStatus, Definitions
 from dagster_openlineage import openlineage_sensor
 
 defs = Definitions(
     assets=[...],
-    sensors=[openlineage_sensor(include_asset_events=True)],
+    sensors=[
+        openlineage_sensor(
+            include_asset_events=True,
+            # optional:
+            # exclude_asset_keys=["*dbt*"],       # keep matching assets out of OL (fnmatch globs)
+            # emit_pipeline_step_events=False,    # asset-only emission (mirror the storage wrapper)
+            # default_status=DefaultSensorStatus.RUNNING,
+        )
+    ],
 )
 ```
+
+Unlike the storage wrapper, the sensor can read each asset's native Dagster `owners`
+(`@asset(owners=["team:analytics"])`) from the asset graph and emit them as the ownership facet —
+the wrapper only sees the runtime event, which carries no owners. So **per-asset ownership is
+sensor-only**; under the wrapper every job gets the single default team.
 
 Environment variables go on the process that runs the Dagster daemon:
 
 - `OPENLINEAGE_URL` (required)
 - `OPENLINEAGE_API_KEY` (optional)
 - `OPENLINEAGE_NAMESPACE` (optional, default `dagster`)
+- `OPENLINEAGE_TEAM` (optional — default team for jobs without per-asset owners)
 
 ## Namespace templates
 

--- a/libraries/dagster-openlineage/dagster_openlineage/adapter.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/adapter.py
@@ -19,7 +19,11 @@ from openlineage.client.event_v2 import (
     RunState,
     StaticDataset,
 )
-from openlineage.client.facet_v2 import parent_run as parent_run_facet
+from openlineage.client.facet_v2 import (
+    job_type_job,
+    ownership_job,
+    parent_run as parent_run_facet,
+)
 
 from dagster import (
     AssetCheckEvaluation,
@@ -57,6 +61,10 @@ _PRODUCER = (
 
 set_producer(_PRODUCER)
 
+# Constant jobType facet fields. BATCH because an asset run is bounded, not streaming.
+_INTEGRATION = "DAGSTER"
+_PROCESSING_TYPE = "BATCH"
+
 log = logging.getLogger(__name__)
 
 
@@ -73,6 +81,7 @@ class OpenLineageAdapter:
         *,
         namespace: Optional[str] = None,
         namespace_template: Optional[str] = None,
+        team: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         strict_assertion_mapping: bool = False,
         emitter: Optional[OpenLineageEmitter] = None,
@@ -82,6 +91,13 @@ class OpenLineageAdapter:
             parse_namespace_template(namespace_template) if namespace_template else None
         )
         self._strict_assertion_mapping = strict_assertion_mapping
+        # default team (from arg or OPENLINEAGE_TEAM env) for any job with no per-asset owners
+        self._team = team or os.getenv("OPENLINEAGE_TEAM")
+        # jobType is the same for every job; build it once
+        self._job_type_facet = job_type_job.JobTypeJobFacet(
+            processingType=_PROCESSING_TYPE, integration=_INTEGRATION, jobType="JOB"
+        )
+        self._default_owners: List[str] = [f"team:{self._team}"] if self._team else []
         self._client = OpenLineageClient()
         self._emitter = emitter or OpenLineageEmitter(
             timeout=timeout, client=self._client
@@ -258,6 +274,7 @@ class OpenLineageAdapter:
         run_id: str,
         timestamp: float,
         *,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -267,7 +284,9 @@ class OpenLineageAdapter:
                 eventTime=to_utc_iso_8601(timestamp),
                 run=self._build_run(namespace=namespace, run_id=run_id),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=namespace,
+                    job_name=asset_key.to_user_string(),
+                    owners=owners,
                 ),
                 producer=_PRODUCER,
                 outputs=[
@@ -287,6 +306,7 @@ class OpenLineageAdapter:
         metadata: Optional[Mapping[str, Any]] = None,
         upstream_asset_keys: Optional[Sequence[AssetKey]] = None,
         partition_key: Optional[str] = None,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -306,7 +326,9 @@ class OpenLineageAdapter:
                     namespace=namespace, run_id=run_id, run_facets=run_facets
                 ),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=namespace,
+                    job_name=asset_key.to_user_string(),
+                    owners=owners,
                 ),
                 producer=_PRODUCER,
                 inputs=inputs,
@@ -329,6 +351,7 @@ class OpenLineageAdapter:
         error_message: Optional[str] = None,
         stack_trace: Optional[str] = None,
         partition_key: Optional[str] = None,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -345,7 +368,9 @@ class OpenLineageAdapter:
                     namespace=namespace, run_id=run_id, run_facets=run_facets
                 ),
                 job=self._build_job(
-                    namespace=namespace, job_name=asset_key.to_user_string()
+                    namespace=namespace,
+                    job_name=asset_key.to_user_string(),
+                    owners=owners,
                 ),
                 producer=_PRODUCER,
                 outputs=[
@@ -404,6 +429,7 @@ class OpenLineageAdapter:
         timestamp: float,
         *,
         standalone: bool,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         # Only emit when a check runs in its own job (standalone). When the
@@ -419,7 +445,9 @@ class OpenLineageAdapter:
                 eventType=RunState.START,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=self._build_run(namespace=namespace, run_id=run_id),
-                job=self._build_job(namespace=namespace, job_name=job_name),
+                job=self._build_job(
+                    namespace=namespace, job_name=job_name, owners=owners
+                ),
                 producer=_PRODUCER,
                 inputs=[
                     InputDataset(namespace=namespace, name="/".join(asset_key.path))
@@ -434,6 +462,7 @@ class OpenLineageAdapter:
         run_id: str,
         timestamp: float,
         *,
+        owners: Optional[Sequence[str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ) -> None:
         namespace = self._resolve_namespace(run_tags)
@@ -458,7 +487,9 @@ class OpenLineageAdapter:
                 eventType=RunState.COMPLETE,
                 eventTime=to_utc_iso_8601(timestamp),
                 run=run,
-                job=self._build_job(namespace=namespace, job_name=job_name),
+                job=self._build_job(
+                    namespace=namespace, job_name=job_name, owners=owners
+                ),
                 producer=_PRODUCER,
                 inputs=[input_ds],
             )
@@ -522,9 +553,22 @@ class OpenLineageAdapter:
             )
         return Run(runId=run_id, facets=facets)
 
-    @staticmethod
-    def _build_job(namespace: str, job_name: str) -> Job:
-        return Job(namespace=namespace, name=job_name, facets={})
+    def _job_facets(self, owners: Optional[Sequence[str]] = None) -> Dict[str, Any]:
+        """Job facets: the constant jobType facet plus an ownership facet. Ownership
+        prefers the passed per-asset ``owners`` and falls back to the default team; an
+        empty result emits no ownership facet."""
+        facets: Dict[str, Any] = {"jobType": self._job_type_facet}
+        effective_owners = list(owners) if owners else self._default_owners
+        if effective_owners:
+            facets["ownership"] = ownership_job.OwnershipJobFacet(
+                owners=[ownership_job.Owner(name=o) for o in effective_owners]
+            )
+        return facets
+
+    def _build_job(
+        self, namespace: str, job_name: str, owners: Optional[Sequence[str]] = None
+    ) -> Job:
+        return Job(namespace=namespace, name=job_name, facets=self._job_facets(owners))
 
 
 def _extract_schema(metadata: Mapping[str, Any]) -> Optional[TableSchema]:

--- a/libraries/dagster-openlineage/dagster_openlineage/sensor.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/sensor.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import dagster
-from dagster import AssetKey
+from dagster import AssetKey, DefaultSensorStatus
 
 from dagster_openlineage.adapter import OpenLineageAdapter
 from dagster_openlineage.compat import (
@@ -21,6 +21,8 @@ from dagster_openlineage.cursor import (
     RunningStep,
 )
 from dagster_openlineage.utils import (
+    asset_key_matches_globs,
+    asset_key_of_event_data,
     get_event_log_records,
     get_repository_name,
     make_step_run_id,
@@ -86,6 +88,9 @@ def openlineage_sensor(
     record_filter_limit: Optional[int] = 30,
     after_storage_id: Optional[int] = 0,
     include_asset_events: bool = False,
+    exclude_asset_keys: Optional[Iterable[str]] = None,
+    emit_pipeline_step_events: bool = True,
+    default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
 ) -> SensorDefinition:
     """Build the OpenLineage sensor.
 
@@ -95,8 +100,23 @@ def openlineage_sensor(
     the opt-in switch per the v0.2 plan; a one-shot WARN at sensor
     construction reminds operators to configure at most one mechanism.
 
+    ``exclude_asset_keys`` is a list of fnmatch glob patterns matched against
+    ``AssetKey.to_user_string()``; matching assets are skipped entirely (no OL
+    events, no failure-synthesis tracking). Same semantics as the storage
+    wrapper's ``exclude_asset_keys`` — useful when a dedicated connector owns an
+    asset's lineage better than OpenLineage does.
+
+    ``emit_pipeline_step_events`` (default ``True``, preserving v0.1 behaviour)
+    controls whether pipeline/step run events are emitted as OL events. Set it to
+    ``False`` for asset-only emission that mirrors the storage wrapper's footprint
+    (which never emitted pipeline/step events): run-termination events are still
+    observed to drive failure-synthesis, but no pipeline/step OL events are sent.
+    Pair with ``include_asset_events=True``.
+
     v0.3 will flip the default to ``True``.
     """
+    _excluded_keys: Set[str] = set(exclude_asset_keys or [])
+
     if concerned_event_types is None:
         filter_set = set(PIPELINE_EVENTS) | set(STEP_EVENTS)
         if include_asset_events:
@@ -116,6 +136,7 @@ def openlineage_sensor(
         name=name,
         minimum_interval_seconds=minimum_interval_seconds,
         description=description,
+        default_status=default_status,
     )
     def _openlineage_sensor(context: SensorEvaluationContext):
         # Runtime duplicate-mechanism guard: if OpenLineageEventLogStorage is
@@ -140,6 +161,32 @@ def openlineage_sensor(
                     _process_asset = False
             except Exception:
                 pass  # cannot determine storage type; proceed as configured
+
+        # Resolve the asset graph once per tick to read each asset's declared `owners`.
+        # Only the sensor can do this — the event stream carries no owners. Falls back to
+        # the adapter's default team when the graph or an asset's owners are unavailable.
+        _asset_graph = None
+        if _process_asset:
+            try:
+                _repo_def = getattr(context, "repository_def", None)
+                _asset_graph = getattr(_repo_def, "asset_graph", None)
+            except Exception:
+                _asset_graph = None
+            if _asset_graph is None:
+                log.warning(
+                    "openlineage_sensor: no repository asset graph on the sensor "
+                    "context; asset owners fall back to the default team."
+                )
+
+        def _owners_for(asset_key: AssetKey) -> Optional[List[str]]:
+            if _asset_graph is None:
+                return None
+            try:
+                node = _asset_graph.get(asset_key)
+            except Exception:
+                return None
+            owners = list(getattr(node, "owners", []) or []) if node is not None else []
+            return owners or None
 
         ol_cursor = (
             OpenLineageCursor.from_json(context.cursor)
@@ -182,6 +229,8 @@ def openlineage_sensor(
                             pipeline_run_id,
                             timestamp,
                             entry,
+                            excluded=_excluded_keys,
+                            owner_resolver=_owners_for,
                         )
                     elif dagster_event_type in PIPELINE_EVENTS:
                         # Drain synthesis BEFORE the pipeline handler so the
@@ -196,16 +245,25 @@ def openlineage_sensor(
                                 pipeline_run_id,
                                 timestamp,
                                 terminal=False,
+                                owner_resolver=_owners_for,
                             )
-                        _handle_pipeline_event(
-                            running_pipelines,
-                            dagster_event_type,
-                            pipeline_name or "",
-                            pipeline_run_id,
-                            timestamp,
-                            repository_name,
-                        )
+                        # synthesis (drain above) still runs; only the pipeline OL
+                        # event is suppressed in asset-only mode
+                        if emit_pipeline_step_events:
+                            _handle_pipeline_event(
+                                running_pipelines,
+                                dagster_event_type,
+                                pipeline_name or "",
+                                pipeline_run_id,
+                                timestamp,
+                                repository_name,
+                            )
                     elif dagster_event_type in STEP_EVENTS:
+                        if not emit_pipeline_step_events:
+                            # asset-only mode: skip step OL events (asset events are
+                            # handled by the first branch above)
+                            last_storage_id = record.storage_id
+                            continue
                         if pipeline_name is None or step_key is None:
                             # Step events should always carry both; skip
                             # defensively when Dagster surfaces unexpected
@@ -331,9 +389,31 @@ def _handle_asset_event(
     pipeline_run_id: str,
     timestamp: float,
     entry: Any,
+    *,
+    excluded: Optional[Set[str]] = None,
+    owner_resolver: Optional[Callable[[AssetKey], Optional[List[str]]]] = None,
 ):
     dagster_event = entry.get_dagster_event()
     data = dagster_event.event_specific_data
+
+    # Exclusion first: an excluded asset is entirely invisible to OL — no event and,
+    # crucially, no failure-synthesis tracking below. Matches the wrapper's ordering.
+    asset_key = asset_key_of_event_data(data, dagster_event_type)
+    if (
+        asset_key is not None
+        and excluded
+        and asset_key_matches_globs(asset_key, excluded)
+    ):
+        return
+
+    # per-asset owners for the job's ownership facet; None → adapter default team.
+    # (observations emit a DatasetEvent with no job, so owners don't apply there)
+    owners = (
+        owner_resolver(asset_key)
+        if owner_resolver is not None and asset_key is not None
+        else None
+    )
+
     # LRU: delete-then-reinsert so this run moves to the most-recently-used
     # position. setdefault would leave existing keys at their original slot.
     running_pipeline = running_pipelines.pop(pipeline_run_id, None) or RunningPipeline()
@@ -341,13 +421,13 @@ def _handle_asset_event(
     planned_paths: Set[Tuple[str, ...]] = running_pipeline.planned_asset_paths
 
     if dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED:
-        asset_key = data.asset_key
         planned_paths.add(tuple(asset_key.path))
-        _ADAPTER.asset_materialization_planned(asset_key, pipeline_run_id, timestamp)
+        _ADAPTER.asset_materialization_planned(
+            asset_key, pipeline_run_id, timestamp, owners=owners
+        )
 
     elif dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION:
         mat = data.materialization
-        asset_key = mat.asset_key
         planned_paths.discard(tuple(asset_key.path))
         _ADAPTER.asset_materialization(
             asset_key,
@@ -355,16 +435,17 @@ def _handle_asset_event(
             timestamp,
             metadata=mat.metadata,
             partition_key=mat.partition,
+            owners=owners,
         )
 
     elif dagster_event_type == DagsterEventType.ASSET_FAILED_TO_MATERIALIZE:
-        asset_key = data.asset_key
         planned_paths.discard(tuple(asset_key.path))
         _ADAPTER.asset_failed_to_materialize(
             asset_key,
             pipeline_run_id,
             timestamp,
             partition_key=data.partition,
+            owners=owners,
         )
 
     elif dagster_event_type == DagsterEventType.ASSET_OBSERVATION:
@@ -379,19 +460,21 @@ def _handle_asset_event(
 
     elif dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED:
         _ADAPTER.asset_check_evaluation_planned(
-            data.asset_key,
+            asset_key,
             check_name=data.check_name,
             run_id=pipeline_run_id,
             timestamp=timestamp,
             standalone=True,
+            owners=owners,
         )
 
     elif dagster_event_type == DagsterEventType.ASSET_CHECK_EVALUATION:
         _ADAPTER.asset_check_evaluation(
-            data.asset_key,
+            asset_key,
             [data],
             run_id=pipeline_run_id,
             timestamp=timestamp,
+            owners=owners,
         )
 
 
@@ -401,17 +484,21 @@ def _drain_planned_as_failures(
     timestamp: float,
     *,
     terminal: bool,
+    owner_resolver: Optional[Callable[[AssetKey], Optional[List[str]]]] = None,
 ) -> None:
     running_pipeline = running_pipelines.get(pipeline_run_id)
     if running_pipeline is None:
         return
     remaining = running_pipeline.planned_asset_paths
     for path in list(remaining):
+        asset_key = AssetKey(list(path))
+        owners = owner_resolver(asset_key) if owner_resolver is not None else None
         _ADAPTER.asset_failed_to_materialize(
-            AssetKey(list(path)),
+            asset_key,
             pipeline_run_id,
             timestamp,
             error_message="asset planned for run, run ended before materialization",
+            owners=owners,
         )
     running_pipeline.planned_asset_paths = set()
     if terminal:

--- a/libraries/dagster-openlineage/dagster_openlineage/utils.py
+++ b/libraries/dagster-openlineage/dagster_openlineage/utils.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from typing import Iterable, Optional, Set, Union
 
 from openlineage.client.uuid import generate_new_uuid
 
-from dagster import DagsterInstance, EventLogRecord, EventRecordsFilter
+from dagster import AssetKey, DagsterInstance, EventLogRecord, EventRecordsFilter
 from dagster_openlineage.compat import (
     SensorDefinition,  # noqa: F401
     DagsterEventType,
@@ -32,6 +33,37 @@ def to_utc_iso_8601(timestamp: float) -> str:
     return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime(
         NOMINAL_TIME_FORMAT
     )
+
+
+def asset_key_matches_globs(asset_key: AssetKey, patterns: Iterable[str]) -> bool:
+    """True if the asset key's user string matches any fnmatch glob pattern.
+
+    Shared by the wrapper and the sensor so both apply ``exclude_asset_keys``
+    identically. Each pattern is fnmatch (``*``, ``?``, ``[seq]``); a plain string with
+    no wildcards is an exact match.
+    """
+    key = asset_key.to_user_string()
+    return any(fnmatch(key, pattern) for pattern in patterns)
+
+
+def asset_key_of_event_data(
+    data: "Any", etype: "DagsterEventType"
+) -> Optional[AssetKey]:
+    """Resolve the AssetKey for an asset-scoped event's ``event_specific_data``
+    (None for run-level events). Extraction differs per event type. Shared by both
+    mechanisms so exclusion/owner resolution key off the same asset key."""
+    if etype == DagsterEventType.ASSET_MATERIALIZATION:
+        return data.materialization.asset_key
+    if etype == DagsterEventType.ASSET_OBSERVATION:
+        return data.asset_observation.asset_key
+    if etype in (
+        DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+        DagsterEventType.ASSET_FAILED_TO_MATERIALIZE,
+        DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
+        DagsterEventType.ASSET_CHECK_EVALUATION,
+    ):
+        return getattr(data, "asset_key", None)
+    return None
 
 
 def make_step_run_id() -> str:

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/conftest.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/conftest.py
@@ -4,6 +4,7 @@
 import time
 from typing import Optional
 
+from openlineage.client.facet_v2 import job_type_job
 from openlineage.client.uuid import generate_new_uuid
 
 from dagster import (
@@ -22,6 +23,14 @@ PRODUCER = (
     f"https://github.com/OpenLineage/OpenLineage/tree/"
     f"{OPENLINEAGE_DAGSTER_VERSION}/integration/dagster"
 )
+
+# every job the adapter emits carries a jobType facet (integration=DAGSTER, BATCH); with no
+# team configured there is no ownership facet.
+DEFAULT_JOB_FACETS = {
+    "jobType": job_type_job.JobTypeJobFacet(
+        processingType="BATCH", integration="DAGSTER", jobType="JOB"
+    )
+}
 
 
 def make_pipeline_run_with_external_pipeline_origin(

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_job_facets.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_job_facets.py
@@ -1,0 +1,90 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+from unittest.mock import patch
+
+from openlineage.client.facet_v2 import job_type_job, ownership_job
+from openlineage.client.uuid import generate_new_uuid
+
+from dagster import AssetKey
+
+from dagster_openlineage.adapter import OpenLineageAdapter
+
+
+def test_jobtype_facet_always_present():
+    facets = OpenLineageAdapter()._job_facets()
+
+    assert facets["jobType"] == job_type_job.JobTypeJobFacet(
+        processingType="BATCH", integration="DAGSTER", jobType="JOB"
+    )
+
+
+def test_no_ownership_without_team_or_owners():
+    assert "ownership" not in OpenLineageAdapter()._job_facets()
+
+
+def test_default_team_ownership_when_no_per_asset_owners():
+    facets = OpenLineageAdapter(team="lakehouse")._job_facets()
+
+    assert facets["ownership"] == ownership_job.OwnershipJobFacet(
+        owners=[ownership_job.Owner(name="team:lakehouse")]
+    )
+
+
+def test_per_asset_owners_override_the_default_team():
+    facets = OpenLineageAdapter(team="lakehouse")._job_facets(
+        owners=["team:calculator", "dan@example.com"]
+    )
+
+    assert facets["ownership"] == ownership_job.OwnershipJobFacet(
+        owners=[
+            ownership_job.Owner(name="team:calculator"),
+            ownership_job.Owner(name="dan@example.com"),
+        ]
+    )
+
+
+def test_per_asset_owners_without_a_default_team():
+    facets = OpenLineageAdapter()._job_facets(owners=["team:calculator"])
+
+    assert facets["ownership"] == ownership_job.OwnershipJobFacet(
+        owners=[ownership_job.Owner(name="team:calculator")]
+    )
+
+
+def test_empty_owners_falls_back_to_default_team():
+    facets = OpenLineageAdapter(team="lakehouse")._job_facets(owners=[])
+
+    assert facets["ownership"].owners[0].name == "team:lakehouse"
+
+
+def test_team_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_TEAM", "calculator")
+
+    facets = OpenLineageAdapter()._job_facets()
+
+    assert facets["ownership"].owners[0].name == "team:calculator"
+
+
+def test_team_argument_takes_precedence_over_env(monkeypatch):
+    monkeypatch.setenv("OPENLINEAGE_TEAM", "from-env")
+
+    facets = OpenLineageAdapter(team="from-arg")._job_facets()
+
+    assert facets["ownership"].owners[0].name == "team:from-arg"
+
+
+@patch("dagster_openlineage.adapter.OpenLineageClient.emit")
+def test_asset_materialization_threads_owners_onto_the_job(mock_emit):
+    # the owners argument on an asset method reaches the emitted job's ownership facet
+    adapter = OpenLineageAdapter()
+    adapter.asset_materialization(
+        AssetKey(["db.table"]),
+        str(generate_new_uuid()),
+        time.time(),
+        owners=["team:lakehouse"],
+    )
+
+    emitted = mock_emit.call_args[0][0]
+    assert emitted.job.facets == adapter._job_facets(["team:lakehouse"])

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_pipeline.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_pipeline.py
@@ -10,7 +10,7 @@ from openlineage.client.uuid import generate_new_uuid
 
 from dagster_openlineage.adapter import OpenLineageAdapter
 
-from .conftest import PRODUCER
+from .conftest import DEFAULT_JOB_FACETS, PRODUCER
 
 
 @patch("dagster_openlineage.adapter.to_utc_iso_8601")
@@ -32,7 +32,11 @@ def test_start_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.START,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],
@@ -59,7 +63,11 @@ def test_complete_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.COMPLETE,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],
@@ -86,7 +94,11 @@ def test_fail_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.FAIL,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],
@@ -113,7 +125,11 @@ def test_cancel_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
             eventType=RunState.ABORT,
             eventTime=event_time,
             run=Run(runId=pipeline_run_id, facets={}),
-            job=Job(namespace=DEFAULT_NAMESPACE_NAME, name=pipeline_name, facets={}),
+            job=Job(
+                namespace=DEFAULT_NAMESPACE_NAME,
+                name=pipeline_name,
+                facets=DEFAULT_JOB_FACETS,
+            ),
             producer=PRODUCER,
             inputs=[],
             outputs=[],

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_step.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_adapter_step.py
@@ -11,7 +11,7 @@ from openlineage.client.uuid import generate_new_uuid
 
 from dagster_openlineage.adapter import OpenLineageAdapter
 
-from .conftest import PRODUCER
+from .conftest import DEFAULT_JOB_FACETS, PRODUCER
 
 
 def _expected_parent_facet(pipeline_run_id: str, pipeline_name: str):
@@ -50,7 +50,7 @@ def test_start_pipeline(mock_client, mock_to_utc_iso_8601):
             job=Job(
                 namespace=DEFAULT_NAMESPACE_NAME,
                 name=f"{pipeline_name}.{step_key}",
-                facets={},
+                facets=DEFAULT_JOB_FACETS,
             ),
             producer=PRODUCER,
             inputs=[],
@@ -90,7 +90,7 @@ def test_complete_step(mock_client, mock_to_utc_iso_8601):
             job=Job(
                 namespace=DEFAULT_NAMESPACE_NAME,
                 name=f"{pipeline_name}.{step_key}",
-                facets={},
+                facets=DEFAULT_JOB_FACETS,
             ),
             producer=PRODUCER,
             inputs=[],
@@ -128,7 +128,7 @@ def test_fail_step(mock_client, mock_to_utc_iso_8601):
             job=Job(
                 namespace=DEFAULT_NAMESPACE_NAME,
                 name=f"{pipeline_name}.{step_key}",
-                facets={},
+                facets=DEFAULT_JOB_FACETS,
             ),
             producer=PRODUCER,
             inputs=[],

--- a/libraries/dagster-openlineage/dagster_openlineage_tests/test_sensor_asset_ownership.py
+++ b/libraries/dagster-openlineage/dagster_openlineage_tests/test_sensor_asset_ownership.py
@@ -1,0 +1,177 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+# ty: ignore
+# OpenLineage facet values are a dynamic union; ty cannot see `.owners` on the
+# resolved ownership facet, and Job.facets is Optional. Asserted at runtime instead.
+
+"""Mechanism B (sensor): per-asset ownership, exclusion, and emission-scope.
+
+Exercises the sensor against a real event log (populated by materialize()) with
+FakeOpenLineageTransport capturing emitted events. Covers the behaviour the
+storage wrapper cannot provide — reading each asset's native Dagster ``owners``
+from the asset graph — plus exclusion and asset-only emission parity.
+"""
+
+import tempfile
+from unittest.mock import patch
+
+from dagster import (
+    AssetKey,
+    DefaultSensorStatus,
+    Definitions,
+    asset,
+    build_sensor_context,
+    materialize,
+)
+from dagster._core.test_utils import instance_for_test
+from openlineage.client import OpenLineageClient
+from openlineage.client.event_v2 import RunState
+
+from dagster_openlineage.adapter import OpenLineageAdapter
+from dagster_openlineage.emitter import OpenLineageEmitter
+from dagster_openlineage.sensor import openlineage_sensor
+
+from .fakes import FakeOpenLineageTransport
+
+
+@asset(key=AssetKey(["shop.orders"]), owners=["team:analytics", "dev@example.com"])
+def _owned_orders():
+    return 1
+
+
+@asset(key=AssetKey(["shop.model_dbt"]))
+def _dbt_like():
+    return 2
+
+
+def _sqlite_overrides(temp_dir: str) -> dict:
+    return {
+        "event_log_storage": {
+            "module": "dagster._core.storage.event_log",
+            "class": "ConsolidatedSqliteEventLogStorage",
+            "config": {"base_dir": temp_dir},
+        },
+    }
+
+
+def _drain(sensor, context) -> None:
+    prev_cursor = None
+    while True:
+        sensor.evaluate_tick(context)
+        if context.cursor == prev_cursor:
+            break
+        prev_cursor = context.cursor
+
+
+def _run(assets, sensor, *, with_repository: bool):
+    """Materialise ``assets`` then drain ``sensor`` over the event log; return the
+    capturing transport. ``with_repository`` decides whether the sensor context
+    exposes the asset graph (the source of native owners)."""
+    transport = FakeOpenLineageTransport()
+    adapter = OpenLineageAdapter(
+        emitter=OpenLineageEmitter(client=OpenLineageClient(transport=transport))
+    )
+    defs = Definitions(assets=assets)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(
+            temp_dir=temp_dir, overrides=_sqlite_overrides(temp_dir)
+        ) as instance:
+            assert materialize(assets, instance=instance).success
+            context = build_sensor_context(
+                instance=instance,
+                repository_def=defs.get_repository_def() if with_repository else None,
+            )
+            with patch("dagster_openlineage.sensor._ADAPTER", adapter):
+                _drain(sensor, context)
+    return transport
+
+
+def _job_names(transport) -> set:
+    events = transport.run_events_of_type(RunState.START) + (
+        transport.run_events_of_type(RunState.COMPLETE)
+    )
+    return {e.job.name for e in events}
+
+
+def _ownership(transport, job_name: str):
+    for e in transport.run_events_of_type(RunState.COMPLETE):
+        if e.job.name == job_name:
+            facet = (e.job.facets or {}).get("ownership")
+            return [o.name for o in facet.owners] if facet else []
+    raise AssertionError(f"no COMPLETE event for job {job_name}")
+
+
+def test_sensor_emits_native_asset_owners():
+    sensor = openlineage_sensor(
+        include_asset_events=True, emit_pipeline_step_events=False
+    )
+    transport = _run([_owned_orders], sensor, with_repository=True)
+
+    assert _ownership(transport, "shop.orders") == ["team:analytics", "dev@example.com"]
+
+
+def test_sensor_owners_fall_back_to_default_team_without_repository():
+    # no asset graph on the context -> owners can't be resolved, so the adapter's
+    # default team is used instead
+    transport = FakeOpenLineageTransport()
+    adapter = OpenLineageAdapter(
+        team="fallback",
+        emitter=OpenLineageEmitter(client=OpenLineageClient(transport=transport)),
+    )
+    defs = Definitions(assets=[_owned_orders])
+    _ = defs
+    sensor = openlineage_sensor(
+        include_asset_events=True, emit_pipeline_step_events=False
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(
+            temp_dir=temp_dir, overrides=_sqlite_overrides(temp_dir)
+        ) as instance:
+            assert materialize([_owned_orders], instance=instance).success
+            context = build_sensor_context(instance=instance)
+            with patch("dagster_openlineage.sensor._ADAPTER", adapter):
+                _drain(sensor, context)
+
+    assert _ownership(transport, "shop.orders") == ["team:fallback"]
+
+
+def test_sensor_excludes_asset_keys():
+    sensor = openlineage_sensor(
+        include_asset_events=True,
+        exclude_asset_keys=["*dbt*"],
+        emit_pipeline_step_events=False,
+    )
+    transport = _run([_owned_orders, _dbt_like], sensor, with_repository=True)
+
+    names = _job_names(transport)
+    assert "shop.orders" in names
+    assert "shop.model_dbt" not in names
+
+
+def test_sensor_asset_only_emits_no_pipeline_or_step_events():
+    sensor = openlineage_sensor(
+        include_asset_events=True, emit_pipeline_step_events=False
+    )
+    transport = _run([_owned_orders], sensor, with_repository=True)
+
+    # only the asset job appears — no pipeline (`__ASSET_JOB…`) or step (`….<step>`) jobs
+    assert _job_names(transport) == {"shop.orders"}
+
+
+def test_sensor_default_emits_pipeline_and_step_events():
+    sensor = openlineage_sensor(include_asset_events=True)  # emit flag defaults True
+    transport = _run([_owned_orders], sensor, with_repository=True)
+
+    names = _job_names(transport)
+    assert "shop.orders" in names
+    # at least one non-asset (pipeline/step) job is present in default mode
+    assert any(n != "shop.orders" for n in names)
+
+
+def test_default_status_passthrough():
+    assert openlineage_sensor().default_status == DefaultSensorStatus.STOPPED
+    assert (
+        openlineage_sensor(default_status=DefaultSensorStatus.RUNNING).default_status
+        == DefaultSensorStatus.RUNNING
+    )


### PR DESCRIPTION
> **Builds on #353** ([dagster-io/community-integrations#353](https://github.com/dagster-io/community-integrations/pull/353)) — please review that first. This branch is stacked on it, so until #353 merges the diff below includes #353's commit.

Read each asset's native Dagster `owners` in the sensor, and add asset exclusion and asset-only emission.

## Summary & Motivation

#353 gives the adapter an `owners` argument, but nothing populates it — the storage wrapper only sees the runtime event, which carries no owners. Only the sensor can reach the asset graph, so this wires the sensor to read each asset's declared `owners` and emit them as the per-asset ownership facet. That is what lets a backend such as OpenMetadata show each pipeline's owner as the asset's own team, rather than one team for a whole deployment.

It also adds two options to `openlineage_sensor`:

- `exclude_asset_keys` — fnmatch globs that keep matching assets out of OpenLineage entirely (same semantics as the storage wrapper's `exclude_asset_keys`), e.g. to let a dedicated dbt connector own dbt models.
- `emit_pipeline_step_events` (default `True`, preserving current behaviour) — when `False`, emit asset events only, mirroring the wrapper's footprint, while still driving failure-synthesis from run-termination events.

Plus a `default_status` passthrough. Backward compatible: the defaults preserve existing behaviour.

## How I Tested These Changes

- Unit tests: native owners resolved from the asset graph and emitted; fallback to the default team when the asset graph is unavailable; `exclude_asset_keys` skips matching assets; `emit_pipeline_step_events=False` emits asset events only; default mode still emits pipeline/step events; `default_status` passthrough.
- `uv run pytest` green; `ruff check`, `ruff format --check`, and `ty check .` clean.
- Tested locally end to end: ran the sensor in a real Dagster daemon, ingested the emitted OpenLineage events into OpenMetadata, and used it to visualise the resulting lineage with each pipeline's owner set from the asset's declared team.

## Changelog

Added a `### Features` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Related changes

Part of a set of small improvements to Dagster → OpenLineage. The lineage-fidelity changes are each independent and mergeable on their own; the ownership pair is stacked (#354 builds on #353).

**Lineage fidelity:**
- #344 — decouple job namespace from dataset namespace
- #345 — emit asset run-start without a placeholder output
- #346 — derive asset inputs from column lineage
- #347 — add `exclude_asset_keys` to the storage wrapper

**Ownership:**
- #353 — emit jobType and per-asset ownership facets
- #354 — read native asset owners in the sensor (builds on #353; until #353 merges its diff includes #353's commit)

